### PR TITLE
feat: add .gitattributes for CRLF line ending normalization on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,46 @@
+# Auto-detect text files and normalize to CRLF on checkout
+* text=auto eol=crlf
+
+# Source code files (explicit UTF-8 with CRLF)
+*.cpp text eol=crlf encoding=utf-8
+*.h text eol=crlf encoding=utf-8
+*.hpp text eol=crlf encoding=utf-8
+*.in text eol=crlf encoding=utf-8
+
+# Build & config files
+CMakeLists.txt text eol=crlf encoding=utf-8
+*.cmake text eol=crlf encoding=utf-8
+*.json text eol=crlf encoding=utf-8
+*.yml text eol=crlf encoding=utf-8
+*.yaml text eol=crlf encoding=utf-8
+
+# Documentation
+*.md text eol=crlf encoding=utf-8
+*.txt text eol=crlf encoding=utf-8
+
+# Shell scripts (preserve LF for Unix compatibility)
+*.sh text eol=lf encoding=utf-8
+
+# Binary files (no conversion)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.bmp binary
+*.ico binary
+*.svg binary
+*.exe binary
+*.dll binary
+*.lib binary
+*.obj binary
+*.o binary
+*.a binary
+*.so binary
+*.zip binary
+*.7z binary
+*.gz binary
+*.tar binary
+
+# IDE files
+.vscode/ text eol=crlf
+*.vssettings text eol=crlf


### PR DESCRIPTION
## Summary

Added `.gitattributes` file to enforce consistent line ending handling for Windows-based development.

## Changes

- All text files normalize to **CRLF** on checkout (Windows environment)
- UTF-8 encoding for source files (*.cpp, *.h, *.hpp)
- Shell scripts (*.sh) preserve **LF** for Unix compatibility
- Binary files excluded from line ending conversion

## Details

### Text Files (CRLF)
- Source code: *.cpp, *.h, *.hpp, *.in
- Build config: CMakeLists.txt, *.cmake, *.json, *.yml
- Documentation: *.md, *.txt

### Shell Scripts (LF)
- *.sh — for Unix compatibility (CI/CD, WSL)

### Binary Files (No Conversion)
- Images: *.png, *.jpg, *.gif, *.svg, etc.
- Binaries: *.exe, *.dll, *.obj, etc.
- Archives: *.zip, *.7z, *.gz, etc.

## Why This Matters

Development is Windows-based. Without explicit rules, Git may:
- Incorrectly convert line endings across platforms
- Create merge conflicts due to inconsistent line endings
- Corrupt binary files through unwanted conversion

This file ensures consistent file handling across the project.