### PR TITLE
feat: add .gitattributes for CRLF line ending normalization on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,46 @@
+# Auto-detect text files and normalize to CRLF on checkout
+* text=auto eol=crlf
+
+# Source code files (explicit UTF-8 with CRLF)
+*.cpp text eol=crlf encoding=utf-8
+*.h text eol=crlf encoding=utf-8
+*.hpp text eol=crlf encoding=utf-8
+*.in text eol=crlf encoding=utf-8
+
+# Build & config files
+CMakeLists.txt text eol=crlf encoding=utf-8
+*.cmake text eol=crlf encoding=utf-8
+*.json text eol=crlf encoding=utf-8
+*.yml text eol=crlf encoding=utf-8
+*.yaml text eol=crlf encoding=utf-8
+
+# Documentation
+*.md text eol=crlf encoding=utf-8
+*.txt text eol=crlf encoding=utf-8
+
+# Shell scripts (preserve LF for Unix compatibility)
+*.sh text eol=lf encoding=utf-8
+
+# Binary files (no conversion)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.bmp binary
+*.ico binary
+*.svg binary
+*.exe binary
+*.dll binary
+*.lib binary
+*.obj binary
+*.o binary
+*.a binary
+*.so binary
+*.zip binary
+*.7z binary
+*.gz binary
+*.tar binary
+
+# IDE files
+.vscode/ text eol=crlf
+*.vssettings text eol=crlf


### PR DESCRIPTION
## Описание

Добавлен файл `.gitattributes` для корректной обработки окончаний строк в Windows-среде разработки.

## Изменения

- Все текстовые файлы нормализуются с **CRLF** при checkout (Windows)
- UTF-8 кодировка для исходников (*.cpp, *.h, *.hpp)
- Shell-скрипты (*.sh) сохраняют **LF** для Unix-совместимости
- Бинарные файлы исключены из конвертации

## Детали

### Текстовые файлы (CRLF)
- Исходный код: *.cpp, *.h, *.hpp, *.in
- Конфигурация: CMakeLists.txt, *.cmake, *.json, *.yml
- Документация: *.md, *.txt

### Shell-скрипты (LF)
- *.sh — для корректной работы в Unix-среде (CI/CD, WSL)

### Бинарные файлы (без конвертации)
- Изображения: *.png, *.jpg, *.gif, *.svg, и др.
- Бинарники: *.exe, *.dll, *.obj, и др.
- Архивы: *.zip, *.7z, *.gz, и др.

## Зачем это нужно

Разработка ведётся на Windows, и без явных правил Git может:
- Неправильно конвертировать окончания строк между ОС
- Создавать конфликты из-за разных line ending
- Портить бинарные файлы конвертацией

Этот файл гарантирует единообразную работу с файлами в команде.