### PR TITLE
fix: recover radial coordinate for graph X-axis

### DIFF
--- a/src/gui/sag_analysis_service.cpp
+++ b/src/gui/sag_analysis_service.cpp
@@ -23,7 +23,10 @@ namespace gui {
         y_vals.reserve(surface.sagDataPoints.size());
 
         for (const auto& point : surface.sagDataPoints) {
-            x_vals.push_back(point.x);
+            // Recover radial coordinate r from (x, y) with sign preservation
+            // r = sign(x) * sqrt(x^2 + y^2) gives correct range from -semiDiameter to +semiDiameter
+            double r = (point.x >= 0 ? 1.0 : -1.0) * std::sqrt(point.x * point.x + point.y * point.y);
+            x_vals.push_back(r);
             y_vals.push_back(point.sag);
         }
 


### PR DESCRIPTION
## Summary
Fixed a bug where the graph X-axis showed incorrect range when cross-section angle was rotated.

- **Root cause**: The `extractSagCoordinates` function was using `point.x` directly for the X-axis, which only represented the projected coordinate after rotation.
- **Fix**: Now computes radial coordinate `r = sign(x) * sqrt(x^2 + y^2)` to restore the correct range from -semiDiameter to +semiDiameter regardless of rotation angle.

Now the graph correctly shows the full profile in both directions with proper X-axis scale matching the surface semi-diameter.