### PR TITLE
feat: add DPI scale support for window resize constraints

### DIFF
--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -1,5 +1,3 @@
-#include <fstream>
-
 #include <nfd.h>
 
 #include "logger/logger.h"
@@ -24,7 +22,6 @@ namespace App {
     // Base window dimensions and system DPI constant
     constexpr int BASE_WIDTH = 800;
     constexpr int BASE_HEIGHT = 600;
-    constexpr float SYSTEM_DPI = 96.0f;
 
     std::unique_ptr<AppContext> initialize(Logger& logger) {
         auto ctx = std::make_unique<AppContext>();
@@ -60,26 +57,21 @@ namespace App {
 
         logger.addLog("[APP] GLFW initialized");
 
-        // Get initial DPI scale factor
-        HDC hdc = GetDC(NULL);
-        int dpiX = GetDeviceCaps(hdc, LOGPIXELSX);
-        ReleaseDC(NULL, hdc);
-        ctx->dpiScale = static_cast<float>(dpiX) / SYSTEM_DPI;
-        logger.addLog(std::format("[APP] Initial DPI scale factor: {:.2f}", ctx->dpiScale));
-
+        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
         glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
 
-        // Scale window size based on DPI
-        int scaledWidth = static_cast<int>(BASE_WIDTH * ctx->dpiScale);
-        int scaledHeight = static_cast<int>(BASE_HEIGHT * ctx->dpiScale);
-
-        ctx->glfwWindow = glfwCreateWindow(scaledWidth, scaledHeight, APP_TITLE, NULL, NULL);
+        ctx->glfwWindow = glfwCreateWindow(BASE_WIDTH, BASE_HEIGHT, APP_TITLE, NULL, NULL);
         
         if (!ctx->glfwWindow) {
             logger.addLog("[APP] Failed to create GLFW window");
             glfwTerminate();
             return nullptr;
         }
+
+        float xScale = 0, yScale = 0;
+        glfwGetWindowContentScale(ctx->glfwWindow, &xScale, &yScale);
+        ctx->dpiScale = xScale;
+        logger.addLog(std::format("[APP] Initial DPI scale factor: {:.2f}", ctx->dpiScale));
 
         glfwMakeContextCurrent(ctx->glfwWindow);
         glfwSwapInterval(1);
@@ -210,11 +202,6 @@ namespace App {
 
             Logger& logger = *ctx->pLogger;
             float newDpiScale = (xScale + yScale) / 2.0f;
-
-            // Update window size
-            int scaledWidth = static_cast<int>(BASE_WIDTH * newDpiScale);
-            int scaledHeight = static_cast<int>(BASE_HEIGHT * newDpiScale);
-            glfwSetWindowSize(window, scaledWidth, scaledHeight);
 
             // Update ImGui style
             ctx->gui->updateDpiStyle(newDpiScale);

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -10,7 +10,7 @@ namespace gui {
     inline constexpr float DEBUG_LOG_WINDOW_HEIGHT_MIN = 460.0f;
 
     // DDE status constraints
-    inline constexpr float DDE_STATUS_WINDOW_WIDTH_MIN  = 440.0f;
+    inline constexpr float DDE_STATUS_WINDOW_WIDTH_MIN  = 220.0f;
     inline constexpr float DDE_STATUS_WINDOW_HEIGHT_MIN = 160.0f;
 
     // DDE status content constraints

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -1,25 +1,49 @@
 #pragma once
 
+#include "lib/imgui/imgui.h"
+
 namespace gui {
-    // Debug log constraints
-    inline constexpr float DEBUG_LOG_WIDTH_MIN  = 600.0f;
-    inline constexpr float DEBUG_LOG_HEIGHT_MIN = 200.0f;
-
-    // Debug log window constraints
-    inline constexpr float DEBUG_LOG_WINDOW_WIDTH_MIN  = 920.0f;
-    inline constexpr float DEBUG_LOG_WINDOW_HEIGHT_MIN = 460.0f;
-
-    // DDE status constraints
+    // DDE status window constraints
     inline constexpr float DDE_STATUS_WINDOW_WIDTH_MIN  = 220.0f;
-    inline constexpr float DDE_STATUS_WINDOW_HEIGHT_MIN = 160.0f;
+    inline constexpr float DDE_STATUS_WINDOW_HEIGHT_MIN = 80.0f;
 
     // DDE status content constraints
     inline constexpr float DDE_STATUS_CONTENT_WIDTH  = 0.0f;   // Automatic width
     inline constexpr float DDE_STATUS_CONTENT_HEIGHT = 0.0f;   // Automatic height
+
+    // DDE status colors
+    inline constexpr ImVec4 DDE_STATUS_COLOR_CONNECTED     = ImVec4(0.0f, 1.0f, 0.0f, 1.0f);  // Green
+    inline constexpr ImVec4 DDE_STATUS_COLOR_DISCONNECTED = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);  // Red
+
+    // DDE button colors - Connect
+    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_NORMAL = ImVec4(0.0f, 0.5f, 0.0f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_HOVER   = ImVec4(0.0f, 0.7f, 0.0f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_ACTIVE  = ImVec4(0.0f, 0.3f, 0.0f, 1.0f);
+
+    // DDE button colors - Disconnect
+    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_NORMAL = ImVec4(0.5f, 0.0f, 0.0f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_HOVER  = ImVec4(0.7f, 0.0f, 0.0f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_ACTIVE = ImVec4(0.3f, 0.0f, 0.0f, 1.0f);
+
+    // Debug log window constraints
+    inline constexpr float DEBUG_LOG_WINDOW_WIDTH_MIN  = 200.0f;
+    inline constexpr float DEBUG_LOG_WINDOW_HEIGHT_MIN = 160.0f;
+
+    // System info window constraints
+    inline constexpr float SYSTEM_INFO_WINDOW_WIDTH_MIN  = 200.0f;
+    inline constexpr float SYSTEM_INFO_WINDOW_HEIGHT_MIN = 160.0f;
+
+    // Sag analysis window constraints
+    inline constexpr float SAG_ANALYSIS_WINDOW_WIDTH_MIN  = 200.0f;
+    inline constexpr float SAG_ANALYSIS_WINDOW_HEIGHT_MIN = 160.0f;
 
     // Sag analysis sampling constraints
     // Maximum: Zemax tool "Surface Sag Cross Section" limit
     inline constexpr int MAX_SAMPLING = 16385;
     // Minimum: Zemax requires at least 33 for valid profile calculation
     inline constexpr int MIN_SAMPLING = 33;
+
+    // DPI scale constraints
+    inline constexpr float MIN_DPI_SCALE = 1.0f;
+    inline constexpr float MAX_DPI_SCALE = 5.0f;
 }

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -1,21 +1,21 @@
 #pragma once
 
 namespace gui {
-    // Content area constraints
-    inline constexpr float CONTENT_WIDTH_MIN    = 600.0f;
-    inline constexpr float CONTENT_HEIGHT_MIN   = 480.0f;
-
     // Debug log constraints
     inline constexpr float DEBUG_LOG_WIDTH_MIN  = 600.0f;
     inline constexpr float DEBUG_LOG_HEIGHT_MIN = 200.0f;
 
-    // DDE status window constraints
+    // Debug log window constraints
+    inline constexpr float DEBUG_LOG_WINDOW_WIDTH_MIN  = 920.0f;
+    inline constexpr float DEBUG_LOG_WINDOW_HEIGHT_MIN = 460.0f;
+
+    // DDE status constraints
     inline constexpr float DDE_STATUS_WINDOW_WIDTH_MIN  = 440.0f;
     inline constexpr float DDE_STATUS_WINDOW_HEIGHT_MIN = 160.0f;
 
-    // DDE status frame constraints
-    inline constexpr float DDE_STATUS_FRAME_WIDTH  = 0.0f;   // Automatic width
-    inline constexpr float DDE_STATUS_FRAME_HEIGHT = 0.0f;   // Automatic height
+    // DDE status content constraints
+    inline constexpr float DDE_STATUS_CONTENT_WIDTH  = 0.0f;   // Automatic width
+    inline constexpr float DDE_STATUS_CONTENT_HEIGHT = 0.0f;   // Automatic height
 
     // Sag analysis sampling constraints
     // Maximum: Zemax tool "Surface Sag Cross Section" limit

--- a/src/gui/graphics_backend.cpp
+++ b/src/gui/graphics_backend.cpp
@@ -1,6 +1,7 @@
 #include <stdexcept>
 #include <filesystem>
 #include <format>
+#include <algorithm>
 
 #include <windows.h>
 
@@ -10,6 +11,7 @@
 #include "lib/imgui/backends/imgui_impl_opengl3.h"
 
 #include "gui/graphics_backend.h"
+#include "gui/constants.h"
 #include "app/config_path.h"
 #include <cmath>
 #include "logger/logger.h"
@@ -41,17 +43,17 @@ namespace gui {
         io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
         io.IniFilename = app::getImguiIniPath();
 
-        // Use pre-computed DPI scale passed from app initialization
         float dpiScale = initialDpiScale;
-        if (!std::isfinite(dpiScale)) dpiScale = 1.0f;
-        if (dpiScale <= 0.0f) dpiScale = 0.01f;
-        if (dpiScale > 98.0f) dpiScale = 98.0f;
+        if (!std::isfinite(dpiScale) || dpiScale <= 0.0f) dpiScale = MIN_DPI_SCALE;
+        dpiScale = std::clamp(dpiScale, MIN_DPI_SCALE, MAX_DPI_SCALE);
+
         io.DisplayFramebufferScale = ImVec2(dpiScale, dpiScale);
+        io.ConfigDpiScaleFonts = true;
+        io.ConfigDpiScaleViewports = true;
 
         std::filesystem::path fontPath = std::filesystem::path{L"C:\\Windows\\Fonts"} / L"segoeui.ttf";
         const std::string fontPathStr = fontPath.string();
 
-        // Load font at base size, then scale via FontGlobalScale
         float baseFontSize = 18.0f;
         ImFont* font = io.Fonts->AddFontFromFileTTF(fontPathStr.c_str(), baseFontSize);
 
@@ -60,6 +62,7 @@ namespace gui {
         }
 
         ImGuiStyle& style = ImGui::GetStyle();
+        style.FontScaleDpi = dpiScale;
         style.WindowPadding = ImVec2(8.0f, 8.0f);
         style.FramePadding = ImVec2(4.0f, 4.0f);
         style.ItemSpacing = ImVec2(8.0f, 4.0f);
@@ -78,19 +81,10 @@ namespace gui {
     }
 
     void GraphicsBackend::updateDpiStyle(float dpiScale) {
-        // Clamp to valid range to avoid ImGui assertion failures
-        // Minimum: ImGui FontGlobalScale must be > 0
-        // Maximum: 5.0 (500%) matches Windows 10/11 max display scaling
-        constexpr float MIN_DPI_SCALE = 1.0f;
-        constexpr float MAX_DPI_SCALE = 5.0f;
+        dpiScale = std::clamp(dpiScale, MIN_DPI_SCALE, MAX_DPI_SCALE);
 
-        if (dpiScale < 1.0f) dpiScale = MIN_DPI_SCALE;
-        if (dpiScale > MAX_DPI_SCALE) dpiScale = MAX_DPI_SCALE;
-
-        ImGuiIO& io = ImGui::GetIO();
-
-        // Only scale font globally, not styles (they're already scaled at init)
-        io.FontGlobalScale = dpiScale;
+        ImGuiStyle& style = ImGui::GetStyle();
+        style.FontScaleDpi = dpiScale;
     }
 
     void GraphicsBackend::beginFrame() {

--- a/src/gui/window_registration.cpp
+++ b/src/gui/window_registration.cpp
@@ -53,7 +53,11 @@ namespace {
     void RenderDebugLogWindow(gui::GuiManager* guiMgr) {
         if (!guiMgr) return;
         bool isVisible = guiMgr->getWindowManager()->IsVisible(WindowID::DebugLog);
-        ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
+        // ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowSizeConstraints(
+            ImVec2(gui::DEBUG_LOG_WINDOW_WIDTH_MIN, gui::DEBUG_LOG_WINDOW_HEIGHT_MIN),
+            ImVec2(FLT_MAX, FLT_MAX)
+        );
         if (ImGui::Begin("Debug Log", &isVisible)) {
             guiMgr->renderDebugLog();
         }

--- a/src/gui/window_registration.cpp
+++ b/src/gui/window_registration.cpp
@@ -8,8 +8,10 @@ namespace {
     void RenderDDEStatusWindow(gui::GuiManager* guiMgr) {
         if (!guiMgr) return;
         bool isVisible = guiMgr->getWindowManager()->IsVisible(WindowID::DDEStatus);
+        float dpiScale = ImGui::GetWindowDpiScale();
         ImGui::SetNextWindowSizeConstraints(
-            ImVec2(gui::DDE_STATUS_WINDOW_WIDTH_MIN, gui::DDE_STATUS_WINDOW_HEIGHT_MIN),
+            ImVec2(gui::DDE_STATUS_WINDOW_WIDTH_MIN * dpiScale,
+                   gui::DDE_STATUS_WINDOW_HEIGHT_MIN * dpiScale),
             ImVec2(FLT_MAX, FLT_MAX)
         );
         if (ImGui::Begin("DDE Status", &isVisible,
@@ -27,7 +29,12 @@ namespace {
     void RenderSystemInfoWindow(gui::GuiManager* guiMgr) {
         if (!guiMgr) return;
         bool isVisible = guiMgr->getWindowManager()->IsVisible(WindowID::SystemInfo);
-        ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
+        float dpiScale = ImGui::GetWindowDpiScale();
+        ImGui::SetNextWindowSizeConstraints(
+            ImVec2(gui::SYSTEM_INFO_WINDOW_WIDTH_MIN * dpiScale,
+                   gui::SYSTEM_INFO_WINDOW_HEIGHT_MIN * dpiScale),
+            ImVec2(FLT_MAX, FLT_MAX)
+        );
         if (ImGui::Begin("Optical System Information", &isVisible)) {
             guiMgr->renderOpticalSystemInfo();
         }
@@ -40,7 +47,12 @@ namespace {
     void RenderSagAnalysisWindow(gui::GuiManager* guiMgr) {
         if (!guiMgr) return;
         bool isVisible = guiMgr->getWindowManager()->IsVisible(WindowID::SagAnalysis);
-        ImGui::SetNextWindowSize(ImVec2(600, 400), ImGuiCond_FirstUseEver);
+        float dpiScale = ImGui::GetWindowDpiScale();
+        ImGui::SetNextWindowSizeConstraints(
+            ImVec2(gui::SAG_ANALYSIS_WINDOW_WIDTH_MIN * dpiScale,
+                   gui::SAG_ANALYSIS_WINDOW_HEIGHT_MIN * dpiScale),
+            ImVec2(FLT_MAX, FLT_MAX)
+        );
         if (ImGui::Begin("Surface Sag Cross Section Analysis", &isVisible)) {
             guiMgr->renderSurfaceSagAnalysis();
         }
@@ -53,9 +65,10 @@ namespace {
     void RenderDebugLogWindow(gui::GuiManager* guiMgr) {
         if (!guiMgr) return;
         bool isVisible = guiMgr->getWindowManager()->IsVisible(WindowID::DebugLog);
-        // ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
+        float dpiScale = ImGui::GetWindowDpiScale();
         ImGui::SetNextWindowSizeConstraints(
-            ImVec2(gui::DEBUG_LOG_WINDOW_WIDTH_MIN, gui::DEBUG_LOG_WINDOW_HEIGHT_MIN),
+            ImVec2(gui::DEBUG_LOG_WINDOW_WIDTH_MIN * dpiScale,
+                   gui::DEBUG_LOG_WINDOW_HEIGHT_MIN * dpiScale),
             ImVec2(FLT_MAX, FLT_MAX)
         );
         if (ImGui::Begin("Debug Log", &isVisible)) {

--- a/src/gui/windows/dde_status.cpp
+++ b/src/gui/windows/dde_status.cpp
@@ -19,7 +19,7 @@ namespace {
 namespace gui {
     void DDEStatus::render(Logger& logger) {
         ImGui::BeginChild("DDE Status Content",
-            ImVec2(DDE_STATUS_FRAME_WIDTH, DDE_STATUS_FRAME_HEIGHT),
+            ImVec2(DDE_STATUS_CONTENT_WIDTH, DDE_STATUS_CONTENT_HEIGHT),
             ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse
         );

--- a/src/gui/windows/dde_status.cpp
+++ b/src/gui/windows/dde_status.cpp
@@ -5,21 +5,10 @@
 #include "lib/imgui/imgui.h"
 #include "logger/logger.h"
 
-namespace {
-    inline constexpr ImVec4 DDE_STATUS_COLOR_CONNECTED    = ImVec4(0.0f, 1.0f, 0.0f, 1.0f);  // Green
-    inline constexpr ImVec4 DDE_STATUS_COLOR_DISCONNECTED = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);  // Red
-    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_NORMAL  = ImVec4(0.0f, 0.5f, 0.0f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_HOVER   = ImVec4(0.0f, 0.7f, 0.0f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_ACTIVE  = ImVec4(0.0f, 0.3f, 0.0f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_NORMAL = ImVec4(0.5f, 0.0f, 0.0f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_HOVER  = ImVec4(0.7f, 0.0f, 0.0f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_ACTIVE = ImVec4(0.3f, 0.0f, 0.0f, 1.0f);
-}
-
 namespace gui {
     void DDEStatus::render(Logger& logger) {
         ImGui::BeginChild("DDE Status Content",
-            ImVec2(DDE_STATUS_CONTENT_WIDTH, DDE_STATUS_CONTENT_HEIGHT),
+            ImVec2(gui::DDE_STATUS_CONTENT_WIDTH, gui::DDE_STATUS_CONTENT_HEIGHT),
             ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse
         );
@@ -38,14 +27,14 @@ namespace gui {
         ImGui::SameLine(0.0f, 4.0f);
 
         bool connected = m_ddeClient && m_ddeClient->isConnected();
-        ImGui::PushStyleColor(ImGuiCol_Text, connected ? DDE_STATUS_COLOR_CONNECTED : DDE_STATUS_COLOR_DISCONNECTED);
+        ImGui::PushStyleColor(ImGuiCol_Text, connected ? gui::DDE_STATUS_COLOR_CONNECTED : gui::DDE_STATUS_COLOR_DISCONNECTED);
         ImGui::TextUnformatted(value);
         ImGui::PopStyleColor();
 
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(-1.0f, 4.0f));
-        ImGui::PushStyleColor(ImGuiCol_Button, connected ? DDE_BUTTON_DISCONNECT_COLOR_NORMAL : DDE_BUTTON_CONNECT_COLOR_NORMAL);
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, connected ? DDE_BUTTON_DISCONNECT_COLOR_HOVER : DDE_BUTTON_CONNECT_COLOR_HOVER);
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, connected ? DDE_BUTTON_DISCONNECT_COLOR_ACTIVE : DDE_BUTTON_CONNECT_COLOR_ACTIVE);
+        ImGui::PushStyleColor(ImGuiCol_Button, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_NORMAL : gui::DDE_BUTTON_CONNECT_COLOR_NORMAL);
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_HOVER : gui::DDE_BUTTON_CONNECT_COLOR_HOVER);
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_ACTIVE : gui::DDE_BUTTON_CONNECT_COLOR_ACTIVE);
         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.5f, 0.5f));
 
         if (ImGui::Button(connected ? "Disconnect from Zemax" : "Connect to Zemax", ImVec2(-1.0f, 0.0f))) {
@@ -55,9 +44,9 @@ namespace gui {
                 } else {
                     m_ddeClient->terminateDDE();
                 }
-            #ifdef DEBUG_LOG
+                #ifdef DEBUG_LOG
                 logger.addLog("[GUI] " + std::string(connected ? "Connected to Zemax" : "Disconnected from Zemax"));
-            #endif
+                #endif
             } catch (const std::runtime_error& e) {
                 logger.addLog("[GUI] DDE connection failed: " + std::string(e.what()));
             }


### PR DESCRIPTION
This PR adds DPI scale support for window resize constraints and includes several refactoring improvements:

## Changes
- Add DPI scale support for window resize constraints
- Apply DPI scaling to all windows (DDE Status, Debug Log, System Info, Sag Analysis)
- Move DDE color constants to constants.h
- Use std::clamp for DPI scale validation

## Commits
- feat: add DPI scale support for window resize constraints
- refactor: move DDE color constants to constants.h