### PR TITLE
fix: centralize CP1251→UTF-8 conversion and add default placeholder for empty lens name

### DIFF
--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -168,11 +168,24 @@ namespace ZemaxDDE {
                     m_logger.addLog(std::format("[DDE] Received 'WM_DDE_DATA', content = {}", buffer));
                 #endif
                     if (command_token == "GetName") {
-                        m_opticalSystem.lensName = buffer;
+                        std::string name = extractStringFromDDE(ddeDataHandle);
+                        if (name.empty()) {
+                            name = "unknown";
+                            m_logger.addLog("[DDE] GetName: empty lens name, using default 'unknown'");
+                        }
+
+                        m_opticalSystem.lensName = name;
+                        #ifdef DEBUG_LOG
+                        m_logger.addLog(std::format("[DDE] GetName (converted): {}", name));
+                        #endif
                         DdeAck.fAck = TRUE;
                     }
                     if (command_token == "GetFile") {
-                        m_opticalSystem.fileName = buffer;
+                        std::string fileNameStr = extractStringFromDDE(ddeDataHandle);
+                        m_opticalSystem.fileName = fileNameStr;
+                        #ifdef DEBUG_LOG
+                        m_logger.addLog(std::format("[DDE] GetFile (converted): {}", fileNameStr));
+                        #endif
                         DdeAck.fAck = TRUE;
                     }
                     if (command_token == "GetSystem") {

--- a/src/dde/utils.cpp
+++ b/src/dde/utils.cpp
@@ -1,6 +1,51 @@
 #include "utils.h"
+#include <windows.h>
 
 namespace ZemaxDDE {
+    // Extract string payload from a DDE data handle (skip 4‑byte header, trim \r\n\0, convert CP1251→UTF‑8)
+    std::string extractStringFromDDE(GLOBALHANDLE handle) {
+        if (!handle) return {};
+        HGLOBAL h = static_cast<HGLOBAL>(handle);
+        LPBYTE pData = static_cast<LPBYTE>(GlobalLock(h));
+        if (!pData) return {};
+
+        SIZE_T totalSize = GlobalSize(h);
+        constexpr SIZE_T DDE_HEADER_SIZE = 4;
+        if (totalSize <= DDE_HEADER_SIZE) {
+            GlobalUnlock(h);
+            return {};
+        }
+
+        const char* raw = reinterpret_cast<const char*>(pData + DDE_HEADER_SIZE);
+        size_t len = totalSize - DDE_HEADER_SIZE;
+        while (len && (raw[len - 1] == '\0' || raw[len - 1] == '\r' || raw[len - 1] == '\n')) {
+            --len;
+        }
+
+        std::string result = cp1251_to_utf8(raw, len);
+        GlobalUnlock(h);
+        return result;
+    }
+
+    // Convert CP1251 (Windows-1251) encoded data to UTF‑8
+    std::string cp1251_to_utf8(const char* data, size_t len) {
+        if (!data || len == 0) return {};
+        int wlen = MultiByteToWideChar(1251, 0, data, (int)len, nullptr, 0);
+        
+        if (wlen <= 0) return {};
+
+        std::wstring wstr(wlen, L'\0');
+        MultiByteToWideChar(1251, 0, data, (int)len, &wstr[0], wlen);
+
+        int u8len = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), wlen, nullptr, 0, nullptr, nullptr);
+        if (u8len <= 0) return {};
+
+        std::string u8str(u8len, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), wlen, &u8str[0], u8len, nullptr, nullptr);
+
+        return u8str;
+    }
+
     /*
     * Splits the input string into individual "tokens" (meaningful parts).
     * Tokens are delimited by commas, spaces, newlines, or carriage returns, unless they are enclosed within double quotes.

--- a/src/dde/utils.h
+++ b/src/dde/utils.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <windows.h>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace ZemaxDDE {
     std::vector<std::string> tokenize(std::string_view bufferStr);
+    std::string cp1251_to_utf8(const char* data, size_t len);
+    std::string extractStringFromDDE(GLOBALHANDLE handle);
 }


### PR DESCRIPTION
This PR moves the CP1251 to UTF‑8 conversion logic into utils, adds a helper to extract strings from DDE handles, and introduces a default placeholder ('unknown') for empty lens names. It also normalizes DEBUG_LOG indentation across the codebase.

Changes:
- utils.h/cpp: new `cp1251_to_utf8` and `extractStringFromDDE` functions.
- client_connection.cpp: uses the new helpers, adds placeholder for empty lens name, and cleans up logging blocks.
- Style adjustments for `#ifdef DEBUG_LOG` blocks.

All tests pass locally and the project builds successfully.