### PR TITLE
Async DDE Refactoring: FIFO queue, OperationMonitor, progress bar, cancellation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "src/lib/json"]
 	path = src/lib/json
 	url = https://github.com/nlohmann/json.git
+[submodule "src/lib/implot3d"]
+	path = src/lib/implot3d
+	url = https://github.com/brenocq/implot3d.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SOURCES
     ${SRC_DIR}/dde/client_connection.cpp
     ${SRC_DIR}/dde/client_commands.cpp
     ${SRC_DIR}/dde/operation_monitor.cpp
+    ${SRC_DIR}/dde/initial_data_load_service.cpp
     ${SRC_DIR}/dde/utils.cpp
     ${SRC_DIR}/dde/dde_connection_manager.cpp
     ${SRC_DIR}/gui/gui_manager.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,6 @@ set(SOURCES
     ${SRC_DIR}/app/zemax_window_enumerator.cpp
     ${SRC_DIR}/logger/logger.cpp
     ${SRC_DIR}/dde/client_connection.cpp
-    ${SRC_DIR}/dde/client_commands.cpp
     ${SRC_DIR}/dde/operation_monitor.cpp
     ${SRC_DIR}/dde/initial_data_load_service.cpp
     ${SRC_DIR}/dde/utils.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SOURCES
     ${SRC_DIR}/logger/logger.cpp
     ${SRC_DIR}/dde/client_connection.cpp
     ${SRC_DIR}/dde/client_commands.cpp
+    ${SRC_DIR}/dde/operation_monitor.cpp
     ${SRC_DIR}/dde/utils.cpp
     ${SRC_DIR}/dde/dde_connection_manager.cpp
     ${SRC_DIR}/gui/gui_manager.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(SRC_DIR "src")
 set(IMGUI_DIR "${SRC_DIR}/lib/imgui")
 set(IMPLOT_DIR "${SRC_DIR}/lib/implot")
+set(IMPLOT3D_DIR "${SRC_DIR}/lib/implot3d")
 set(NFD_DIR "${SRC_DIR}/lib/nfd")
 set(JSON_DIR "${SRC_DIR}/lib/json")
 
@@ -113,6 +114,12 @@ list(APPEND SOURCES
     ${IMPLOT_DIR}/implot_items.cpp
 )
 
+# Add ImPlot3D source files directly
+list(APPEND SOURCES
+    ${IMPLOT3D_DIR}/implot3d.cpp
+    ${IMPLOT3D_DIR}/implot3d_items.cpp
+)
+
 # Add NFD source files directly
 list(APPEND SOURCES
     ${NFD_DIR}/src/nfd_common.c
@@ -134,6 +141,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${IMGUI_DIR}
     ${IMGUI_DIR}/backends
     ${IMPLOT_DIR}
+    ${IMPLOT3D_DIR}
     ${NFD_DIR}/src/include
     ${JSON_DIR}/single_include
     ${MINGW_INCLUDE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SOURCES
     ${SRC_DIR}/main.cpp
     ${SRC_DIR}/app/app_init.cpp
     ${SRC_DIR}/app/config_path.cpp
+    ${SRC_DIR}/app/zemax_window_enumerator.cpp
     ${SRC_DIR}/logger/logger.cpp
     ${SRC_DIR}/dde/client_connection.cpp
     ${SRC_DIR}/dde/client_commands.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SOURCES
     ${SRC_DIR}/gui/menu_bar_controller.cpp
     ${SRC_DIR}/gui/graphics_backend.cpp
     ${SRC_DIR}/gui/sag_analysis_service.cpp
+    ${SRC_DIR}/gui/sag_map_analysis_service.cpp
     ${SRC_DIR}/gui/utils.cpp
     ${SRC_DIR}/gui/popups/about_dialog.cpp
     ${SRC_DIR}/gui/popups/update_checker.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SOURCES
     ${SRC_DIR}/gui/utils.cpp
     ${SRC_DIR}/gui/popups/about_dialog.cpp
     ${SRC_DIR}/gui/popups/update_checker.cpp
+    ${SRC_DIR}/gui/popups/connect_dde.cpp
     ${SRC_DIR}/gui/dockable_windows_manager.cpp
     ${SRC_DIR}/gui/windows_dockable/dde_status.cpp
     ${SRC_DIR}/gui/windows_dockable/debug_log.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(SOURCES
     ${SRC_DIR}/gui/windows_dockable/debug_log.cpp
     ${SRC_DIR}/gui/windows_dockable/optical_system_info.cpp
     ${SRC_DIR}/gui/windows_dockable/surface_sag_analysis.cpp
+    ${SRC_DIR}/gui/windows_dockable/surface_map_analysis.cpp
 )
 
 # Add ImGui source files directly

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -4,8 +4,8 @@
 #include <GLFW/glfw3.h>
 #include <windows.h>
 
-#include "dde/client.h"
 #include "gui/gui.h"
+#include "dde/dde_connection_manager.h"
 #include "version.h"
 
 class Logger;
@@ -15,8 +15,7 @@ class Logger;
 
 struct AppContext {
     GLFWwindow* glfwWindow = nullptr;
-    HWND hwndClient = nullptr;
-    std::unique_ptr<ZemaxDDE::ZemaxDDEClient> ddeClient;
+    std::unique_ptr<DDEConnectionManager> ddeConnectionManager;
     std::unique_ptr<gui::GuiManager> gui;
     Logger* pLogger = nullptr;
     float dpiScale = 1.0f;

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -91,7 +91,7 @@ namespace App {
             if (dwmFunc) {
                 // Detect system dark mode via registry (reliable for Windows 10/11)
                 bool isDarkMode = false;
-                HKEY hKey = NULL;
+                HKEY hKey = nullptr;
                 LONG regResult = RegOpenKeyExW(HKEY_CURRENT_USER,
                     L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
                     0, KEY_READ, &hKey);

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -6,18 +6,6 @@
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
 
-namespace {
-    extern "C" LRESULT CALLBACK WndProc(HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam) {
-        if (iMsg >= WM_DDE_FIRST && iMsg <= WM_DDE_LAST) {
-            auto* client = reinterpret_cast<ZemaxDDE::ZemaxDDEClient*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
-            if (client) {
-                return client->handleDDEMessages(iMsg, wParam, lParam);
-            }
-        }
-        return DefWindowProcW(hwnd, iMsg, wParam, lParam);
-    }
-}
-
 namespace App {
     // Base window dimensions and system DPI constant
     constexpr int BASE_WIDTH = 800;
@@ -119,77 +107,11 @@ namespace App {
 
         logger.addLog("[APP] Application starting");
 
-        // Register DDE message-only window class
-        WNDCLASSEXW wndClass = {};
-        wndClass.cbSize = sizeof(WNDCLASSEXW);
-        wndClass.style = CS_HREDRAW | CS_VREDRAW;
-        wndClass.lpfnWndProc = WndProc;
-        wndClass.hInstance = GetModuleHandle(NULL);
-        wndClass.lpszClassName = L"ZEMAX_DDE_Client";
+        // Create DDE connection manager (manages multi-window connections)
+        ctx->ddeConnectionManager = std::make_unique<DDEConnectionManager>(logger);
 
-        if (!RegisterClassExW(&wndClass)) {
-            logger.addLog("[APP] Failed to register DDE window class");
-            glfwDestroyWindow(ctx->glfwWindow);
-            glfwTerminate();
-            return nullptr;
-        }
-
-        logger.addLog("[APP] DDE window class registered");
-
-        // Create and associate ZemaxDDEClient with the window
-        ctx->hwndClient = CreateWindowExW(0, L"ZEMAX_DDE_Client", L"DDE Client", 0, 0, 0, 0, 0, HWND_MESSAGE, NULL, GetModuleHandle(NULL), NULL);
-
-        if (!ctx->hwndClient) {
-            MessageBoxA(NULL, "Failed to create DDE communication window.\n"
-                            "The application will now exit.\n\n"
-                            "Ensure no other instance is running and try again.", "Error", MB_OK | MB_ICONERROR);
-            logger.addLog("[APP] Failed to create DDE window (CreateWindowExW returned NULL)");
-            glfwTerminate();
-            return nullptr;
-        }
-
-        logger.addLog(std::format("[APP] DDE window created: hwndClient = {}", reinterpret_cast<uintptr_t>(ctx->hwndClient)));
-
-        // Create and associate ZemaxDDEClient with the window
-        ctx->ddeClient = std::make_unique<ZemaxDDE::ZemaxDDEClient>(ctx->hwndClient, logger);
-        SetWindowLongPtr(ctx->hwndClient, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(ctx->ddeClient.get()));
-
-        // Register callback to send requests after DDE connection
-        ctx->ddeClient->setOnDDEConnectedCallback([&logger](ZemaxDDE::ZemaxDDEClient* client) {
-            try {
-                client->getLensName();
-                client->getFileName();
-                client->getSystemData();
-                client->getFieldData();
-
-                int numFields = client->getOpticalSystemData().numFields;
-                if (numFields < 0) {
-                    logger.addLog(std::format("[DDE] Invalid numFields value: {}. Skipping field requests.", numFields));
-                    return;
-                }
-
-                for (int i = ZemaxDDE::MIN_FIELDS; i <= numFields; ++i) {
-                    client->getFieldByIndex(i);
-                }
-
-                client->getWaveData();
-
-                int numWaves = client->getOpticalSystemData().numWaves;
-                if (numWaves < 0) {
-                    logger.addLog(std::format("[DDE] Invalid numWaves value: {}. Skipping field requests.", numWaves));
-                    return;
-                }
-
-                for (int i = ZemaxDDE::MIN_WAVES; i <= numWaves; ++i) {
-                    client->getWaveByIndex(i);
-                }
-            } catch (const std::exception& e) {
-                logger.addLog(std::format("[DDE] Error requesting initial system data: {}", e.what()));
-            }
-        });
-
-        // Initialize GUI manager with existing DDE client
-        ctx->gui = std::make_unique<gui::GuiManager>(ctx->glfwWindow, ctx->hwndClient, ctx->ddeClient.get(), logger);
+        // Initialize GUI manager with DDE connection manager
+        ctx->gui = std::make_unique<gui::GuiManager>(ctx->glfwWindow, ctx->ddeConnectionManager.get(), logger);
         ctx->gui->initialize(ctx->dpiScale);
 
         // Store context pointer for callback access (must be before callback registration)
@@ -214,19 +136,11 @@ namespace App {
     }
 
     void shutdown(AppContext& ctx) {
-        // GUI depends on DDE client and GLFW
+        // GUI depends on DDE connection manager and GLFW
         ctx.gui.reset();
 
-        if (ctx.hwndClient && ctx.ddeClient) {
-            ctx.ddeClient->terminateDDE();
-            SetWindowLongPtr(ctx.hwndClient, GWLP_USERDATA, 0);
-            ctx.ddeClient.reset();
-        }
-
-        if (ctx.hwndClient) {
-            DestroyWindow(ctx.hwndClient);
-            ctx.hwndClient = nullptr;
-        }
+        // DDE connection manager cleanup (disconnects all clients, destroys windows)
+        ctx.ddeConnectionManager.reset();
 
         if (ctx.glfwWindow) {
             glfwDestroyWindow(ctx.glfwWindow);

--- a/src/app/zemax_window_enumerator.cpp
+++ b/src/app/zemax_window_enumerator.cpp
@@ -23,6 +23,18 @@ namespace app {
             return TRUE;
         }
 
+        if (GetWindow(hwnd, GW_OWNER) != nullptr) {
+            return TRUE;
+        }
+
+        if (GetParent(hwnd) != nullptr) {
+            return TRUE;
+        }
+
+        if (GetWindowLongPtrW(hwnd, GWL_STYLE) & WS_CHILD) {
+            return TRUE;
+        }
+
         wchar_t title[256];
         int len = GetWindowTextW(hwnd, title, sizeof(title) / sizeof(title[0]));
         if (len == 0) {

--- a/src/app/zemax_window_enumerator.cpp
+++ b/src/app/zemax_window_enumerator.cpp
@@ -1,0 +1,69 @@
+#include "zemax_window_enumerator.h"
+
+#include <tlhelp32.h>
+
+namespace app {
+
+    struct EnumWindowContext {
+        DWORD targetPid;
+        std::vector<ZemaxWindowInfo>& results;
+    };
+
+    static BOOL CALLBACK enumWindowsProc(HWND hwnd, LPARAM lParam) {
+        auto& ctx = *reinterpret_cast<EnumWindowContext*>(lParam);
+
+        DWORD windowPid = 0;
+        GetWindowThreadProcessId(hwnd, &windowPid);
+
+        if (windowPid != ctx.targetPid) {
+            return TRUE;
+        }
+
+        if (!IsWindowVisible(hwnd)) {
+            return TRUE;
+        }
+
+        wchar_t title[256];
+        int len = GetWindowTextW(hwnd, title, sizeof(title) / sizeof(title[0]));
+        if (len == 0) {
+            return TRUE;
+        }
+
+        ZemaxWindowInfo info;
+        info.pid = ctx.targetPid;
+        info.hwnd = hwnd;
+        info.title.assign(title, static_cast<size_t>(len));
+        ctx.results.push_back(std::move(info));
+
+        return TRUE;
+    }
+
+    static void enumerateWindowsForPid(DWORD pid, std::vector<ZemaxWindowInfo>& results) {
+        EnumWindowContext ctx{pid, results};
+        EnumWindows(enumWindowsProc, reinterpret_cast<LPARAM>(&ctx));
+    }
+
+    std::vector<ZemaxWindowInfo> ZemaxWindowEnumerator::enumerate() {
+        std::vector<ZemaxWindowInfo> results;
+
+        HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if (snapshot == INVALID_HANDLE_VALUE) {
+            return results;
+        }
+
+        PROCESSENTRY32W pe;
+        pe.dwSize = sizeof(pe);
+
+        if (Process32FirstW(snapshot, &pe)) {
+            do {
+                if (_wcsicmp(pe.szExeFile, L"zemax.exe") == 0) {
+                    enumerateWindowsForPid(pe.th32ProcessID, results);
+                }
+            } while (Process32NextW(snapshot, &pe));
+        }
+
+        CloseHandle(snapshot);
+        return results;
+    }
+
+}

--- a/src/app/zemax_window_enumerator.h
+++ b/src/app/zemax_window_enumerator.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <windows.h>
+
+namespace app {
+
+struct ZemaxWindowInfo {
+    DWORD pid;
+    HWND hwnd;
+    std::wstring title;
+};
+
+class ZemaxWindowEnumerator {
+public:
+    static std::vector<ZemaxWindowInfo> enumerate();
+};
+
+}

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <string_view>
-#include <windows.h>
+#include <cstdint>
 #include <functional>
+#include <string>
+#include <vector>
+#include <windows.h>
 
 #include "types.h"
 
@@ -27,6 +29,20 @@ namespace ZemaxDDE {
 
             using OnDDEConnectedCallback = std::function<void(ZemaxDDEClient*)>;
             void setOnDDEConnectedCallback(OnDDEConnectedCallback callback);
+
+            struct PendingRequest {
+                uint64_t id;
+                std::string command;
+                std::string rawRequest;
+                std::function<void(const std::string&)> onResult;
+                std::function<void(const std::string&)> onError;
+                int retryCount = 0;
+                DWORD startTime = 0;
+            };
+
+            uint64_t sendRequest(const std::string& command,
+                std::function<void(const std::string&)> onResult,
+                std::function<void(const std::string&)> onError);
 
             // DDE Commands
             void getLensName();
@@ -64,6 +80,9 @@ namespace ZemaxDDE {
             SurfaceData m_nominalSurface;
             SurfaceData* m_currentStorage = &m_tolerancedSurface;
             bool m_isDataReceived{false};
+
+            std::vector<PendingRequest> m_pendingRequests;
+            uint64_t m_nextRequestId = 1;
 
             void sendPostRequest(std::string_view request);
             void waitForData();

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -47,31 +47,10 @@ namespace ZemaxDDE {
                 std::function<void(const std::string&)> onResult,
                 std::function<void(const std::string&)> onError);
 
-            // DDE Commands
-            void getLensName();
-            void getFileName();
-            void getSystemData();
-            void getFieldData();
-            void getFieldByIndex(int fieldIndex);
-            void getWaveData();
-            void getWaveByIndex(int waveIndex);
-            void getSurfaceData(int surfaceNumber, int code, int arg2 = 0);
-            void getSag(int surfaceNumber, double x = 0.0, double y = 0.0);
-
             // Getters
             [[nodiscard]] const OpticalSystemData& getOpticalSystemData() const noexcept { return m_opticalSystem; }
             [[nodiscard]] SurfaceData* getTolerancedSurface() noexcept { return &m_tolerancedSurface; }
             [[nodiscard]] SurfaceData* getNominalSurface() noexcept { return &m_nominalSurface; }
-            [[nodiscard]] SurfaceData* getCurrentStorage() noexcept { return m_currentStorage; }
-
-            // Setters
-            void setStorageTarget(SurfaceData* targetStorage) noexcept { m_currentStorage = targetStorage; }
-            void setSurfaceProfileMetadata(const SurfaceProfileMetadata& metadata) {
-                if (m_currentStorage) {
-                    m_currentStorage->angle = metadata.angle;
-                    m_currentStorage->sampling = metadata.sampling;
-                }
-            }
 
         private:
             HWND m_hwndZemaxServer = nullptr;
@@ -81,17 +60,12 @@ namespace ZemaxDDE {
             OpticalSystemData m_opticalSystem;
             SurfaceData m_tolerancedSurface;
             SurfaceData m_nominalSurface;
-            SurfaceData* m_currentStorage = &m_tolerancedSurface;
-            bool m_isDataReceived{false};
 
             std::unique_ptr<InitialDataLoadService> m_initialDataLoad;
 
             std::vector<PendingRequest> m_pendingRequests;
             uint64_t m_nextRequestId = 1;
 
-            void sendPostRequest(std::string_view request);
-            void waitForData();
             void checkDDEConnection();
-            void checkResponseStatus(const std::string& errorMsg);
     };
 }

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -17,7 +17,7 @@ namespace ZemaxDDE {
             void initiateDDE();
             void terminateDDE();
 
-            bool isConnected() const noexcept { return m_hwndZemaxServer != NULL; }
+            bool isConnected() const noexcept { return m_hwndZemaxServer != nullptr; }
 
             LRESULT handleDDEMessages(UINT iMsg, WPARAM wParam, LPARAM lParam);
 
@@ -36,31 +36,30 @@ namespace ZemaxDDE {
             void getSag(int surfaceNumber, double x = 0.0, double y = 0.0);
 
             // Getters
-            [[nodiscard]] const StorageTarget& getStorageTarget() const noexcept { return m_currentStorageTarget; }
             [[nodiscard]] const OpticalSystemData& getOpticalSystemData() const noexcept { return m_opticalSystem; }
-            [[nodiscard]] const SurfaceData& getTolerancedSurface() const noexcept { return m_tolerancedSurface; }
-            [[nodiscard]] const SurfaceData& getNominalSurface() const noexcept { return m_nominalSurface; }
+            [[nodiscard]] SurfaceData* getTolerancedSurface() noexcept { return &m_tolerancedSurface; }
+            [[nodiscard]] SurfaceData* getNominalSurface() noexcept { return &m_nominalSurface; }
+            [[nodiscard]] SurfaceData* getCurrentStorage() noexcept { return m_currentStorage; }
 
             // Setters
-            void setStorageTarget(StorageTarget target) noexcept { m_currentStorageTarget = target; }
-            void clearTolerancedSurface() noexcept { m_tolerancedSurface.clear(); }
-            void clearNominalSurface() noexcept { m_nominalSurface.clear(); }
-            void setSurfaceProfileMetadata(ZemaxDDE::StorageTarget target, const SurfaceProfileMetadata& metadata) {
-                SurfaceData& surface = (target == StorageTarget::NOMINAL) ? m_nominalSurface : m_tolerancedSurface;
-                surface.angle = metadata.angle;
-                surface.sampling = metadata.sampling;
+            void setStorageTarget(SurfaceData* targetStorage) noexcept { m_currentStorage = targetStorage; }
+            void setSurfaceProfileMetadata(const SurfaceProfileMetadata& metadata) {
+                if (m_currentStorage) {
+                    m_currentStorage->angle = metadata.angle;
+                    m_currentStorage->sampling = metadata.sampling;
+                }
             }
 
         private:
             HWND m_hwndZemaxServer = nullptr;
-            HWND m_hwndZemaxClient = NULL;
+            HWND m_hwndZemaxClient = nullptr;
             Logger& m_logger;
             OnDDEConnectedCallback m_onDDEConnected;
             OpticalSystemData m_opticalSystem;
             SurfaceData m_tolerancedSurface;
             SurfaceData m_nominalSurface;
-            StorageTarget m_currentStorageTarget = StorageTarget::TOLERANCED;
-            bool m_isDataReceived = false;
+            SurfaceData* m_currentStorage = &m_tolerancedSurface;
+            bool m_isDataReceived{false};
 
             void sendPostRequest(std::string_view request);
             void waitForData();

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 #include <windows.h>
@@ -11,6 +12,8 @@
 class Logger;
 
 namespace ZemaxDDE {
+    class InitialDataLoadService;
+
     class ZemaxDDEClient {
         public:
             ZemaxDDEClient(HWND hwndClient, Logger& logger);
@@ -80,6 +83,8 @@ namespace ZemaxDDE {
             SurfaceData m_nominalSurface;
             SurfaceData* m_currentStorage = &m_tolerancedSurface;
             bool m_isDataReceived{false};
+
+            std::unique_ptr<InitialDataLoadService> m_initialDataLoad;
 
             std::vector<PendingRequest> m_pendingRequests;
             uint64_t m_nextRequestId = 1;

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
-#include <vector>
 #include <windows.h>
 
 #include "types.h"
@@ -13,6 +14,18 @@ class Logger;
 
 namespace ZemaxDDE {
     class InitialDataLoadService;
+    class OperationMonitor;
+
+    struct DdeRequest {
+        uint64_t id;
+        std::string command;
+        std::function<void(const std::string&)> onSuccess;
+        std::function<void(const std::string&)> onError;
+        DWORD timeoutMs;
+        int retriesLeft;
+        std::string serviceId;
+        DWORD startTime = 0;
+    };
 
     class ZemaxDDEClient {
         public:
@@ -33,26 +46,23 @@ namespace ZemaxDDE {
             using OnDDEConnectedCallback = std::function<void(ZemaxDDEClient*)>;
             void setOnDDEConnectedCallback(OnDDEConnectedCallback callback);
 
-            struct PendingRequest {
-                uint64_t id;
-                std::string command;
-                std::string rawRequest;
-                std::function<void(const std::string&)> onResult;
-                std::function<void(const std::string&)> onError;
-                int retryCount = 0;
-                DWORD startTime = 0;
-            };
-
-            uint64_t sendRequest(const std::string& command,
-                std::function<void(const std::string&)> onResult,
-                std::function<void(const std::string&)> onError);
+            uint64_t enqueueRequest(const std::string& command,
+                std::function<void(const std::string&)> onSuccess,
+                std::function<void(const std::string&)> onError,
+                DWORD timeoutMs = 1000,
+                int retries = 1,
+                const std::string& serviceId = "");
 
             // Getters
             [[nodiscard]] const OpticalSystemData& getOpticalSystemData() const noexcept { return m_opticalSystem; }
             [[nodiscard]] SurfaceData* getTolerancedSurface() noexcept { return &m_tolerancedSurface; }
             [[nodiscard]] SurfaceData* getNominalSurface() noexcept { return &m_nominalSurface; }
+            [[nodiscard]] OperationMonitor* getOperationMonitor() noexcept { return m_operationMonitor.get(); }
 
         private:
+            void dequeueAndSend();
+            void checkDDEConnection();
+
             HWND m_hwndZemaxServer = nullptr;
             HWND m_hwndZemaxClient = nullptr;
             Logger& m_logger;
@@ -62,10 +72,10 @@ namespace ZemaxDDE {
             SurfaceData m_nominalSurface;
 
             std::unique_ptr<InitialDataLoadService> m_initialDataLoad;
+            std::unique_ptr<OperationMonitor> m_operationMonitor;
 
-            std::vector<PendingRequest> m_pendingRequests;
+            std::deque<DdeRequest> m_requestQueue;
+            std::optional<DdeRequest> m_activeRequest;
             uint64_t m_nextRequestId = 1;
-
-            void checkDDEConnection();
     };
 }

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -15,9 +15,13 @@ namespace ZemaxDDE {
             ~ZemaxDDEClient();
 
             void initiateDDE();
+            void initiateDDE(HWND targetHwnd);
             void terminateDDE();
 
             bool isConnected() const noexcept { return m_hwndZemaxServer != nullptr; }
+
+            void pumpMessages();
+            void processTimeouts();
 
             LRESULT handleDDEMessages(UINT iMsg, WPARAM wParam, LPARAM lParam);
 

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -204,45 +204,6 @@ namespace ZemaxDDE {
         }
     }
 
-    void ZemaxDDEClient::waitForData() {
-        MSG msg;
-        DWORD dwTime = GetTickCount();
-        m_isDataReceived = false;
-        while ((GetTickCount() - dwTime < DDE_TIMEOUT_MS) && !m_isDataReceived) {
-            while (PeekMessage(&msg, m_hwndZemaxClient, WM_DDE_FIRST, WM_DDE_LAST, PM_REMOVE)) {
-                DispatchMessage(&msg);
-            }
-        }
-    }
-
-    void ZemaxDDEClient::sendPostRequest(std::string_view request) {
-        #ifdef DEBUG_LOG
-        m_logger.addLog(std::format("[DDE] Sending request: {}", request));
-        #endif
-
-        int wideCharCount = MultiByteToWideChar(CP_ACP,0, request.data(), static_cast<int>(request.size()), nullptr,0);
-        if (wideCharCount == 0) {
-            throw std::runtime_error("Failed to convert DDE request to wide string");
-        }
-
-        std::vector<wchar_t> wItem(wideCharCount + 1);
-
-        int converted = MultiByteToWideChar(CP_ACP, 0, request.data(), static_cast<int>(request.size()), wItem.data(), wideCharCount);
-        if (converted == 0 || converted != wideCharCount) {
-            throw std::runtime_error("Failed to convert DDE request to wide string");
-        }
-
-        wItem[wideCharCount] = L'\0';
-        ATOM aItem = GlobalAddAtomW(wItem.data());
-
-        if (!PostMessageW(m_hwndZemaxServer, WM_DDE_REQUEST, reinterpret_cast<WPARAM>(m_hwndZemaxClient), PackDDElParam(WM_DDE_REQUEST, CF_TEXT, aItem))) {
-            GlobalDeleteAtom(aItem);
-            throw std::runtime_error("Cannot communicate with Zemax");
-        }
-
-        waitForData();
-    }
-
     class GlobalLockGuard {
         HGLOBAL m_handle;
         void* m_ptr;
@@ -573,91 +534,12 @@ namespace ZemaxDDE {
                         }
                     }
                     if (command_token == "GetSurfaceData") {
-                        if (!routeAsync("GetSurfaceData")) {
-                            auto tokens = ZemaxDDE::tokenize(buffer);
-
-                            int currentSurface = std::stoi(item_tokens[1]);
-                            if (currentSurface < 0 || currentSurface > m_opticalSystem.numSurfs) {
-                                m_logger.addLog(std::format("[DDE] GetSurfaceData: Invalid current surface value: {}. Must be in range [{}, {}]",
-                                                        currentSurface, 0, m_opticalSystem.numSurfs));
-                                return 0;
-                            }
-
-                            int code = std::stoi(item_tokens[2]);
-                            if (!ZemaxDDE::SurfaceDataCode::isValid(code)) {
-                                m_logger.addLog(std::format("[DDE] GetSurfaceData: Invalid surface data code received: {}", code));
-                                return 0;
-                            }
-
-                            if (!m_currentStorage) {
-                                m_logger.addLog("[DDE] GetSurfaceData: No storage target set");
-                                return 0;
-                            }
-                            
-                            auto& surface = *m_currentStorage;
-                            surface.id = currentSurface;
-
-                            switch (code) {
-                                case ZemaxDDE::SurfaceDataCode::TYPE_NAME:{
-                                    surface.type = tokens[0];
-                                    break;
-                                }
-                                case ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER: {
-                                    surface.semiDiameter = std::stod(tokens[0]);
-                                    break;
-                                }
-                                default: {
-                                    m_logger.addLog(std::format("[DDE] GetSurfaceData: Unsupported code for storage: {}", code));
-                                    return 0;
-                                }
-                            }
-                        }
+                        routeAsync("GetSurfaceData");
                         DdeAck.fAck = true;
                         return 0;
                     }
                     if (command_token == "GetSag") {
-                        if (!routeAsync("GetSag")) {
-                            auto tokens = ZemaxDDE::tokenize(buffer);
-
-                            int currentSurface = std::stoi(item_tokens[1]);
-                            if (currentSurface < 0 || currentSurface > m_opticalSystem.numSurfs) {
-                                m_logger.addLog(std::format("[DDE] GetSag: Invalid current surface value: {}. Must be in range [{}, {}]",
-                                                        currentSurface, 0, m_opticalSystem.numSurfs));
-                                return 0;
-                            }
-
-                            double x = 0.0;
-                            double y = 0.0;
-
-                            try {
-                                x = std::stod(item_tokens[2]);
-                                y = std::stod(item_tokens[3]);
-                        } catch (const std::exception& e) {
-                            m_logger.addLog(std::format("[DDE] GetSag: Failed to parse x/y: {}", e.what()));
-                            return 0;
-                        }
-                        
-                        auto values = ZemaxDDE::tokenize(buffer);
-                        if (values.empty()) {
-                            m_logger.addLog("[DDE] GetSag: No values in response");
-                            return 0;
-                        }
-
-                        double sag = std::stod(values[0]);
-                        double alternateSag = std::stod(values[1]);
-
-                        // Selecting target storage
-                        if (!m_currentStorage) {
-                            m_logger.addLog("[DDE] GetSag: No storage target set");
-                            return 0;
-                        }
-                        
-                        auto& surface = *m_currentStorage;
-                        surface.id = currentSurface;
-                        surface.sagDataPoints.push_back({
-                            x, y, sag, alternateSag
-                        });
-                        }
+                        routeAsync("GetSag");
                         DdeAck.fAck = true;
                         return 0;    
                     }
@@ -690,17 +572,6 @@ namespace ZemaxDDE {
             #endif
 
             throw std::runtime_error(DDE_ERROR_MSG_CONNECTION_NOT_ESTABLISHED);
-        }
-    }
-
-    void ZemaxDDEClient::checkResponseStatus(const std::string& errorMsg) {
-        if (!m_isDataReceived) {
-
-            #ifdef DEBUG_LOG
-            m_logger.addLog(std::format("[DDE] {}", errorMsg));
-            #endif
-
-            throw std::runtime_error(errorMsg);
         }
     }
 }

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -4,11 +4,16 @@
 #include <vector>
 
 #include "client.h"
+#include "initial_data_load_service.h"
 #include "utils.h"
 #include "logger/logger.h"
 
 namespace ZemaxDDE {
-    ZemaxDDEClient::ZemaxDDEClient(HWND hwndClient, Logger& logger) : m_hwndZemaxClient(hwndClient), m_logger(logger) {}
+    ZemaxDDEClient::ZemaxDDEClient(HWND hwndClient, Logger& logger)
+        : m_hwndZemaxClient(hwndClient)
+        , m_logger(logger)
+        , m_initialDataLoad(std::make_unique<InitialDataLoadService>(*this, m_opticalSystem, m_logger))
+    {}
 
     ZemaxDDEClient::~ZemaxDDEClient() {
         terminateDDE();
@@ -269,6 +274,10 @@ namespace ZemaxDDE {
                     FreeDDElParam(WM_DDE_ACK, lParam);
 
                     m_hwndZemaxServer = reinterpret_cast<HWND>(wParam);
+
+                    if (m_initialDataLoad) {
+                        m_initialDataLoad->start();
+                    }
 
                     GlobalDeleteAtom(static_cast<ATOM>(lowWord));
                     GlobalDeleteAtom(static_cast<ATOM>(highWord));

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -5,6 +5,7 @@
 
 #include "client.h"
 #include "initial_data_load_service.h"
+#include "operation_monitor.h"
 #include "utils.h"
 #include "logger/logger.h"
 
@@ -13,6 +14,7 @@ namespace ZemaxDDE {
         : m_hwndZemaxClient(hwndClient)
         , m_logger(logger)
         , m_initialDataLoad(std::make_unique<InitialDataLoadService>(*this, m_opticalSystem, m_logger))
+        , m_operationMonitor(std::make_unique<OperationMonitor>())
     {}
 
     ZemaxDDEClient::~ZemaxDDEClient() {
@@ -115,84 +117,115 @@ namespace ZemaxDDE {
         }
     }
 
-    uint64_t ZemaxDDEClient::sendRequest(const std::string& command,
-        std::function<void(const std::string&)> onResult,
-        std::function<void(const std::string&)> onError) {
+    uint64_t ZemaxDDEClient::enqueueRequest(const std::string& command,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&)> onError,
+        DWORD timeoutMs,
+        int retries,
+        const std::string& serviceId) {
 
         uint64_t id = m_nextRequestId++;
+        DdeRequest req;
+        req.id = id;
+        req.command = command;
+        req.onSuccess = std::move(onSuccess);
+        req.onError = std::move(onError);
+        req.timeoutMs = timeoutMs;
+        req.retriesLeft = retries;
+        req.serviceId = serviceId;
+        req.startTime = GetTickCount();
+        m_requestQueue.push_back(std::move(req));
 
-        int wideCharCount = MultiByteToWideChar(CP_ACP, 0, command.data(),
-            static_cast<int>(command.size()), nullptr, 0);
+        m_logger.addLog(std::format("[DDE] Enqueued request #{}: '{}' (svc={}, timeout={}ms, retries={})",
+            id, command, serviceId, timeoutMs, retries));
+
+        if (!m_activeRequest) {
+            dequeueAndSend();
+        }
+
+        return id;
+    }
+
+    void ZemaxDDEClient::dequeueAndSend() {
+        if (m_requestQueue.empty()) return;
+
+        DdeRequest req = std::move(m_requestQueue.front());
+        m_requestQueue.pop_front();
+
+        int wideCharCount = MultiByteToWideChar(CP_ACP, 0,
+            req.command.data(), static_cast<int>(req.command.size()),
+            nullptr, 0);
         if (wideCharCount == 0) {
-            if (onError) onError("Failed to convert request to wide string");
-            return id;
+            if (req.onError) req.onError("Failed to convert request to wide string");
+            dequeueAndSend();
+            return;
         }
 
         std::vector<wchar_t> wItem(wideCharCount + 1);
-        int converted = MultiByteToWideChar(CP_ACP, 0, command.data(),
-            static_cast<int>(command.size()), wItem.data(), wideCharCount);
+        int converted = MultiByteToWideChar(CP_ACP, 0,
+            req.command.data(), static_cast<int>(req.command.size()),
+            wItem.data(), wideCharCount);
         if (converted == 0 || converted != wideCharCount) {
-            if (onError) onError("Failed to convert request to wide string");
-            return id;
+            if (req.onError) req.onError("Failed to convert request to wide string");
+            dequeueAndSend();
+            return;
         }
 
         wItem[wideCharCount] = L'\0';
         ATOM aItem = GlobalAddAtomW(wItem.data());
 
-        if (!PostMessageW(m_hwndZemaxServer, WM_DDE_REQUEST, reinterpret_cast<WPARAM>(m_hwndZemaxClient), PackDDElParam(WM_DDE_REQUEST, CF_TEXT, aItem))) {
+        if (!PostMessageW(m_hwndZemaxServer, WM_DDE_REQUEST,
+                reinterpret_cast<WPARAM>(m_hwndZemaxClient),
+                PackDDElParam(WM_DDE_REQUEST, CF_TEXT, aItem))) {
             GlobalDeleteAtom(aItem);
-            if (onError) onError("Cannot communicate with Zemax");
-            return id;
+            if (req.onError) req.onError("Cannot communicate with Zemax");
+            dequeueAndSend();
+            return;
         }
 
-        PendingRequest req;
-        req.id = id;
-        req.command = command;
-        req.rawRequest = command;
-        req.onResult = std::move(onResult);
-        req.onError = std::move(onError);
         req.startTime = GetTickCount();
-        m_pendingRequests.push_back(std::move(req));
+        m_activeRequest = std::move(req);
 
-        return id;
+        m_logger.addLog(std::format("[DDE] Sent request #{}: '{}'", m_activeRequest->id, m_activeRequest->command));
     }
 
     void ZemaxDDEClient::processTimeouts() {
+        if (!m_activeRequest) return;
+
         DWORD now = GetTickCount();
-        std::vector<size_t> completed;
+        auto& req = *m_activeRequest;
 
-        for (size_t i = 0; i < m_pendingRequests.size(); ++i) {
-            auto& req = m_pendingRequests[i];
-            if (now - req.startTime < DDE_TIMEOUT_MS) continue;
+        if (now - req.startTime < req.timeoutMs) return;
 
-            if (req.retryCount < 3) {
-                req.retryCount++;
-                req.startTime = now;
+        if (req.retriesLeft > 0) {
+            req.retriesLeft--;
+            req.timeoutMs = static_cast<DWORD>(static_cast<double>(req.timeoutMs) * 1.5);
+            req.startTime = now;
 
-                int wideCharCount = MultiByteToWideChar(CP_ACP, 0,
-                    req.rawRequest.data(), static_cast<int>(req.rawRequest.size()),
-                    nullptr, 0);
-                if (wideCharCount > 0) {
-                    std::vector<wchar_t> wItem(wideCharCount + 1);
-                    MultiByteToWideChar(CP_ACP, 0, req.rawRequest.data(),
-                        static_cast<int>(req.rawRequest.size()),
-                        wItem.data(), wideCharCount);
-                    wItem[wideCharCount] = L'\0';
-                    ATOM aItem = GlobalAddAtomW(wItem.data());
-                    PostMessageW(m_hwndZemaxServer, WM_DDE_REQUEST,
-                        reinterpret_cast<WPARAM>(m_hwndZemaxClient),
-                        PackDDElParam(WM_DDE_REQUEST, CF_TEXT, aItem));
-                }
-            } else {
-                if (req.onError) {
-                    req.onError("Max retries exceeded");
-                }
-                completed.push_back(i);
+            int wideCharCount = MultiByteToWideChar(CP_ACP, 0,
+                req.command.data(), static_cast<int>(req.command.size()),
+                nullptr, 0);
+            if (wideCharCount > 0) {
+                std::vector<wchar_t> wItem(wideCharCount + 1);
+                MultiByteToWideChar(CP_ACP, 0, req.command.data(),
+                    static_cast<int>(req.command.size()),
+                    wItem.data(), wideCharCount);
+                wItem[wideCharCount] = L'\0';
+                ATOM aItem = GlobalAddAtomW(wItem.data());
+                PostMessageW(m_hwndZemaxServer, WM_DDE_REQUEST,
+                    reinterpret_cast<WPARAM>(m_hwndZemaxClient),
+                    PackDDElParam(WM_DDE_REQUEST, CF_TEXT, aItem));
             }
-        }
 
-        for (auto it = completed.rbegin(); it != completed.rend(); ++it) {
-            m_pendingRequests.erase(m_pendingRequests.begin() + static_cast<ptrdiff_t>(*it));
+            m_logger.addLog(std::format("[DDE] Retry #{} for request #{}: '{}' (timeout={}ms)",
+                m_activeRequest->retriesLeft, req.id, req.command, req.timeoutMs));
+        } else {
+            m_logger.addLog(std::format("[DDE] Request #{} timed out: '{}'", req.id, req.command));
+            if (req.onError) {
+                req.onError("Timeout");
+            }
+            m_activeRequest.reset();
+            dequeueAndSend();
         }
     }
 
@@ -274,47 +307,39 @@ namespace ZemaxDDE {
                     m_logger.addLog(std::format("[DDE] Received 'WM_DDE_DATA', content = {}", buffer));
                     #endif
 
-                    auto findPendingRequest = [&](const std::string& cmd) {
-                        return std::find_if(m_pendingRequests.begin(), m_pendingRequests.end(),
-                            [&](const PendingRequest& req) {
-                                return req.rawRequest.rfind(cmd, 0) == 0;
-                            });
-                    };
-
-                    auto routeAsync = [&](const std::string& cmdToken) -> bool {
-                        auto it = findPendingRequest(cmdToken);
-                        if (it != m_pendingRequests.end()) {
-                            if (it->onResult) it->onResult(buffer);
-                            m_pendingRequests.erase(it);
-                            return true;
+                    bool matched = false;
+                    if (m_activeRequest && dde_item_str == m_activeRequest->command) {
+                        if (m_activeRequest->onSuccess) {
+                            m_activeRequest->onSuccess(buffer);
                         }
-                        return false;
-                    };
+                        m_logger.addLog(std::format("[DDE] Routed to request #{} ('{}', svc={})",
+                            m_activeRequest->id, m_activeRequest->command, m_activeRequest->serviceId));
+                        m_activeRequest.reset();
+                        dequeueAndSend();
+                        DdeAck.fAck = true;
+                        matched = true;
+                    }
 
-                    if (command_token == "GetName") {
-                        std::string name = extractStringFromDDE(ddeDataHandle);
-                        if (name.empty()) {
-                            name = "unknown";
-                            m_logger.addLog("[DDE] GetName: empty lens name, using default 'unknown'");
-                        }
+                    if (!matched) {
+                        #ifdef DEBUG_LOG
+                        m_logger.addLog(std::format("[DDE] No matching active request, using fallback for '{}'", command_token));
+                        #endif
 
-                        if (!routeAsync("GetName")) {
+                        if (command_token == "GetName") {
+                            std::string name = extractStringFromDDE(ddeDataHandle);
+                            if (name.empty()) {
+                                name = "unknown";
+                                m_logger.addLog("[DDE] GetName: empty lens name, using default 'unknown'");
+                            }
                             m_opticalSystem.lensName = name;
+                            DdeAck.fAck = true;
                         }
-
-                        DdeAck.fAck = true;
-                    }
-                    if (command_token == "GetFile") {
-                        std::string fileNameStr = extractStringFromDDE(ddeDataHandle);
-
-                        if (!routeAsync("GetFile")) {
+                        if (command_token == "GetFile") {
+                            std::string fileNameStr = extractStringFromDDE(ddeDataHandle);
                             m_opticalSystem.fileName = fileNameStr;
+                            DdeAck.fAck = true;
                         }
-
-                        DdeAck.fAck = true;
-                    }
-                    if (command_token == "GetSystem") {
-                        if (!routeAsync("GetSystem")) {
+                        if (command_token == "GetSystem") {
                             const int GET_SYSTEM_PARAMS_COUNT = 9;
                             auto systemParams = ZemaxDDE::tokenize(buffer);
                             int params = static_cast<int>(systemParams.size());
@@ -360,9 +385,7 @@ namespace ZemaxDDE {
                                 return 0;
                             }
                         }
-                    }
-                    if (command_token == "GetField") {
-                        if (!routeAsync("GetField")) {
+                        if (command_token == "GetField") {
                             const int EXPECTED_COMMAND_TOKENS = 2;
                             int params = static_cast<int>(item_tokens.size());
 
@@ -449,9 +472,7 @@ namespace ZemaxDDE {
                             }
                             DdeAck.fAck = true;
                         }
-                    }
-                    if (command_token == "GetWave") {
-                        if (!routeAsync("GetWave")) {
+                        if (command_token == "GetWave") {
                             const int EXPECTED_COMMAND_TOKENS = 2;
                             int params = static_cast<int>(item_tokens.size());
 
@@ -527,21 +548,17 @@ namespace ZemaxDDE {
                                 }
                             } else {
                                 m_logger.addLog(std::format("[DDE] GetWave: Wave index must be 0 (metadata) or in range [{}, {}]. Got: {}",
-                                                        ZemaxDDE::MIN_WAVES, ZemaxDDE::MAX_WAVES, arg));
+                                                        ZemaxDDE::MIN_WAVES, ZemaxDDE::MAX_FIELDS, arg));
                                 return 0;
                             }
                             DdeAck.fAck = true;
                         }
-                    }
-                    if (command_token == "GetSurfaceData") {
-                        routeAsync("GetSurfaceData");
-                        DdeAck.fAck = true;
-                        return 0;
-                    }
-                    if (command_token == "GetSag") {
-                        routeAsync("GetSag");
-                        DdeAck.fAck = true;
-                        return 0;    
+                        if (command_token == "GetSurfaceData") {
+                            DdeAck.fAck = true;
+                        }
+                        if (command_token == "GetSag") {
+                            DdeAck.fAck = true;
+                        }
                     }
                 }
                 if (ddeDataLock.as<::DDEDATA>()->fAckReq == true) {

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -447,8 +447,6 @@ namespace ZemaxDDE {
                         
                         auto& surface = *m_currentStorage;
                         surface.id = currentSurface;
-                        surface.units = m_opticalSystem.units;
-                        surface.fileName = m_opticalSystem.fileName;
 
                         switch (code) {
                             case ZemaxDDE::SurfaceDataCode::TYPE_NAME:{

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -23,7 +23,7 @@ namespace ZemaxDDE {
             return;
         }
 
-        m_hwndZemaxServer = NULL;
+        m_hwndZemaxServer = nullptr;
 
         ATOM appAtom = GlobalAddAtomW(DDE_APP_NAME);
         ATOM topicAtom = GlobalAddAtomW(DDE_TOPIC);
@@ -187,7 +187,7 @@ namespace ZemaxDDE {
                         m_logger.addLog(std::format("[DDE] GetName (converted): {}", name));
                         #endif
 
-                        DdeAck.fAck = TRUE;
+                        DdeAck.fAck = true;
                     }
                     if (command_token == "GetFile") {
                         std::string fileNameStr = extractStringFromDDE(ddeDataHandle);
@@ -197,7 +197,7 @@ namespace ZemaxDDE {
                         m_logger.addLog(std::format("[DDE] GetFile (converted): {}", fileNameStr));
                         #endif
 
-                        DdeAck.fAck = TRUE;
+                        DdeAck.fAck = true;
                     }
                     if (command_token == "GetSystem") {
                         const int GET_SYSTEM_PARAMS_COUNT = 9;
@@ -234,7 +234,7 @@ namespace ZemaxDDE {
                             m_opticalSystem.pressure      = std::stod(systemParams[PRESSURE]);
                             m_opticalSystem.globalRefSurf = std::stoi(systemParams[GLOBAL_REF_SURF]);
 
-                            DdeAck.fAck = TRUE;
+                            DdeAck.fAck = true;
                         } catch (const std::invalid_argument& e) {
                             m_logger.addLog(std::format("[DDE] GetSystem: Invalid number format in parameter: {}", e.what()));
                             return 0;
@@ -337,7 +337,7 @@ namespace ZemaxDDE {
                                                     ZemaxDDE::MIN_FIELDS, ZemaxDDE::MAX_FIELDS, arg));
                             return 0;
                         }
-                        DdeAck.fAck = TRUE;
+                        DdeAck.fAck = true;
                     }
                     if (command_token == "GetWave") {
                         const int EXPECTED_COMMAND_TOKENS = 2;
@@ -418,7 +418,7 @@ namespace ZemaxDDE {
                                                     ZemaxDDE::MIN_WAVES, ZemaxDDE::MAX_WAVES, arg));
                             return 0;
                         }
-                        DdeAck.fAck = TRUE;
+                        DdeAck.fAck = true;
                     }
                     if (command_token == "GetSurfaceData") {
                         auto tokens = ZemaxDDE::tokenize(buffer);
@@ -440,11 +440,15 @@ namespace ZemaxDDE {
                         // int arg2 = std::stoi(item_tokens[3]);
 
                         // Selecting target storage
-                        auto& surface = (m_currentStorageTarget == StorageTarget::NOMINAL)
-                            ? m_nominalSurface
-                            : m_tolerancedSurface;
+                        if (!m_currentStorage) {
+                            m_logger.addLog("[DDE] GetSurfaceData: No storage target set");
+                            return 0;
+                        }
+                        
+                        auto& surface = *m_currentStorage;
                         surface.id = currentSurface;
                         surface.units = m_opticalSystem.units;
+                        surface.fileName = m_opticalSystem.fileName;
 
                         switch (code) {
                             case ZemaxDDE::SurfaceDataCode::TYPE_NAME:{
@@ -461,7 +465,7 @@ namespace ZemaxDDE {
                             }
                         }
 
-                        DdeAck.fAck = TRUE;
+                        DdeAck.fAck = true;
                         return 0;
                     }
                     if (command_token == "GetSag") {
@@ -496,19 +500,22 @@ namespace ZemaxDDE {
                         double alternateSag = std::stod(values[1]);
 
                         // Selecting target storage
-                        auto& surface = (m_currentStorageTarget == StorageTarget::NOMINAL)
-                            ? m_nominalSurface
-                            : m_tolerancedSurface;
+                        if (!m_currentStorage) {
+                            m_logger.addLog("[DDE] GetSag: No storage target set");
+                            return 0;
+                        }
+                        
+                        auto& surface = *m_currentStorage;
                         surface.id = currentSurface;
                         surface.sagDataPoints.push_back({
                             x, y, sag, alternateSag
                         });
 
-                        DdeAck.fAck = TRUE;
+                        DdeAck.fAck = true;
                         return 0;    
                     }
                 }
-                if (ddeDataLock.as<::DDEDATA>()->fAckReq == TRUE) {
+                if (ddeDataLock.as<::DDEDATA>()->fAckReq == true) {
                     WORD wStatus;
                     memcpy(&wStatus, &DdeAck, sizeof(wStatus));
                     if (!PostMessageW(reinterpret_cast<HWND>(wParam), WM_DDE_ACK, reinterpret_cast<WPARAM>(m_hwndZemaxClient), PackDDElParam(WM_DDE_ACK, wStatus, aItem))) {
@@ -519,7 +526,7 @@ namespace ZemaxDDE {
                 } else {
                     GlobalDeleteAtom(aItem);
                 }
-                if (ddeDataLock.as<::DDEDATA>()->fRelease == TRUE || DdeAck.fAck == FALSE) {
+                if (ddeDataLock.as<::DDEDATA>()->fRelease == true || DdeAck.fAck == false) {
                     GlobalFree(ddeDataHandle);
                 }
                 return 0;

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <stdexcept>
 #include <fstream>
 #include <vector>
@@ -109,8 +110,85 @@ namespace ZemaxDDE {
         }
     }
 
+    uint64_t ZemaxDDEClient::sendRequest(const std::string& command,
+        std::function<void(const std::string&)> onResult,
+        std::function<void(const std::string&)> onError) {
+
+        uint64_t id = m_nextRequestId++;
+
+        int wideCharCount = MultiByteToWideChar(CP_ACP, 0, command.data(),
+            static_cast<int>(command.size()), nullptr, 0);
+        if (wideCharCount == 0) {
+            if (onError) onError("Failed to convert request to wide string");
+            return id;
+        }
+
+        std::vector<wchar_t> wItem(wideCharCount + 1);
+        int converted = MultiByteToWideChar(CP_ACP, 0, command.data(),
+            static_cast<int>(command.size()), wItem.data(), wideCharCount);
+        if (converted == 0 || converted != wideCharCount) {
+            if (onError) onError("Failed to convert request to wide string");
+            return id;
+        }
+
+        wItem[wideCharCount] = L'\0';
+        ATOM aItem = GlobalAddAtomW(wItem.data());
+
+        if (!PostMessageW(m_hwndZemaxServer, WM_DDE_REQUEST, reinterpret_cast<WPARAM>(m_hwndZemaxClient), PackDDElParam(WM_DDE_REQUEST, CF_TEXT, aItem))) {
+            GlobalDeleteAtom(aItem);
+            if (onError) onError("Cannot communicate with Zemax");
+            return id;
+        }
+
+        PendingRequest req;
+        req.id = id;
+        req.command = command;
+        req.rawRequest = command;
+        req.onResult = std::move(onResult);
+        req.onError = std::move(onError);
+        req.startTime = GetTickCount();
+        m_pendingRequests.push_back(std::move(req));
+
+        return id;
+    }
+
     void ZemaxDDEClient::processTimeouts() {
-        // Will be used in async DDE phase
+        DWORD now = GetTickCount();
+        std::vector<size_t> completed;
+
+        for (size_t i = 0; i < m_pendingRequests.size(); ++i) {
+            auto& req = m_pendingRequests[i];
+            if (now - req.startTime < DDE_TIMEOUT_MS) continue;
+
+            if (req.retryCount < 3) {
+                req.retryCount++;
+                req.startTime = now;
+
+                int wideCharCount = MultiByteToWideChar(CP_ACP, 0,
+                    req.rawRequest.data(), static_cast<int>(req.rawRequest.size()),
+                    nullptr, 0);
+                if (wideCharCount > 0) {
+                    std::vector<wchar_t> wItem(wideCharCount + 1);
+                    MultiByteToWideChar(CP_ACP, 0, req.rawRequest.data(),
+                        static_cast<int>(req.rawRequest.size()),
+                        wItem.data(), wideCharCount);
+                    wItem[wideCharCount] = L'\0';
+                    ATOM aItem = GlobalAddAtomW(wItem.data());
+                    PostMessageW(m_hwndZemaxServer, WM_DDE_REQUEST,
+                        reinterpret_cast<WPARAM>(m_hwndZemaxClient),
+                        PackDDElParam(WM_DDE_REQUEST, CF_TEXT, aItem));
+                }
+            } else {
+                if (req.onError) {
+                    req.onError("Max retries exceeded");
+                }
+                completed.push_back(i);
+            }
+        }
+
+        for (auto it = completed.rbegin(); it != completed.rend(); ++it) {
+            m_pendingRequests.erase(m_pendingRequests.begin() + static_cast<ptrdiff_t>(*it));
+        }
     }
 
     void ZemaxDDEClient::terminateDDE() {
@@ -220,12 +298,28 @@ namespace ZemaxDDE {
                     std::vector<std::string> item_tokens = ZemaxDDE::tokenize(dde_item_str);
                     std::string command_token = item_tokens.empty() ? "" : item_tokens[0];
 
-                    m_isDataReceived = true;
                     buffer = reinterpret_cast<char*>(ddeDataLock.as<::DDEDATA>()->Value);
 
                     #ifdef DEBUG_LOG
                     m_logger.addLog(std::format("[DDE] Received 'WM_DDE_DATA', content = {}", buffer));
                     #endif
+
+                    auto findPendingRequest = [&](const std::string& cmd) {
+                        return std::find_if(m_pendingRequests.begin(), m_pendingRequests.end(),
+                            [&](const PendingRequest& req) {
+                                return req.rawRequest.rfind(cmd, 0) == 0;
+                            });
+                    };
+
+                    auto routeAsync = [&](const std::string& cmdToken) -> bool {
+                        auto it = findPendingRequest(cmdToken);
+                        if (it != m_pendingRequests.end()) {
+                            if (it->onResult) it->onResult(buffer);
+                            m_pendingRequests.erase(it);
+                            return true;
+                        }
+                        return false;
+                    };
 
                     if (command_token == "GetName") {
                         std::string name = extractStringFromDDE(ddeDataHandle);
@@ -234,308 +328,301 @@ namespace ZemaxDDE {
                             m_logger.addLog("[DDE] GetName: empty lens name, using default 'unknown'");
                         }
 
-                        m_opticalSystem.lensName = name;
-
-                        #ifdef DEBUG_LOG
-                        m_logger.addLog(std::format("[DDE] GetName (converted): {}", name));
-                        #endif
+                        if (!routeAsync("GetName")) {
+                            m_opticalSystem.lensName = name;
+                        }
 
                         DdeAck.fAck = true;
                     }
                     if (command_token == "GetFile") {
                         std::string fileNameStr = extractStringFromDDE(ddeDataHandle);
-                        m_opticalSystem.fileName = fileNameStr;
 
-                        #ifdef DEBUG_LOG
-                        m_logger.addLog(std::format("[DDE] GetFile (converted): {}", fileNameStr));
-                        #endif
+                        if (!routeAsync("GetFile")) {
+                            m_opticalSystem.fileName = fileNameStr;
+                        }
 
                         DdeAck.fAck = true;
                     }
                     if (command_token == "GetSystem") {
-                        const int GET_SYSTEM_PARAMS_COUNT = 9;
-                        auto systemParams = ZemaxDDE::tokenize(buffer);
-                        int params = static_cast<int>(systemParams.size());
+                        if (!routeAsync("GetSystem")) {
+                            const int GET_SYSTEM_PARAMS_COUNT = 9;
+                            auto systemParams = ZemaxDDE::tokenize(buffer);
+                            int params = static_cast<int>(systemParams.size());
 
-                        if (params != GET_SYSTEM_PARAMS_COUNT) {
-                            m_logger.addLog(std::format("[DDE] GetSystem: Invalid parameter count. Expected exactly {}, got {}",
-                                                    GET_SYSTEM_PARAMS_COUNT, params));
-                            return 0;
-                        }
-
-                        try {
-                            // GetSystem parameter indexes
-                            enum {
-                                NUM_SURFS,                      // Number of surfaces
-                                UNIT_CODE,                      // Unit code (0=mm, 1=cm, 2=in, 3=M)
-                                STOP_SURF,                      // Stop surface number
-                                NON_AXIAL_FLAG,                 // Non-axial symmetry flag (0=axial, 1=non-axial)
-                                RAY_AIMING_TYPE,                // Ray aiming type (0=off, 1=paraxial, 2=real)
-                                ADJUST_INDEX,                   // Index adjustment flag (0=false, 1=true)
-                                TEMP,                           // Temperature
-                                PRESSURE,                       // Pressure
-                                GLOBAL_REF_SURF                 // Global reference surface
-                            };
-
-                            m_opticalSystem.numSurfs      = std::stoi(systemParams[NUM_SURFS]);
-                            m_opticalSystem.units         = std::stoi(systemParams[UNIT_CODE]);
-                            m_opticalSystem.stopSurf      = std::stoi(systemParams[STOP_SURF]);
-                            m_opticalSystem.nonAxialFlag  = std::stoi(systemParams[NON_AXIAL_FLAG]);
-                            m_opticalSystem.rayAimingType = std::stoi(systemParams[RAY_AIMING_TYPE]);
-                            m_opticalSystem.adjustIndex   = std::stoi(systemParams[ADJUST_INDEX]);
-                            m_opticalSystem.temp          = std::stod(systemParams[TEMP]);
-                            m_opticalSystem.pressure      = std::stod(systemParams[PRESSURE]);
-                            m_opticalSystem.globalRefSurf = std::stoi(systemParams[GLOBAL_REF_SURF]);
-
-                            DdeAck.fAck = true;
-                        } catch (const std::invalid_argument& e) {
-                            m_logger.addLog(std::format("[DDE] GetSystem: Invalid number format in parameter: {}", e.what()));
-                            return 0;
-                        } catch (const std::out_of_range& e) {
-                            m_logger.addLog(std::format("[DDE] GetSystem: Number out of range: {}", e.what()));
-                            return 0;
-                        } catch (const std::exception& e) {
-                            m_logger.addLog(std::format("[DDE] GetSystem: Unexpected error: {}", e.what()));
-                            return 0;
-                        }
-                    }
-                    if (command_token == "GetField") {
-                        const int EXPECTED_COMMAND_TOKENS = 2;
-                        int params = static_cast<int>(item_tokens.size());
-
-                        if (params != EXPECTED_COMMAND_TOKENS) {
-                            m_logger.addLog(std::format("[DDE] GetField: Invalid command format. Expected exactly {} tokens, got {}",
-                                                    EXPECTED_COMMAND_TOKENS, params));
-                            return 0;
-                        }
-
-                        int arg = -1;
-                        try {
-                            arg = std::stoi(item_tokens[1]);
-                        } catch (const std::invalid_argument&) {
-                            m_logger.addLog(std::format("[DDE] GetField: Invalid field index '{}'. Not a number.", item_tokens[1]));
-                            return 0;
-                        } catch (const std::out_of_range&) {
-                            m_logger.addLog(std::format("[DDE] GetField: Field index '{}' is out of range (too large).", item_tokens[1]));
-                            return 0;
-                        }
-
-                        if (arg == 0 || (arg >= ZemaxDDE::MIN_FIELDS && arg <= ZemaxDDE::MAX_FIELDS)) {
-                            auto tokens = ZemaxDDE::tokenize(buffer);
-                            int dataCount = static_cast<int>(tokens.size());
-
-                            if(arg == 0) {
-                                const int GET_FIELD_META_COUNT = 5;     // fieldType, numFields, maxX, maxY, normalizationMethod
-                                if (dataCount != GET_FIELD_META_COUNT) {
-                                    m_logger.addLog(std::format("[DDE] GetField: Invalid parameter count for field metadata. Expected exactly {}, got {}",
-                                                            GET_FIELD_META_COUNT, dataCount));
-                                    return 0;
-                                }
-
-                                try {
-                                    enum  {
-                                        FIELD_TYPE,
-                                        NUM_FIELDS,
-                                        MAX_X_FIELD,
-                                        MAX_Y_FIELD,
-                                        NORMALIZATION_METHOD
-                                    };
-
-                                    m_opticalSystem.fieldType = std::stoi(tokens[FIELD_TYPE]);
-
-                                    int numFields = std::stoi(tokens[NUM_FIELDS]);
-                                    if (numFields < ZemaxDDE::MIN_FIELDS || numFields > ZemaxDDE::MAX_FIELDS) {
-                                        m_logger.addLog(std::format("[DDE] GetField: Invalid numFields value: {}. Must be in range [{}, {}]",
-                                                                numFields, ZemaxDDE::MIN_FIELDS, ZemaxDDE::MAX_FIELDS));
-                                        return 0;
-                                    }
-
-                                    m_opticalSystem.numFields = numFields;
-                                    m_opticalSystem.maxXField = std::stod(tokens[MAX_X_FIELD]);
-                                    m_opticalSystem.maxYField = std::stod(tokens[MAX_Y_FIELD]);
-                                    m_opticalSystem.normalizationMethod = std::stoi(tokens[NORMALIZATION_METHOD]);
-                                } catch (const std::exception& e) {
-                                    m_logger.addLog(std::format("[DDE] GetField: Failed to parse field metadata: {}", e.what()));
-                                    return 0;
-                                }
-                            } else {
-                                const int GET_FIELD_DATA_COUNT = 8;     // xField, yField, weight, vDx, vDy, vCx, vCy, vAn
-                                if (dataCount != GET_FIELD_DATA_COUNT) {
-                                    m_logger.addLog(std::format("[DDE] GetField: Invalid parameter count for field data. Expected exactly {}, got {}",
-                                                            GET_FIELD_DATA_COUNT, dataCount));
-                                    return 0;
-                                }
-
-                                try {
-                                    enum {
-                                        XFIELD,
-                                        YFIELD,
-                                        // WEIGHT,
-                                        // VDX,
-                                        // VDY,
-                                        // VCX,
-                                        // VCY,
-                                        // VAN
-                                    };
-
-                                    m_opticalSystem.xField[arg] = std::stod(tokens[XFIELD]);
-                                    m_opticalSystem.yField[arg] = std::stod(tokens[YFIELD]);
-                                } catch (const std::exception& e) {
-                                    m_logger.addLog(std::format("[DDE] GetField: Failed to parse data for field {}: {}", arg, e.what()));
-                                    return 0;
-                                }
+                            if (params != GET_SYSTEM_PARAMS_COUNT) {
+                                m_logger.addLog(std::format("[DDE] GetSystem: Invalid parameter count. Expected exactly {}, got {}",
+                                                        GET_SYSTEM_PARAMS_COUNT, params));
+                                return 0;
                             }
-                        } else {
-                            m_logger.addLog(std::format("[DDE] GetField: Field index must be 0 (metadata) or in range [{}, {}]. Got: {}",
-                                                    ZemaxDDE::MIN_FIELDS, ZemaxDDE::MAX_FIELDS, arg));
-                            return 0;
-                        }
-                        DdeAck.fAck = true;
-                    }
-                    if (command_token == "GetWave") {
-                        const int EXPECTED_COMMAND_TOKENS = 2;
-                        int params = static_cast<int>(item_tokens.size());
 
-                        if (params != EXPECTED_COMMAND_TOKENS) {
-                            m_logger.addLog(std::format("[DDE] GetWave: Invalid command format. Expected exactly {} tokens, got {}",
-                                                    EXPECTED_COMMAND_TOKENS, params));
-                            return 0;
-                        }
+                            try {
+                                enum {
+                                    NUM_SURFS,
+                                    UNIT_CODE,
+                                    STOP_SURF,
+                                    NON_AXIAL_FLAG,
+                                    RAY_AIMING_TYPE,
+                                    ADJUST_INDEX,
+                                    TEMP,
+                                    PRESSURE,
+                                    GLOBAL_REF_SURF
+                                };
 
-                        int arg = -1;
-                        try {
-                            arg = std::stoi(item_tokens[1]);
-                        } catch (const std::invalid_argument&) {
-                            m_logger.addLog(std::format("[DDE] GetWave: Invalid wave index '{}'. Not a number.", item_tokens[1]));
-                            return 0;
-                        } catch (const std::out_of_range&) {
-                            m_logger.addLog(std::format("[DDE] GetWave: Wave index '{}' is out of range (too large).", item_tokens[1]));
-                            return 0;
-                        }
+                                m_opticalSystem.numSurfs      = std::stoi(systemParams[NUM_SURFS]);
+                                m_opticalSystem.units         = std::stoi(systemParams[UNIT_CODE]);
+                                m_opticalSystem.stopSurf      = std::stoi(systemParams[STOP_SURF]);
+                                m_opticalSystem.nonAxialFlag  = std::stoi(systemParams[NON_AXIAL_FLAG]);
+                                m_opticalSystem.rayAimingType = std::stoi(systemParams[RAY_AIMING_TYPE]);
+                                m_opticalSystem.adjustIndex   = std::stoi(systemParams[ADJUST_INDEX]);
+                                m_opticalSystem.temp          = std::stod(systemParams[TEMP]);
+                                m_opticalSystem.pressure      = std::stod(systemParams[PRESSURE]);
+                                m_opticalSystem.globalRefSurf = std::stoi(systemParams[GLOBAL_REF_SURF]);
 
-                        if (arg == 0 || (arg >= ZemaxDDE::MIN_WAVES && arg <= ZemaxDDE::MAX_WAVES)) {
-                            auto tokens = ZemaxDDE::tokenize(buffer);
-                            int dataCount = static_cast<int>(tokens.size());
-
-                            if(arg == 0) {
-                                const int GET_WAVE_META_COUNT = 2;     // primary, number
-                                if (dataCount != GET_WAVE_META_COUNT) {
-                                    m_logger.addLog(std::format("[DDE] GetWave: Invalid parameter count for wave metadata. Expected exactly {}, got {}",
-                                                            GET_WAVE_META_COUNT, dataCount));
-                                    return 0;
-                                }
-
-                                try {
-                                    enum  {
-                                        PRIM_WAVE,
-                                        NUM_WAVES
-                                    };
-
-                                    m_opticalSystem.primWave = std::stoi(tokens[PRIM_WAVE]);
-
-                                    int numWaves = std::stoi(tokens[NUM_WAVES]);
-                                    if (numWaves < ZemaxDDE::MIN_WAVES || numWaves > ZemaxDDE::MAX_WAVES) {
-                                        m_logger.addLog(std::format("[DDE] GetWave: Invalid numWaves value: {}. Must be in range [{}, {}]",
-                                                                numWaves, ZemaxDDE::MIN_WAVES, ZemaxDDE::MAX_WAVES));
-                                        return 0;
-                                    }
-
-                                    m_opticalSystem.numWaves = numWaves;
-                                } catch (const std::exception& e) {
-                                    m_logger.addLog(std::format("[DDE] GetWave: Failed to parse wave metadata: {}", e.what()));
-                                    return 0;
-                                }
-                            } else {
-                                const int GET_WAVE_DATA_COUNT = 2;     // waveLen, weight
-                                if (dataCount != GET_WAVE_DATA_COUNT) {
-                                    m_logger.addLog(std::format("[DDE] GetWave: Invalid parameter count for wave data. Expected exactly {}, got {}",
-                                                            GET_WAVE_DATA_COUNT, dataCount));
-                                    return 0;
-                                }
-
-                                try {
-                                    enum {
-                                        WAVE_LENGTH,
-                                        WEIGHT,
-                                    };
-
-                                    m_opticalSystem.waveData[arg].value  = std::stod(tokens[WAVE_LENGTH]);
-                                    m_opticalSystem.waveData[arg].weight = std::stod(tokens[WEIGHT]);
-                                } catch (const std::exception& e) {
-                                    m_logger.addLog(std::format("[DDE] GetWave: Failed to parse data for wave {}: {}", arg, e.what()));
-                                    return 0;
-                                }
-                            }
-                        } else {
-                            m_logger.addLog(std::format("[DDE] GetWave: Wave index must be 0 (metadata) or in range [{}, {}]. Got: {}",
-                                                    ZemaxDDE::MIN_WAVES, ZemaxDDE::MAX_WAVES, arg));
-                            return 0;
-                        }
-                        DdeAck.fAck = true;
-                    }
-                    if (command_token == "GetSurfaceData") {
-                        auto tokens = ZemaxDDE::tokenize(buffer);
-                        // int params = static_cast<int>(tokens.size());
-
-                        int currentSurface = std::stoi(item_tokens[1]);
-                        if (currentSurface < 0 || currentSurface > m_opticalSystem.numSurfs) {
-                            m_logger.addLog(std::format("[DDE] GetSurfaceData: Invalid current surface value: {}. Must be in range [{}, {}]",
-                                                    currentSurface, 0, m_opticalSystem.numSurfs));
-                            return 0;
-                        }
-
-                        int code = std::stoi(item_tokens[2]);
-                        if (!ZemaxDDE::SurfaceDataCode::isValid(code)) {
-                            m_logger.addLog(std::format("[DDE] GetSurfaceData: Invalid surface data code received: {}", code));
-                            return 0;
-                        }
-
-                        // int arg2 = std::stoi(item_tokens[3]);
-
-                        // Selecting target storage
-                        if (!m_currentStorage) {
-                            m_logger.addLog("[DDE] GetSurfaceData: No storage target set");
-                            return 0;
-                        }
-                        
-                        auto& surface = *m_currentStorage;
-                        surface.id = currentSurface;
-
-                        switch (code) {
-                            case ZemaxDDE::SurfaceDataCode::TYPE_NAME:{
-                                surface.type = tokens[0];
-                                break;
-                            }
-                            case ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER: {
-                                surface.semiDiameter = std::stod(tokens[0]);
-                                break;
-                            }
-                            default: {
-                                m_logger.addLog(std::format("[DDE] GetSurfaceData: Unsupported code for storage: {}", code));
+                                DdeAck.fAck = true;
+                            } catch (const std::invalid_argument& e) {
+                                m_logger.addLog(std::format("[DDE] GetSystem: Invalid number format in parameter: {}", e.what()));
+                                return 0;
+                            } catch (const std::out_of_range& e) {
+                                m_logger.addLog(std::format("[DDE] GetSystem: Number out of range: {}", e.what()));
+                                return 0;
+                            } catch (const std::exception& e) {
+                                m_logger.addLog(std::format("[DDE] GetSystem: Unexpected error: {}", e.what()));
                                 return 0;
                             }
                         }
+                    }
+                    if (command_token == "GetField") {
+                        if (!routeAsync("GetField")) {
+                            const int EXPECTED_COMMAND_TOKENS = 2;
+                            int params = static_cast<int>(item_tokens.size());
 
+                            if (params != EXPECTED_COMMAND_TOKENS) {
+                                m_logger.addLog(std::format("[DDE] GetField: Invalid command format. Expected exactly {} tokens, got {}",
+                                                        EXPECTED_COMMAND_TOKENS, params));
+                                return 0;
+                            }
+
+                            int arg = -1;
+                            try {
+                                arg = std::stoi(item_tokens[1]);
+                            } catch (const std::invalid_argument&) {
+                                m_logger.addLog(std::format("[DDE] GetField: Invalid field index '{}'. Not a number.", item_tokens[1]));
+                                return 0;
+                            } catch (const std::out_of_range&) {
+                                m_logger.addLog(std::format("[DDE] GetField: Field index '{}' is out of range (too large).", item_tokens[1]));
+                                return 0;
+                            }
+
+                            if (arg == 0 || (arg >= ZemaxDDE::MIN_FIELDS && arg <= ZemaxDDE::MAX_FIELDS)) {
+                                auto tokens = ZemaxDDE::tokenize(buffer);
+                                int dataCount = static_cast<int>(tokens.size());
+
+                                if(arg == 0) {
+                                    const int GET_FIELD_META_COUNT = 5;
+                                    if (dataCount != GET_FIELD_META_COUNT) {
+                                        m_logger.addLog(std::format("[DDE] GetField: Invalid parameter count for field metadata. Expected exactly {}, got {}",
+                                                                GET_FIELD_META_COUNT, dataCount));
+                                        return 0;
+                                    }
+
+                                    try {
+                                        enum  {
+                                            FIELD_TYPE,
+                                            NUM_FIELDS,
+                                            MAX_X_FIELD,
+                                            MAX_Y_FIELD,
+                                            NORMALIZATION_METHOD
+                                        };
+
+                                        m_opticalSystem.fieldType = std::stoi(tokens[FIELD_TYPE]);
+
+                                        int numFields = std::stoi(tokens[NUM_FIELDS]);
+                                        if (numFields < ZemaxDDE::MIN_FIELDS || numFields > ZemaxDDE::MAX_FIELDS) {
+                                            m_logger.addLog(std::format("[DDE] GetField: Invalid numFields value: {}. Must be in range [{}, {}]",
+                                                                    numFields, ZemaxDDE::MIN_FIELDS, ZemaxDDE::MAX_FIELDS));
+                                            return 0;
+                                        }
+
+                                        m_opticalSystem.numFields = numFields;
+                                        m_opticalSystem.maxXField = std::stod(tokens[MAX_X_FIELD]);
+                                        m_opticalSystem.maxYField = std::stod(tokens[MAX_Y_FIELD]);
+                                        m_opticalSystem.normalizationMethod = std::stoi(tokens[NORMALIZATION_METHOD]);
+                                    } catch (const std::exception& e) {
+                                        m_logger.addLog(std::format("[DDE] GetField: Failed to parse field metadata: {}", e.what()));
+                                        return 0;
+                                    }
+                                } else {
+                                    const int GET_FIELD_DATA_COUNT = 8;
+                                    if (dataCount != GET_FIELD_DATA_COUNT) {
+                                        m_logger.addLog(std::format("[DDE] GetField: Invalid parameter count for field data. Expected exactly {}, got {}",
+                                                                GET_FIELD_DATA_COUNT, dataCount));
+                                        return 0;
+                                    }
+
+                                    try {
+                                        enum {
+                                            XFIELD,
+                                            YFIELD,
+                                        };
+
+                                        m_opticalSystem.xField[arg] = std::stod(tokens[XFIELD]);
+                                        m_opticalSystem.yField[arg] = std::stod(tokens[YFIELD]);
+                                    } catch (const std::exception& e) {
+                                        m_logger.addLog(std::format("[DDE] GetField: Failed to parse data for field {}: {}", arg, e.what()));
+                                        return 0;
+                                    }
+                                }
+                            } else {
+                                m_logger.addLog(std::format("[DDE] GetField: Field index must be 0 (metadata) or in range [{}, {}]. Got: {}",
+                                                        ZemaxDDE::MIN_FIELDS, ZemaxDDE::MAX_FIELDS, arg));
+                                return 0;
+                            }
+                            DdeAck.fAck = true;
+                        }
+                    }
+                    if (command_token == "GetWave") {
+                        if (!routeAsync("GetWave")) {
+                            const int EXPECTED_COMMAND_TOKENS = 2;
+                            int params = static_cast<int>(item_tokens.size());
+
+                            if (params != EXPECTED_COMMAND_TOKENS) {
+                                m_logger.addLog(std::format("[DDE] GetWave: Invalid command format. Expected exactly {} tokens, got {}",
+                                                        EXPECTED_COMMAND_TOKENS, params));
+                                return 0;
+                            }
+
+                            int arg = -1;
+                            try {
+                                arg = std::stoi(item_tokens[1]);
+                            } catch (const std::invalid_argument&) {
+                                m_logger.addLog(std::format("[DDE] GetWave: Invalid wave index '{}'. Not a number.", item_tokens[1]));
+                                return 0;
+                            } catch (const std::out_of_range&) {
+                                m_logger.addLog(std::format("[DDE] GetWave: Wave index '{}' is out of range (too large).", item_tokens[1]));
+                                return 0;
+                            }
+
+                            if (arg == 0 || (arg >= ZemaxDDE::MIN_WAVES && arg <= ZemaxDDE::MAX_WAVES)) {
+                                auto tokens = ZemaxDDE::tokenize(buffer);
+                                int dataCount = static_cast<int>(tokens.size());
+
+                                if(arg == 0) {
+                                    const int GET_WAVE_META_COUNT = 2;
+                                    if (dataCount != GET_WAVE_META_COUNT) {
+                                        m_logger.addLog(std::format("[DDE] GetWave: Invalid parameter count for wave metadata. Expected exactly {}, got {}",
+                                                                GET_WAVE_META_COUNT, dataCount));
+                                        return 0;
+                                    }
+
+                                    try {
+                                        enum  {
+                                            PRIM_WAVE,
+                                            NUM_WAVES
+                                        };
+
+                                        m_opticalSystem.primWave = std::stoi(tokens[PRIM_WAVE]);
+
+                                        int numWaves = std::stoi(tokens[NUM_WAVES]);
+                                        if (numWaves < ZemaxDDE::MIN_WAVES || numWaves > ZemaxDDE::MAX_WAVES) {
+                                            m_logger.addLog(std::format("[DDE] GetWave: Invalid numWaves value: {}. Must be in range [{}, {}]",
+                                                                    numWaves, ZemaxDDE::MIN_WAVES, ZemaxDDE::MAX_WAVES));
+                                            return 0;
+                                        }
+
+                                        m_opticalSystem.numWaves = numWaves;
+                                    } catch (const std::exception& e) {
+                                        m_logger.addLog(std::format("[DDE] GetWave: Failed to parse wave metadata: {}", e.what()));
+                                        return 0;
+                                    }
+                                } else {
+                                    const int GET_WAVE_DATA_COUNT = 2;
+                                    if (dataCount != GET_WAVE_DATA_COUNT) {
+                                        m_logger.addLog(std::format("[DDE] GetWave: Invalid parameter count for wave data. Expected exactly {}, got {}",
+                                                                GET_WAVE_DATA_COUNT, dataCount));
+                                        return 0;
+                                    }
+
+                                    try {
+                                        enum {
+                                            WAVE_LENGTH,
+                                            WEIGHT,
+                                        };
+
+                                        m_opticalSystem.waveData[arg].value  = std::stod(tokens[WAVE_LENGTH]);
+                                        m_opticalSystem.waveData[arg].weight = std::stod(tokens[WEIGHT]);
+                                    } catch (const std::exception& e) {
+                                        m_logger.addLog(std::format("[DDE] GetWave: Failed to parse data for wave {}: {}", arg, e.what()));
+                                        return 0;
+                                    }
+                                }
+                            } else {
+                                m_logger.addLog(std::format("[DDE] GetWave: Wave index must be 0 (metadata) or in range [{}, {}]. Got: {}",
+                                                        ZemaxDDE::MIN_WAVES, ZemaxDDE::MAX_WAVES, arg));
+                                return 0;
+                            }
+                            DdeAck.fAck = true;
+                        }
+                    }
+                    if (command_token == "GetSurfaceData") {
+                        if (!routeAsync("GetSurfaceData")) {
+                            auto tokens = ZemaxDDE::tokenize(buffer);
+
+                            int currentSurface = std::stoi(item_tokens[1]);
+                            if (currentSurface < 0 || currentSurface > m_opticalSystem.numSurfs) {
+                                m_logger.addLog(std::format("[DDE] GetSurfaceData: Invalid current surface value: {}. Must be in range [{}, {}]",
+                                                        currentSurface, 0, m_opticalSystem.numSurfs));
+                                return 0;
+                            }
+
+                            int code = std::stoi(item_tokens[2]);
+                            if (!ZemaxDDE::SurfaceDataCode::isValid(code)) {
+                                m_logger.addLog(std::format("[DDE] GetSurfaceData: Invalid surface data code received: {}", code));
+                                return 0;
+                            }
+
+                            if (!m_currentStorage) {
+                                m_logger.addLog("[DDE] GetSurfaceData: No storage target set");
+                                return 0;
+                            }
+                            
+                            auto& surface = *m_currentStorage;
+                            surface.id = currentSurface;
+
+                            switch (code) {
+                                case ZemaxDDE::SurfaceDataCode::TYPE_NAME:{
+                                    surface.type = tokens[0];
+                                    break;
+                                }
+                                case ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER: {
+                                    surface.semiDiameter = std::stod(tokens[0]);
+                                    break;
+                                }
+                                default: {
+                                    m_logger.addLog(std::format("[DDE] GetSurfaceData: Unsupported code for storage: {}", code));
+                                    return 0;
+                                }
+                            }
+                        }
                         DdeAck.fAck = true;
                         return 0;
                     }
                     if (command_token == "GetSag") {
-                        auto tokens = ZemaxDDE::tokenize(buffer);
-                        // int params = static_cast<int>(tokens.size());
+                        if (!routeAsync("GetSag")) {
+                            auto tokens = ZemaxDDE::tokenize(buffer);
 
-                        int currentSurface = std::stoi(item_tokens[1]);
-                        if (currentSurface < 0 || currentSurface > m_opticalSystem.numSurfs) {
-                            m_logger.addLog(std::format("[DDE] GetSag: Invalid current surface value: {}. Must be in range [{}, {}]",
-                                                    currentSurface, 0, m_opticalSystem.numSurfs));
-                            return 0;
-                        }
+                            int currentSurface = std::stoi(item_tokens[1]);
+                            if (currentSurface < 0 || currentSurface > m_opticalSystem.numSurfs) {
+                                m_logger.addLog(std::format("[DDE] GetSag: Invalid current surface value: {}. Must be in range [{}, {}]",
+                                                        currentSurface, 0, m_opticalSystem.numSurfs));
+                                return 0;
+                            }
 
-                        double x = 0.0;
-                        double y = 0.0;
+                            double x = 0.0;
+                            double y = 0.0;
 
-                        try {
-                            x = std::stod(item_tokens[2]);
-                            y = std::stod(item_tokens[3]);
+                            try {
+                                x = std::stod(item_tokens[2]);
+                                y = std::stod(item_tokens[3]);
                         } catch (const std::exception& e) {
                             m_logger.addLog(std::format("[DDE] GetSag: Failed to parse x/y: {}", e.what()));
                             return 0;
@@ -561,7 +648,7 @@ namespace ZemaxDDE {
                         surface.sagDataPoints.push_back({
                             x, y, sag, alternateSag
                         });
-
+                        }
                         DdeAck.fAck = true;
                         return 0;    
                     }

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -60,6 +60,59 @@ namespace ZemaxDDE {
         }
     }
 
+    void ZemaxDDEClient::initiateDDE(HWND targetHwnd) {
+        if (m_hwndZemaxServer != nullptr) {
+            m_logger.addLog("[DDE] DDE already connected. Skipping initiate.");
+            return;
+        }
+
+        m_hwndZemaxServer = nullptr;
+
+        ATOM appAtom = GlobalAddAtomW(DDE_APP_NAME);
+        ATOM topicAtom = GlobalAddAtomW(DDE_TOPIC);
+        DWORD_PTR dwResult = 0;
+
+        SendMessageTimeoutW(targetHwnd, WM_DDE_INITIATE, (WPARAM)m_hwndZemaxClient, MAKELONG(appAtom, topicAtom),
+            SMTO_ABORTIFHUNG | SMTO_ERRORONEXIT, DDE_TIMEOUT_MS, &dwResult);
+
+        #ifdef DEBUG_LOG
+        char appName[256], topicName[256];
+        WideCharToMultiByte(CP_ACP, 0, DDE_APP_NAME, -1, appName, sizeof(appName), NULL, NULL);
+        WideCharToMultiByte(CP_ACP, 0, DDE_TOPIC, -1, topicName, sizeof(topicName), NULL, NULL);
+        m_logger.addLog(std::format("[DDE] Sent 'WM_DDE_INITIATE' to app='{}', topic='{}'.", appName, topicName));
+        #endif
+
+        GlobalDeleteAtom(appAtom);
+        GlobalDeleteAtom(topicAtom);
+        checkDDEConnection();
+
+        if (m_hwndZemaxServer) {
+            m_logger.addLog("[DDE] Connection established successfully");
+        } else {
+            m_logger.addLog("[DDE] Connection not established yet (waiting for 'WM_DDE_ACK')");
+        }
+
+        if (m_onDDEConnected) {
+            try {
+                m_onDDEConnected(this);
+            } catch (const std::exception& e) {
+                m_logger.addLog(std::format("[DDE] Error in DDE connected callback: {}", e.what()));
+                throw;
+            }
+        }
+    }
+
+    void ZemaxDDEClient::pumpMessages() {
+        MSG msg;
+        while (PeekMessageW(&msg, m_hwndZemaxClient, WM_DDE_FIRST, WM_DDE_LAST, PM_REMOVE)) {
+            DispatchMessageW(&msg);
+        }
+    }
+
+    void ZemaxDDEClient::processTimeouts() {
+        // Will be used in async DDE phase
+    }
+
     void ZemaxDDEClient::terminateDDE() {
         if (m_hwndZemaxServer) {
             PostMessageW(m_hwndZemaxServer, WM_DDE_TERMINATE, (WPARAM)m_hwndZemaxClient, 0L);

--- a/src/dde/constants.h
+++ b/src/dde/constants.h
@@ -5,11 +5,6 @@ namespace ZemaxDDE {
     inline constexpr const wchar_t* DDE_TOPIC       = L"RayData";   // Topic DDE
     static constexpr int DDE_TIMEOUT_MS             = 5000;         // Timeout in ms (5 sec.)
 
-    enum class StorageTarget {
-        TOLERANCED,
-        NOMINAL
-    };
-
     inline constexpr int MIN_FIELDS = 1;
     inline constexpr int MAX_FIELDS = 12;
 

--- a/src/dde/constants.h
+++ b/src/dde/constants.h
@@ -3,7 +3,7 @@
 namespace ZemaxDDE {
     inline constexpr const wchar_t* DDE_APP_NAME    = L"ZEMAX";     // Appname DDE
     inline constexpr const wchar_t* DDE_TOPIC       = L"RayData";   // Topic DDE
-    static constexpr int DDE_TIMEOUT_MS             = 5000;         // Timeout in ms (5 sec.)
+    static constexpr int DDE_TIMEOUT_MS             = 300;          // Timeout in ms (300 ms)
 
     inline constexpr int MIN_FIELDS = 1;
     inline constexpr int MAX_FIELDS = 12;

--- a/src/dde/dde_connection.h
+++ b/src/dde/dde_connection.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <windows.h>
+
+namespace ZemaxDDE {
+    class ZemaxDDEClient;
+}
+
+struct DDEConnection {
+    HWND hwndClient = nullptr;
+    HWND hwndServer = nullptr;
+    std::wstring serverTitle;
+    DWORD serverPid = 0;
+    std::unique_ptr<ZemaxDDE::ZemaxDDEClient> client;
+    bool isConnected = false;
+};

--- a/src/dde/dde_connection_manager.cpp
+++ b/src/dde/dde_connection_manager.cpp
@@ -20,18 +20,20 @@ namespace {
         return result;
     }
 
+    extern "C" LRESULT CALLBACK DDEClientWndProc(HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam) {
+        if (iMsg >= WM_DDE_FIRST && iMsg <= WM_DDE_LAST) {
+            auto* client = reinterpret_cast<ZemaxDDE::ZemaxDDEClient*>(
+                GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+            if (client) {
+                return client->handleDDEMessages(iMsg, wParam, lParam);
+            }
+        }
+        return DefWindowProcW(hwnd, iMsg, wParam, lParam);
+    }
+
     ATOM registerDDEClientClass() {
         WNDCLASSW wndClass{};
-        wndClass.lpfnWndProc = [](HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam) -> LRESULT {
-            if (iMsg >= WM_DDE_FIRST && iMsg <= WM_DDE_LAST) {
-                auto* client = reinterpret_cast<ZemaxDDE::ZemaxDDEClient*>(
-                    GetWindowLongPtrW(hwnd, GWLP_USERDATA));
-                if (client) {
-                    return client->handleDDEMessages(iMsg, wParam, lParam);
-                }
-            }
-            return DefWindowProcW(hwnd, iMsg, wParam, lParam);
-        };
+        wndClass.lpfnWndProc = DDEClientWndProc;
         wndClass.hInstance = GetModuleHandleW(nullptr);
         wndClass.lpszClassName = L"ZEMAX_DDE_Client";
         return RegisterClassW(&wndClass);

--- a/src/dde/dde_connection_manager.cpp
+++ b/src/dde/dde_connection_manager.cpp
@@ -99,15 +99,18 @@ int DDEConnectionManager::connectToZemax(HWND targetHwnd, const std::wstring& ti
     conn.serverTitle = title;
     conn.isConnected = true;
 
+    DWORD pid = 0;
+    GetWindowThreadProcessId(targetHwnd, &pid);
+    conn.serverPid = pid;
+
     if (m_activeIndex < 0) {
         m_activeIndex = idx;
     }
 
-    m_logger.addLog(std::format("[DDE] Connected to slot {}: {}", idx, ws2s(title)));
-
-    DWORD pid = 0;
-    GetWindowThreadProcessId(targetHwnd, &pid);
-    conn.serverPid = pid;
+    m_logger.addLog(std::format("[DDE] Connected slot {}: \"{}\" (PID: {}, hwndClient={:#010x}, hwndServer={:#010x})",
+        idx, ws2s(title), pid,
+        reinterpret_cast<uintptr_t>(conn.hwndClient),
+        reinterpret_cast<uintptr_t>(conn.hwndServer)));
 
     return idx;
 }
@@ -118,7 +121,10 @@ void DDEConnectionManager::disconnect(int index) {
     auto& conn = m_connections[index];
     if (!conn.isConnected) return;
 
-    m_logger.addLog(std::format("[DDE] Disconnecting slot {}", index));
+    m_logger.addLog(std::format("[DDE] Disconnected slot {}: \"{}\" (PID: {}, hwndClient={:#010x}, hwndServer={:#010x})",
+        index, ws2s(conn.serverTitle), conn.serverPid,
+        reinterpret_cast<uintptr_t>(conn.hwndClient),
+        reinterpret_cast<uintptr_t>(conn.hwndServer)));
 
     if (conn.client) {
         conn.client->terminateDDE();

--- a/src/dde/dde_connection_manager.cpp
+++ b/src/dde/dde_connection_manager.cpp
@@ -1,34 +1,202 @@
 #include "dde_connection_manager.h"
+
+#include <algorithm>
+#include <format>
+#include <string>
+
+#include "app/zemax_window_enumerator.h"
 #include "dde/client.h"
 #include "logger/logger.h"
 
-DDEConnectionManager::DDEConnectionManager(ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger)
-    : m_ddeClient(ddeClient)
-    , m_logger(logger)
+namespace {
+
+    std::string ws2s(const std::wstring& wstr) {
+        if (wstr.empty()) return {};
+        int len = WideCharToMultiByte(CP_ACP, 0, wstr.data(), static_cast<int>(wstr.size()),
+            nullptr, 0, nullptr, nullptr);
+        std::string result(static_cast<size_t>(len), '\0');
+        WideCharToMultiByte(CP_ACP, 0, wstr.data(), static_cast<int>(wstr.size()),
+            result.data(), len, nullptr, nullptr);
+        return result;
+    }
+
+    ATOM registerDDEClientClass() {
+        WNDCLASSW wndClass{};
+        wndClass.lpfnWndProc = [](HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (iMsg >= WM_DDE_FIRST && iMsg <= WM_DDE_LAST) {
+                auto* client = reinterpret_cast<ZemaxDDE::ZemaxDDEClient*>(
+                    GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+                if (client) {
+                    return client->handleDDEMessages(iMsg, wParam, lParam);
+                }
+            }
+            return DefWindowProcW(hwnd, iMsg, wParam, lParam);
+        };
+        wndClass.hInstance = GetModuleHandleW(nullptr);
+        wndClass.lpszClassName = L"ZEMAX_DDE_Client";
+        return RegisterClassW(&wndClass);
+    }
+
+    HWND createDDEClientWindow() {
+        registerDDEClientClass();
+        return CreateWindowExW(0, L"ZEMAX_DDE_Client", L"DDE Client",
+            0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, GetModuleHandleW(nullptr), nullptr);
+    }
+
+}
+
+DDEConnectionManager::DDEConnectionManager(Logger& logger)
+    : m_logger(logger)
 {
 }
 
-bool DDEConnectionManager::connect() {
-    if (!m_ddeClient) return false;
-    if (isConnected()) return true;
-    m_ddeClient->initiateDDE();
-    return isConnected();
+int DDEConnectionManager::findFreeSlot() {
+    for (int i = 0; i < MAX_CONNECTIONS; ++i) {
+        if (!m_connections[i].isConnected) {
+            return i;
+        }
+    }
+    return -1;
 }
 
-void DDEConnectionManager::disconnect() {
-    if (isConnected()) {
-        m_ddeClient->terminateDDE();
+int DDEConnectionManager::connectToZemax(HWND targetHwnd, const std::wstring& title) {
+    if (!targetHwnd) {
+        m_logger.addLog("[DDE] connectToZemax: null target HWND");
+        return -1;
+    }
+
+    int idx = findFreeSlot();
+    if (idx < 0) {
+        m_logger.addLog("[DDE] connectToZemax: no free slots available");
+        return -1;
+    }
+
+    auto& conn = m_connections[idx];
+
+    conn.hwndClient = createDDEClientWindow();
+    if (!conn.hwndClient) {
+        m_logger.addLog("[DDE] connectToZemax: failed to create DDE client window");
+        return -1;
+    }
+
+    conn.client = std::make_unique<ZemaxDDE::ZemaxDDEClient>(conn.hwndClient, m_logger);
+    SetWindowLongPtrW(conn.hwndClient, GWLP_USERDATA,
+        reinterpret_cast<LONG_PTR>(conn.client.get()));
+
+    try {
+        conn.client->initiateDDE(targetHwnd);
+    } catch (const std::exception& e) {
+        m_logger.addLog(std::format("[DDE] connectToZemax: initiateDDE failed: {}", e.what()));
+        conn.client.reset();
+        DestroyWindow(conn.hwndClient);
+        conn.hwndClient = nullptr;
+        return -1;
+    }
+
+    conn.hwndServer = targetHwnd;
+    conn.serverTitle = title;
+    conn.isConnected = true;
+
+    if (m_activeIndex < 0) {
+        m_activeIndex = idx;
+    }
+
+    m_logger.addLog(std::format("[DDE] Connected to slot {}: {}", idx, ws2s(title)));
+
+    DWORD pid = 0;
+    GetWindowThreadProcessId(targetHwnd, &pid);
+    conn.serverPid = pid;
+
+    return idx;
+}
+
+void DDEConnectionManager::disconnect(int index) {
+    if (index < 0 || index >= MAX_CONNECTIONS) return;
+
+    auto& conn = m_connections[index];
+    if (!conn.isConnected) return;
+
+    m_logger.addLog(std::format("[DDE] Disconnecting slot {}", index));
+
+    if (conn.client) {
+        conn.client->terminateDDE();
+        conn.client.reset();
+    }
+
+    if (conn.hwndClient) {
+        DestroyWindow(conn.hwndClient);
+        conn.hwndClient = nullptr;
+    }
+
+    conn.hwndServer = nullptr;
+    conn.serverTitle.clear();
+    conn.serverPid = 0;
+    conn.isConnected = false;
+
+    if (m_activeIndex == index) {
+        m_activeIndex = -1;
+        for (int i = 0; i < MAX_CONNECTIONS; ++i) {
+            if (m_connections[i].isConnected) {
+                m_activeIndex = i;
+                break;
+            }
+        }
     }
 }
 
-bool DDEConnectionManager::isConnected() const {
-    return m_ddeClient ? m_ddeClient->isConnected() : false;
+void DDEConnectionManager::disconnectAll() {
+    for (int i = 0; i < MAX_CONNECTIONS; ++i) {
+        if (m_connections[i].isConnected) {
+            disconnect(i);
+        }
+    }
 }
 
-void DDEConnectionManager::setOnConnected(std::function<void()> cb) {
-    m_onConnected = std::move(cb);
+void DDEConnectionManager::setActiveConnection(int index) {
+    if (index >= 0 && index < MAX_CONNECTIONS && m_connections[index].isConnected) {
+        m_activeIndex = index;
+        m_logger.addLog(std::format("[DDE] Switched active connection to slot {}: {}",
+            index, ws2s(m_connections[index].serverTitle)));
+    }
 }
 
-void DDEConnectionManager::setOnDisconnected(std::function<void()> cb) {
-    m_onDisconnected = std::move(cb);
+ZemaxDDE::ZemaxDDEClient* DDEConnectionManager::getActiveClient() const {
+    if (m_activeIndex >= 0 && m_activeIndex < MAX_CONNECTIONS) {
+        return m_connections[m_activeIndex].client.get();
+    }
+    return nullptr;
+}
+
+DDEConnection* DDEConnectionManager::getConnection(int index) {
+    if (index >= 0 && index < MAX_CONNECTIONS) {
+        return &m_connections[index];
+    }
+    return nullptr;
+}
+
+bool DDEConnectionManager::isAnyConnected() const {
+    for (const auto& conn : m_connections) {
+        if (conn.isConnected) return true;
+    }
+    return false;
+}
+
+void DDEConnectionManager::pumpAllMessages() {
+    for (auto& conn : m_connections) {
+        if (conn.client) {
+            conn.client->pumpMessages();
+        }
+    }
+}
+
+void DDEConnectionManager::processAllTimeouts() {
+    for (auto& conn : m_connections) {
+        if (conn.client) {
+            conn.client->processTimeouts();
+        }
+    }
+}
+
+std::vector<app::ZemaxWindowInfo> DDEConnectionManager::enumerateAvailableTargets() {
+    return app::ZemaxWindowEnumerator::enumerate();
 }

--- a/src/dde/dde_connection_manager.h
+++ b/src/dde/dde_connection_manager.h
@@ -1,25 +1,46 @@
 #pragma once
 
-#include <functional>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+#include <windows.h>
 
+#include "dde/dde_connection.h"
+
+namespace app { struct ZemaxWindowInfo; }
 namespace ZemaxDDE { class ZemaxDDEClient; }
-
 class Logger;
 
 class DDEConnectionManager {
-    public:
-        DDEConnectionManager(ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger);
+public:
+    static constexpr int MAX_CONNECTIONS = 2;
 
-        bool connect();
-        void disconnect();
-        bool isConnected() const;
+    explicit DDEConnectionManager(Logger& logger);
 
-        void setOnConnected(std::function<void()> cb);
-        void setOnDisconnected(std::function<void()> cb);
+    int connectToZemax(HWND targetHwnd, const std::wstring& title);
+    void disconnect(int index);
+    void disconnectAll();
 
-    private:
-        ZemaxDDE::ZemaxDDEClient* m_ddeClient;
-        Logger& m_logger;
-        std::function<void()> m_onConnected;
-        std::function<void()> m_onDisconnected;
+    void setActiveConnection(int index);
+    ZemaxDDE::ZemaxDDEClient* getActiveClient() const;
+    int getActiveIndex() const { return m_activeIndex; }
+
+    DDEConnection* getConnection(int index);
+    const std::array<DDEConnection, MAX_CONNECTIONS>& getConnections() const { return m_connections; }
+
+    bool isAnyConnected() const;
+
+    void pumpAllMessages();
+    void processAllTimeouts();
+
+    std::vector<app::ZemaxWindowInfo> enumerateAvailableTargets();
+
+private:
+    std::array<DDEConnection, MAX_CONNECTIONS> m_connections;
+    Logger& m_logger;
+    int m_activeIndex = -1;
+
+    int findFreeSlot();
+    HWND createClientWindow();
 };

--- a/src/dde/initial_data_load_service.cpp
+++ b/src/dde/initial_data_load_service.cpp
@@ -25,106 +25,106 @@ namespace ZemaxDDE {
     }
 
     void InitialDataLoadService::loadSystem() {
-        m_pendingRequests = 3;
-
-        m_client.sendRequest("GetName",
+        m_client.enqueueRequest("GetName",
             [this](const std::string& buffer) {
                 std::string name = cp1251_to_utf8(buffer.data(), buffer.size());
                 while (!name.empty() && (name.back() == '\0' || name.back() == '\r' || name.back() == '\n' || name.back() == ' '))
                     name.pop_back();
                 m_opticalSystem.lensName = name.empty() ? "unknown" : name;
-                m_logger.addLog(std::format("[InitLoad] lensName = '{}'", name));
-                checkCompletion();
+                m_logger.addLog(std::format("[InitLoad] lensName = '{}'", m_opticalSystem.lensName));
+
+                m_client.enqueueRequest("GetFile",
+                    [this](const std::string& buf) {
+                        std::string fileName = cp1251_to_utf8(buf.data(), buf.size());
+                        while (!fileName.empty() && (fileName.back() == '\0' || fileName.back() == '\r' || fileName.back() == '\n' || fileName.back() == ' '))
+                            fileName.pop_back();
+                        m_opticalSystem.fileName = fileName;
+                        m_logger.addLog(std::format("[InitLoad] fileName = '{}'", fileName));
+
+                        m_client.enqueueRequest("GetSystem",
+                            [this](const std::string& sysBuf) {
+                                auto tokens = tokenize(sysBuf);
+                                constexpr int EXPECTED = 9;
+                                if (tokens.size() < EXPECTED) {
+                                    onError(std::format("GetSystem: expected {} tokens, got {}", EXPECTED, tokens.size()));
+                                    return;
+                                }
+                                try {
+                                    enum { NUM_SURFS, UNIT_CODE, STOP_SURF, NON_AXIAL_FLAG, RAY_AIMING_TYPE, ADJUST_INDEX, TEMP, PRESSURE, GLOBAL_REF_SURF };
+                                    m_opticalSystem.numSurfs      = std::stoi(tokens[NUM_SURFS]);
+                                    m_opticalSystem.units         = std::stoi(tokens[UNIT_CODE]);
+                                    m_opticalSystem.stopSurf      = std::stoi(tokens[STOP_SURF]);
+                                    m_opticalSystem.nonAxialFlag  = std::stoi(tokens[NON_AXIAL_FLAG]);
+                                    m_opticalSystem.rayAimingType = std::stoi(tokens[RAY_AIMING_TYPE]);
+                                    m_opticalSystem.adjustIndex   = std::stoi(tokens[ADJUST_INDEX]);
+                                    m_opticalSystem.temp          = std::stod(tokens[TEMP]);
+                                    m_opticalSystem.pressure      = std::stod(tokens[PRESSURE]);
+                                    m_opticalSystem.globalRefSurf = std::stoi(tokens[GLOBAL_REF_SURF]);
+                                    m_logger.addLog(std::format("[InitLoad] System: {} surfaces, unit={}, stop={}", m_opticalSystem.numSurfs, m_opticalSystem.units, m_opticalSystem.stopSurf));
+                                } catch (const std::exception& e) {
+                                    onError(std::format("GetSystem: parse error: {}", e.what()));
+                                    return;
+                                }
+
+                                m_state = LoadState::LoadingFields;
+                                m_logger.addLog("[InitLoad] System loaded, loading fields");
+
+                                m_client.enqueueRequest("GetField,0",
+                                    [this](const std::string& fBuf) {
+                                        auto ftokens = tokenize(fBuf);
+                                        constexpr int FEXPECTED = 5;
+                                        if (ftokens.size() < FEXPECTED) {
+                                            onError(std::format("GetField,0: expected {} tokens, got {}", FEXPECTED, ftokens.size()));
+                                            return;
+                                        }
+                                        try {
+                                            enum { FIELD_TYPE, NUM_FIELDS, MAX_X_FIELD, MAX_Y_FIELD, NORMALIZATION_METHOD };
+                                            m_opticalSystem.fieldType = std::stoi(ftokens[FIELD_TYPE]);
+                                            int numFields = std::stoi(ftokens[NUM_FIELDS]);
+                                            if (numFields < MIN_FIELDS || numFields > MAX_FIELDS) {
+                                                onError(std::format("GetField,0: numFields {} out of range [{}, {}]", numFields, MIN_FIELDS, MAX_FIELDS));
+                                                return;
+                                            }
+                                            m_opticalSystem.numFields = numFields;
+                                            m_opticalSystem.maxXField = std::stod(ftokens[MAX_X_FIELD]);
+                                            m_opticalSystem.maxYField = std::stod(ftokens[MAX_Y_FIELD]);
+                                            m_opticalSystem.normalizationMethod = std::stoi(ftokens[NORMALIZATION_METHOD]);
+                                            m_logger.addLog(std::format("[InitLoad] Fields: type={}, count={}", m_opticalSystem.fieldType, numFields));
+
+                                            m_totalFields = numFields;
+                                            m_currentField = MIN_FIELDS;
+                                            loadNextField();
+                                        } catch (const std::exception& e) {
+                                            onError(std::format("GetField,0: parse error: {}", e.what()));
+                                        }
+                                    },
+                                    [this](const std::string& err) {
+                                        onError(std::format("GetField,0: {}", err));
+                                    },
+                                    2000, 1, "InitialDataLoad");
+                            },
+                            [this](const std::string& err) {
+                                onError(std::format("GetSystem: {}", err));
+                            },
+                            2000, 1, "InitialDataLoad");
+                    },
+                    [this](const std::string& err) {
+                        onError(std::format("GetFile: {}", err));
+                    },
+                    2000, 1, "InitialDataLoad");
             },
             [this](const std::string& err) {
                 onError(std::format("GetName: {}", err));
-            });
-
-        m_client.sendRequest("GetFile",
-            [this](const std::string& buffer) {
-                std::string fileName = cp1251_to_utf8(buffer.data(), buffer.size());
-                while (!fileName.empty() && (fileName.back() == '\0' || fileName.back() == '\r' || fileName.back() == '\n' || fileName.back() == ' '))
-                    fileName.pop_back();
-                m_opticalSystem.fileName = fileName;
-                m_logger.addLog(std::format("[InitLoad] fileName = '{}'", fileName));
-                checkCompletion();
             },
-            [this](const std::string& err) {
-                onError(std::format("GetFile: {}", err));
-            });
-
-        m_client.sendRequest("GetSystem",
-            [this](const std::string& buffer) {
-                auto tokens = tokenize(buffer);
-                constexpr int EXPECTED = 9;
-                if (tokens.size() < EXPECTED) {
-                    onError(std::format("GetSystem: expected {} tokens, got {}", EXPECTED, tokens.size()));
-                    return;
-                }
-                try {
-                    enum { NUM_SURFS, UNIT_CODE, STOP_SURF, NON_AXIAL_FLAG, RAY_AIMING_TYPE, ADJUST_INDEX, TEMP, PRESSURE, GLOBAL_REF_SURF };
-                    m_opticalSystem.numSurfs      = std::stoi(tokens[NUM_SURFS]);
-                    m_opticalSystem.units         = std::stoi(tokens[UNIT_CODE]);
-                    m_opticalSystem.stopSurf      = std::stoi(tokens[STOP_SURF]);
-                    m_opticalSystem.nonAxialFlag  = std::stoi(tokens[NON_AXIAL_FLAG]);
-                    m_opticalSystem.rayAimingType = std::stoi(tokens[RAY_AIMING_TYPE]);
-                    m_opticalSystem.adjustIndex   = std::stoi(tokens[ADJUST_INDEX]);
-                    m_opticalSystem.temp          = std::stod(tokens[TEMP]);
-                    m_opticalSystem.pressure      = std::stod(tokens[PRESSURE]);
-                    m_opticalSystem.globalRefSurf = std::stoi(tokens[GLOBAL_REF_SURF]);
-                    m_logger.addLog(std::format("[InitLoad] System: {} surfaces, unit={}, stop={}", m_opticalSystem.numSurfs, m_opticalSystem.units, m_opticalSystem.stopSurf));
-                } catch (const std::exception& e) {
-                    onError(std::format("GetSystem: parse error: {}", e.what()));
-                    return;
-                }
-                checkCompletion();
-            },
-            [this](const std::string& err) {
-                onError(std::format("GetSystem: {}", err));
-            });
+            2000, 1, "InitialDataLoad");
     }
 
-    void InitialDataLoadService::checkCompletion() {
-        if (m_state == LoadState::LoadingSystem && --m_pendingRequests == 0) {
-            m_state = LoadState::LoadingFields;
-            m_pendingRequests = 0;
-            m_logger.addLog("[InitLoad] System loaded, loading fields");
-
-            m_client.sendRequest("GetField,0",
-                [this](const std::string& buffer) {
-                    auto tokens = tokenize(buffer);
-                    constexpr int EXPECTED = 5;
-                    if (tokens.size() < EXPECTED) {
-                        onError(std::format("GetField,0: expected {} tokens, got {}", EXPECTED, tokens.size()));
-                        return;
-                    }
-                    try {
-                        enum { FIELD_TYPE, NUM_FIELDS, MAX_X_FIELD, MAX_Y_FIELD, NORMALIZATION_METHOD };
-                        m_opticalSystem.fieldType = std::stoi(tokens[FIELD_TYPE]);
-                        int numFields = std::stoi(tokens[NUM_FIELDS]);
-                        if (numFields < MIN_FIELDS || numFields > MAX_FIELDS) {
-                            onError(std::format("GetField,0: numFields {} out of range [{}, {}]", numFields, MIN_FIELDS, MAX_FIELDS));
-                            return;
-                        }
-                        m_opticalSystem.numFields = numFields;
-                        m_opticalSystem.maxXField = std::stod(tokens[MAX_X_FIELD]);
-                        m_opticalSystem.maxYField = std::stod(tokens[MAX_Y_FIELD]);
-                        m_opticalSystem.normalizationMethod = std::stoi(tokens[NORMALIZATION_METHOD]);
-                        m_logger.addLog(std::format("[InitLoad] Fields: type={}, count={}", m_opticalSystem.fieldType, numFields));
-                        loadFields(numFields);
-                    } catch (const std::exception& e) {
-                        onError(std::format("GetField,0: parse error: {}", e.what()));
-                    }
-                },
-                [this](const std::string& err) {
-                    onError(std::format("GetField,0: {}", err));
-                });
-        } else if (m_state == LoadState::LoadingFields && --m_pendingRequests == 0) {
+    void InitialDataLoadService::loadNextField() {
+        if (m_currentField > m_totalFields) {
             m_state = LoadState::LoadingWaves;
-            m_pendingRequests = 0;
             m_logger.addLog("[InitLoad] Fields loaded, loading waves");
 
-            m_client.sendRequest("GetWave,0",
+            m_client.enqueueRequest("GetWave,0",
                 [this](const std::string& buffer) {
                     auto tokens = tokenize(buffer);
                     constexpr int EXPECTED = 2;
@@ -142,66 +142,68 @@ namespace ZemaxDDE {
                         }
                         m_opticalSystem.numWaves = numWaves;
                         m_logger.addLog(std::format("[InitLoad] Waves: primary={}, count={}", m_opticalSystem.primWave, numWaves));
-                        loadWaves(numWaves);
+
+                        m_totalWaves = numWaves;
+                        m_currentWave = MIN_WAVES;
+                        loadNextWave();
                     } catch (const std::exception& e) {
                         onError(std::format("GetWave,0: parse error: {}", e.what()));
                     }
                 },
                 [this](const std::string& err) {
                     onError(std::format("GetWave,0: {}", err));
-                });
-        } else if (m_state == LoadState::LoadingWaves && --m_pendingRequests == 0) {
+                },
+                2000, 1, "InitialDataLoad");
+            return;
+        }
+
+        m_client.enqueueRequest(std::format("GetField,{}", m_currentField),
+            [this](const std::string& buffer) {
+                auto tokens = tokenize(buffer);
+                if (tokens.size() >= 2) {
+                    try {
+                        m_opticalSystem.xField[m_currentField] = std::stod(tokens[0]);
+                        m_opticalSystem.yField[m_currentField] = std::stod(tokens[1]);
+                    } catch (const std::exception& e) {
+                        onError(std::format("GetField,{}: parse error: {}", m_currentField, e.what()));
+                        return;
+                    }
+                }
+                m_currentField++;
+                loadNextField();
+            },
+            [this](const std::string& err) {
+                onError(std::format("GetField,{}: {}", m_currentField, err));
+            },
+            2000, 1, "InitialDataLoad");
+    }
+
+    void InitialDataLoadService::loadNextWave() {
+        if (m_currentWave > m_totalWaves) {
             m_state = LoadState::Completed;
             m_logger.addLog(std::format("[InitLoad] Data load completed: {} fields, {} waves", m_opticalSystem.numFields, m_opticalSystem.numWaves));
+            return;
         }
-    }
 
-    void InitialDataLoadService::loadFields(int numFields) {
-        m_pendingRequests = numFields;
-
-        for (int i = MIN_FIELDS; i <= numFields; ++i) {
-            m_client.sendRequest(std::format("GetField,{}", i),
-                [this, i](const std::string& buffer) {
-                    auto tokens = tokenize(buffer);
-                    if (tokens.size() >= 2) {
-                        try {
-                            m_opticalSystem.xField[i] = std::stod(tokens[0]);
-                            m_opticalSystem.yField[i] = std::stod(tokens[1]);
-                        } catch (const std::exception& e) {
-                            onError(std::format("GetField,{}: parse error: {}", i, e.what()));
-                            return;
-                        }
+        m_client.enqueueRequest(std::format("GetWave,{}", m_currentWave),
+            [this](const std::string& buffer) {
+                auto tokens = tokenize(buffer);
+                if (tokens.size() >= 2) {
+                    try {
+                        m_opticalSystem.waveData[m_currentWave].value  = std::stod(tokens[0]);
+                        m_opticalSystem.waveData[m_currentWave].weight = std::stod(tokens[1]);
+                    } catch (const std::exception& e) {
+                        onError(std::format("GetWave,{}: parse error: {}", m_currentWave, e.what()));
+                        return;
                     }
-                    checkCompletion();
-                },
-                [this, i](const std::string& err) {
-                    onError(std::format("GetField,{}: {}", i, err));
-                });
-        }
-    }
-
-    void InitialDataLoadService::loadWaves(int numWaves) {
-        m_pendingRequests = numWaves;
-
-        for (int i = MIN_WAVES; i <= numWaves; ++i) {
-            m_client.sendRequest(std::format("GetWave,{}", i),
-                [this, i](const std::string& buffer) {
-                    auto tokens = tokenize(buffer);
-                    if (tokens.size() >= 2) {
-                        try {
-                            m_opticalSystem.waveData[i].value  = std::stod(tokens[0]);
-                            m_opticalSystem.waveData[i].weight = std::stod(tokens[1]);
-                        } catch (const std::exception& e) {
-                            onError(std::format("GetWave,{}: parse error: {}", i, e.what()));
-                            return;
-                        }
-                    }
-                    checkCompletion();
-                },
-                [this, i](const std::string& err) {
-                    onError(std::format("GetWave,{}: {}", i, err));
-                });
-        }
+                }
+                m_currentWave++;
+                loadNextWave();
+            },
+            [this](const std::string& err) {
+                onError(std::format("GetWave,{}: {}", m_currentWave, err));
+            },
+            2000, 1, "InitialDataLoad");
     }
 
     void InitialDataLoadService::onError(const std::string& msg) {

--- a/src/dde/initial_data_load_service.cpp
+++ b/src/dde/initial_data_load_service.cpp
@@ -1,0 +1,213 @@
+#include <format>
+#include <string>
+
+#include "initial_data_load_service.h"
+#include "client.h"
+#include "constants.h"
+#include "utils.h"
+#include "logger/logger.h"
+
+namespace ZemaxDDE {
+
+    InitialDataLoadService::InitialDataLoadService(ZemaxDDEClient& client, OpticalSystemData& opticalSystem, Logger& logger)
+        : m_client(client)
+        , m_opticalSystem(opticalSystem)
+        , m_logger(logger)
+    {
+    }
+
+    void InitialDataLoadService::start() {
+        if (m_state != LoadState::Idle) return;
+        m_state = LoadState::LoadingSystem;
+        m_error.clear();
+        m_logger.addLog("[InitLoad] Starting initial data load");
+        loadSystem();
+    }
+
+    void InitialDataLoadService::loadSystem() {
+        m_pendingRequests = 3;
+
+        m_client.sendRequest("GetName",
+            [this](const std::string& buffer) {
+                std::string name = cp1251_to_utf8(buffer.data(), buffer.size());
+                while (!name.empty() && (name.back() == '\0' || name.back() == '\r' || name.back() == '\n' || name.back() == ' '))
+                    name.pop_back();
+                m_opticalSystem.lensName = name.empty() ? "unknown" : name;
+                m_logger.addLog(std::format("[InitLoad] lensName = '{}'", name));
+                checkCompletion();
+            },
+            [this](const std::string& err) {
+                onError(std::format("GetName: {}", err));
+            });
+
+        m_client.sendRequest("GetFile",
+            [this](const std::string& buffer) {
+                std::string fileName = cp1251_to_utf8(buffer.data(), buffer.size());
+                while (!fileName.empty() && (fileName.back() == '\0' || fileName.back() == '\r' || fileName.back() == '\n' || fileName.back() == ' '))
+                    fileName.pop_back();
+                m_opticalSystem.fileName = fileName;
+                m_logger.addLog(std::format("[InitLoad] fileName = '{}'", fileName));
+                checkCompletion();
+            },
+            [this](const std::string& err) {
+                onError(std::format("GetFile: {}", err));
+            });
+
+        m_client.sendRequest("GetSystem",
+            [this](const std::string& buffer) {
+                auto tokens = tokenize(buffer);
+                constexpr int EXPECTED = 9;
+                if (tokens.size() < EXPECTED) {
+                    onError(std::format("GetSystem: expected {} tokens, got {}", EXPECTED, tokens.size()));
+                    return;
+                }
+                try {
+                    enum { NUM_SURFS, UNIT_CODE, STOP_SURF, NON_AXIAL_FLAG, RAY_AIMING_TYPE, ADJUST_INDEX, TEMP, PRESSURE, GLOBAL_REF_SURF };
+                    m_opticalSystem.numSurfs      = std::stoi(tokens[NUM_SURFS]);
+                    m_opticalSystem.units         = std::stoi(tokens[UNIT_CODE]);
+                    m_opticalSystem.stopSurf      = std::stoi(tokens[STOP_SURF]);
+                    m_opticalSystem.nonAxialFlag  = std::stoi(tokens[NON_AXIAL_FLAG]);
+                    m_opticalSystem.rayAimingType = std::stoi(tokens[RAY_AIMING_TYPE]);
+                    m_opticalSystem.adjustIndex   = std::stoi(tokens[ADJUST_INDEX]);
+                    m_opticalSystem.temp          = std::stod(tokens[TEMP]);
+                    m_opticalSystem.pressure      = std::stod(tokens[PRESSURE]);
+                    m_opticalSystem.globalRefSurf = std::stoi(tokens[GLOBAL_REF_SURF]);
+                    m_logger.addLog(std::format("[InitLoad] System: {} surfaces, unit={}, stop={}", m_opticalSystem.numSurfs, m_opticalSystem.units, m_opticalSystem.stopSurf));
+                } catch (const std::exception& e) {
+                    onError(std::format("GetSystem: parse error: {}", e.what()));
+                    return;
+                }
+                checkCompletion();
+            },
+            [this](const std::string& err) {
+                onError(std::format("GetSystem: {}", err));
+            });
+    }
+
+    void InitialDataLoadService::checkCompletion() {
+        if (m_state == LoadState::LoadingSystem && --m_pendingRequests == 0) {
+            m_state = LoadState::LoadingFields;
+            m_pendingRequests = 0;
+            m_logger.addLog("[InitLoad] System loaded, loading fields");
+
+            m_client.sendRequest("GetField,0",
+                [this](const std::string& buffer) {
+                    auto tokens = tokenize(buffer);
+                    constexpr int EXPECTED = 5;
+                    if (tokens.size() < EXPECTED) {
+                        onError(std::format("GetField,0: expected {} tokens, got {}", EXPECTED, tokens.size()));
+                        return;
+                    }
+                    try {
+                        enum { FIELD_TYPE, NUM_FIELDS, MAX_X_FIELD, MAX_Y_FIELD, NORMALIZATION_METHOD };
+                        m_opticalSystem.fieldType = std::stoi(tokens[FIELD_TYPE]);
+                        int numFields = std::stoi(tokens[NUM_FIELDS]);
+                        if (numFields < MIN_FIELDS || numFields > MAX_FIELDS) {
+                            onError(std::format("GetField,0: numFields {} out of range [{}, {}]", numFields, MIN_FIELDS, MAX_FIELDS));
+                            return;
+                        }
+                        m_opticalSystem.numFields = numFields;
+                        m_opticalSystem.maxXField = std::stod(tokens[MAX_X_FIELD]);
+                        m_opticalSystem.maxYField = std::stod(tokens[MAX_Y_FIELD]);
+                        m_opticalSystem.normalizationMethod = std::stoi(tokens[NORMALIZATION_METHOD]);
+                        m_logger.addLog(std::format("[InitLoad] Fields: type={}, count={}", m_opticalSystem.fieldType, numFields));
+                        loadFields(numFields);
+                    } catch (const std::exception& e) {
+                        onError(std::format("GetField,0: parse error: {}", e.what()));
+                    }
+                },
+                [this](const std::string& err) {
+                    onError(std::format("GetField,0: {}", err));
+                });
+        } else if (m_state == LoadState::LoadingFields && --m_pendingRequests == 0) {
+            m_state = LoadState::LoadingWaves;
+            m_pendingRequests = 0;
+            m_logger.addLog("[InitLoad] Fields loaded, loading waves");
+
+            m_client.sendRequest("GetWave,0",
+                [this](const std::string& buffer) {
+                    auto tokens = tokenize(buffer);
+                    constexpr int EXPECTED = 2;
+                    if (tokens.size() < EXPECTED) {
+                        onError(std::format("GetWave,0: expected {} tokens, got {}", EXPECTED, tokens.size()));
+                        return;
+                    }
+                    try {
+                        enum { PRIM_WAVE, NUM_WAVES };
+                        m_opticalSystem.primWave = std::stoi(tokens[PRIM_WAVE]);
+                        int numWaves = std::stoi(tokens[NUM_WAVES]);
+                        if (numWaves < MIN_WAVES || numWaves > MAX_WAVES) {
+                            onError(std::format("GetWave,0: numWaves {} out of range [{}, {}]", numWaves, MIN_WAVES, MAX_WAVES));
+                            return;
+                        }
+                        m_opticalSystem.numWaves = numWaves;
+                        m_logger.addLog(std::format("[InitLoad] Waves: primary={}, count={}", m_opticalSystem.primWave, numWaves));
+                        loadWaves(numWaves);
+                    } catch (const std::exception& e) {
+                        onError(std::format("GetWave,0: parse error: {}", e.what()));
+                    }
+                },
+                [this](const std::string& err) {
+                    onError(std::format("GetWave,0: {}", err));
+                });
+        } else if (m_state == LoadState::LoadingWaves && --m_pendingRequests == 0) {
+            m_state = LoadState::Completed;
+            m_logger.addLog(std::format("[InitLoad] Data load completed: {} fields, {} waves", m_opticalSystem.numFields, m_opticalSystem.numWaves));
+        }
+    }
+
+    void InitialDataLoadService::loadFields(int numFields) {
+        m_pendingRequests = numFields;
+
+        for (int i = MIN_FIELDS; i <= numFields; ++i) {
+            m_client.sendRequest(std::format("GetField,{}", i),
+                [this, i](const std::string& buffer) {
+                    auto tokens = tokenize(buffer);
+                    if (tokens.size() >= 2) {
+                        try {
+                            m_opticalSystem.xField[i] = std::stod(tokens[0]);
+                            m_opticalSystem.yField[i] = std::stod(tokens[1]);
+                        } catch (const std::exception& e) {
+                            onError(std::format("GetField,{}: parse error: {}", i, e.what()));
+                            return;
+                        }
+                    }
+                    checkCompletion();
+                },
+                [this, i](const std::string& err) {
+                    onError(std::format("GetField,{}: {}", i, err));
+                });
+        }
+    }
+
+    void InitialDataLoadService::loadWaves(int numWaves) {
+        m_pendingRequests = numWaves;
+
+        for (int i = MIN_WAVES; i <= numWaves; ++i) {
+            m_client.sendRequest(std::format("GetWave,{}", i),
+                [this, i](const std::string& buffer) {
+                    auto tokens = tokenize(buffer);
+                    if (tokens.size() >= 2) {
+                        try {
+                            m_opticalSystem.waveData[i].value  = std::stod(tokens[0]);
+                            m_opticalSystem.waveData[i].weight = std::stod(tokens[1]);
+                        } catch (const std::exception& e) {
+                            onError(std::format("GetWave,{}: parse error: {}", i, e.what()));
+                            return;
+                        }
+                    }
+                    checkCompletion();
+                },
+                [this, i](const std::string& err) {
+                    onError(std::format("GetWave,{}: {}", i, err));
+                });
+        }
+    }
+
+    void InitialDataLoadService::onError(const std::string& msg) {
+        m_state = LoadState::Failed;
+        m_error = msg;
+        m_logger.addLog(std::format("[InitLoad] Error: {}", msg));
+    }
+
+}

--- a/src/dde/initial_data_load_service.h
+++ b/src/dde/initial_data_load_service.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <string>
+
+class Logger;
+
+namespace ZemaxDDE {
+
+    class ZemaxDDEClient;
+    struct OpticalSystemData;
+
+    enum class LoadState {
+        Idle,
+        LoadingSystem,
+        LoadingFields,
+        LoadingWaves,
+        Completed,
+        Failed
+    };
+
+    class InitialDataLoadService {
+        public:
+            InitialDataLoadService(ZemaxDDEClient& client, OpticalSystemData& opticalSystem, Logger& logger);
+
+            void start();
+            LoadState getState() const { return m_state; }
+            const std::string& getError() const { return m_error; }
+
+        private:
+            void loadSystem();
+            void loadFields(int numFields);
+            void loadWaves(int numWaves);
+            void onError(const std::string& msg);
+            void checkCompletion();
+
+            ZemaxDDEClient& m_client;
+            OpticalSystemData& m_opticalSystem;
+            Logger& m_logger;
+
+            LoadState m_state = LoadState::Idle;
+            std::string m_error;
+            int m_pendingRequests = 0;
+    };
+
+}

--- a/src/dde/initial_data_load_service.h
+++ b/src/dde/initial_data_load_service.h
@@ -28,10 +28,9 @@ namespace ZemaxDDE {
 
         private:
             void loadSystem();
-            void loadFields(int numFields);
-            void loadWaves(int numWaves);
+            void loadNextField();
+            void loadNextWave();
             void onError(const std::string& msg);
-            void checkCompletion();
 
             ZemaxDDEClient& m_client;
             OpticalSystemData& m_opticalSystem;
@@ -39,7 +38,10 @@ namespace ZemaxDDE {
 
             LoadState m_state = LoadState::Idle;
             std::string m_error;
-            int m_pendingRequests = 0;
+            int m_currentField = 0;
+            int m_totalFields = 0;
+            int m_currentWave = 0;
+            int m_totalWaves = 0;
     };
 
 }

--- a/src/dde/operation_monitor.cpp
+++ b/src/dde/operation_monitor.cpp
@@ -3,29 +3,72 @@
 
 namespace ZemaxDDE {
 
-uint64_t OperationMonitor::registerRequest(const std::string& command) {
+uint64_t OperationMonitor::registerOperation(const std::string& serviceId, int totalSteps) {
     OperationInfo info;
     info.id = m_nextId++;
-    info.command = command;
+    info.serviceId = serviceId;
     info.status = OperationStatus::Pending;
     info.startTime = GetTickCount();
+    info.totalSteps = totalSteps;
+    info.currentStep = 0;
+    info.cancelRequested = false;
     m_operations.push_back(info);
     return info.id;
 }
 
-void OperationMonitor::updateStatus(uint64_t id, OperationStatus status, const std::string& error) {
-    int idx = findIndex(id);
+void OperationMonitor::onRequestQueued(uint64_t operationId, const std::string& command) {
+    int idx = findIndex(operationId);
+    if (idx < 0) return;
+    m_operations[idx].command = command;
+    m_operations[idx].status = OperationStatus::InFlight;
+    m_operations[idx].startTime = GetTickCount();
+}
+
+void OperationMonitor::reportProgress(uint64_t operationId, int currentStep, const std::string& message) {
+    int idx = findIndex(operationId);
     if (idx < 0) return;
 
     auto& op = m_operations[idx];
-    op.status = status;
+    op.currentStep = currentStep;
+    op.message = message;
     op.elapsed = GetTickCount() - op.startTime;
-    if (!error.empty()) {
-        op.error = error;
-    }
 }
 
-int OperationMonitor::findIndex(uint64_t id) {
+void OperationMonitor::onCompleted(uint64_t operationId) {
+    int idx = findIndex(operationId);
+    if (idx < 0) return;
+
+    auto& op = m_operations[idx];
+    op.status = OperationStatus::Completed;
+    op.elapsed = GetTickCount() - op.startTime;
+    op.message = "Completed";
+}
+
+void OperationMonitor::onError(uint64_t operationId, const std::string& error) {
+    int idx = findIndex(operationId);
+    if (idx < 0) return;
+
+    auto& op = m_operations[idx];
+    op.status = OperationStatus::Failed;
+    op.elapsed = GetTickCount() - op.startTime;
+    op.error = error;
+    op.message = "Error";
+}
+
+void OperationMonitor::requestCancel(uint64_t operationId) {
+    int idx = findIndex(operationId);
+    if (idx < 0) return;
+    m_operations[idx].cancelRequested = true;
+    m_operations[idx].message = "Cancelling...";
+}
+
+bool OperationMonitor::isCancelled(uint64_t operationId) const {
+    int idx = findIndex(operationId);
+    if (idx < 0) return false;
+    return m_operations[idx].cancelRequested;
+}
+
+int OperationMonitor::findIndex(uint64_t id) const {
     for (size_t i = 0; i < m_operations.size(); ++i) {
         if (m_operations[i].id == id) return static_cast<int>(i);
     }
@@ -38,7 +81,7 @@ void OperationMonitor::clearCompleted() {
             [](const OperationInfo& op) {
                 return op.status == OperationStatus::Completed ||
                        op.status == OperationStatus::Failed ||
-                       op.status == OperationStatus::TimedOut;
+                       op.status == OperationStatus::Cancelled;
             }),
         m_operations.end());
 }

--- a/src/dde/operation_monitor.cpp
+++ b/src/dde/operation_monitor.cpp
@@ -1,0 +1,46 @@
+#include "operation_monitor.h"
+#include <algorithm>
+
+namespace ZemaxDDE {
+
+uint64_t OperationMonitor::registerRequest(const std::string& command) {
+    OperationInfo info;
+    info.id = m_nextId++;
+    info.command = command;
+    info.status = OperationStatus::Pending;
+    info.startTime = GetTickCount();
+    m_operations.push_back(info);
+    return info.id;
+}
+
+void OperationMonitor::updateStatus(uint64_t id, OperationStatus status, const std::string& error) {
+    int idx = findIndex(id);
+    if (idx < 0) return;
+
+    auto& op = m_operations[idx];
+    op.status = status;
+    op.elapsed = GetTickCount() - op.startTime;
+    if (!error.empty()) {
+        op.error = error;
+    }
+}
+
+int OperationMonitor::findIndex(uint64_t id) {
+    for (size_t i = 0; i < m_operations.size(); ++i) {
+        if (m_operations[i].id == id) return static_cast<int>(i);
+    }
+    return -1;
+}
+
+void OperationMonitor::clearCompleted() {
+    m_operations.erase(
+        std::remove_if(m_operations.begin(), m_operations.end(),
+            [](const OperationInfo& op) {
+                return op.status == OperationStatus::Completed ||
+                       op.status == OperationStatus::Failed ||
+                       op.status == OperationStatus::TimedOut;
+            }),
+        m_operations.end());
+}
+
+} // namespace ZemaxDDE

--- a/src/dde/operation_monitor.h
+++ b/src/dde/operation_monitor.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+namespace ZemaxDDE {
+
+enum class OperationStatus {
+    Pending,
+    InFlight,
+    Completed,
+    Failed,
+    TimedOut
+};
+
+struct OperationInfo {
+    uint64_t id;
+    std::string command;
+    OperationStatus status = OperationStatus::Pending;
+    DWORD startTime = 0;
+    DWORD elapsed = 0;
+    std::string error;
+};
+
+class OperationMonitor {
+public:
+    uint64_t registerRequest(const std::string& command);
+    void updateStatus(uint64_t id, OperationStatus status, const std::string& error = "");
+    const std::vector<OperationInfo>& getOperations() const { return m_operations; }
+    void clearCompleted();
+
+private:
+    std::vector<OperationInfo> m_operations;
+    uint64_t m_nextId = 1;
+
+    int findIndex(uint64_t id);
+};
+
+} // namespace ZemaxDDE

--- a/src/dde/operation_monitor.h
+++ b/src/dde/operation_monitor.h
@@ -12,22 +12,33 @@ enum class OperationStatus {
     InFlight,
     Completed,
     Failed,
-    TimedOut
+    Cancelled
 };
 
 struct OperationInfo {
     uint64_t id;
+    std::string serviceId;
     std::string command;
     OperationStatus status = OperationStatus::Pending;
     DWORD startTime = 0;
     DWORD elapsed = 0;
+    int currentStep = 0;
+    int totalSteps = 0;
+    std::string message;
     std::string error;
+    bool cancelRequested = false;
 };
 
 class OperationMonitor {
 public:
-    uint64_t registerRequest(const std::string& command);
-    void updateStatus(uint64_t id, OperationStatus status, const std::string& error = "");
+    uint64_t registerOperation(const std::string& serviceId, int totalSteps);
+    void onRequestQueued(uint64_t operationId, const std::string& command);
+    void reportProgress(uint64_t operationId, int currentStep, const std::string& message);
+    void onCompleted(uint64_t operationId);
+    void onError(uint64_t operationId, const std::string& error);
+    void requestCancel(uint64_t operationId);
+    bool isCancelled(uint64_t operationId) const;
+
     const std::vector<OperationInfo>& getOperations() const { return m_operations; }
     void clearCompleted();
 
@@ -35,7 +46,7 @@ private:
     std::vector<OperationInfo> m_operations;
     uint64_t m_nextId = 1;
 
-    int findIndex(uint64_t id);
+    int findIndex(uint64_t id) const;
 };
 
 } // namespace ZemaxDDE

--- a/src/dde/types.h
+++ b/src/dde/types.h
@@ -31,6 +31,7 @@ namespace ZemaxDDE {
         double angle = 0.0;
         double semiDiameter = 0.0;
         std::string type = "Unknown";
+        std::string fileName;
         std::vector<SagData> sagDataPoints;
         bool isValid() const noexcept { return id >= 0; }
         double diameter() const noexcept { return 2.0 * semiDiameter; }
@@ -42,6 +43,7 @@ namespace ZemaxDDE {
             angle = 0.0;
             semiDiameter = 0.0;
             type = "Unknown";
+            fileName.clear();
             sagDataPoints.clear();
         }
     };

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -5,7 +5,7 @@
 namespace gui {
     // DDE status window constraints
     inline constexpr float DDE_STATUS_WINDOW_WIDTH_MIN  = 220.0f;
-    inline constexpr float DDE_STATUS_WINDOW_HEIGHT_MIN = 100.0f;
+    inline constexpr float DDE_STATUS_WINDOW_HEIGHT_MIN = 130.0f;
 
     // DDE status content constraints
     inline constexpr float DDE_STATUS_CONTENT_WIDTH  = 0.0f;   // Automatic width
@@ -42,6 +42,10 @@ namespace gui {
     inline constexpr int MAX_SAMPLING = 16385;
     // Minimum: Zemax requires at least 33 for valid profile calculation
     inline constexpr int MIN_SAMPLING = 33;
+
+    // Connect DDE popup constraints
+    inline constexpr float CONNECT_DDE_POPUP_WIDTH_MIN  = 260.0f;
+    inline constexpr float CONNECT_DDE_POPUP_HEIGHT_MIN = 100.0f;
 
     // DPI scale constraints
     inline constexpr float MIN_DPI_SCALE = 1.0f;

--- a/src/gui/dockable_windows_manager.cpp
+++ b/src/gui/dockable_windows_manager.cpp
@@ -1,5 +1,6 @@
 #include "dockable_windows_manager.h"
 #include "gui.h"
+#include "gui/utils.h"
 #include "app/config_path.h"
 #include <fstream>
 #include <algorithm>
@@ -103,20 +104,12 @@ const char* DockableWindowsManager::GetName(WindowID id) const {
 }
 
 namespace {
-    void SetDpiScaledWindowConstraints(float minWidth, float minHeight) {
-        float dpiScale = ImGui::GetWindowDpiScale();
-        ImGui::SetNextWindowSizeConstraints(
-            ImVec2(minWidth * dpiScale, minHeight * dpiScale),
-            ImVec2(FLT_MAX, FLT_MAX)
-        );
-    }
-
     void RenderDDEStatusWindow(gui::GuiManager* guiMgr) {
         if (!guiMgr) return;
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::DDEStatus);
         const char* title = mgr->GetName(WindowID::DDEStatus);
-        SetDpiScaledWindowConstraints(gui::DDE_STATUS_WINDOW_WIDTH_MIN, gui::DDE_STATUS_WINDOW_HEIGHT_MIN);
+        gui::SetDpiScaledWindowConstraints(gui::DDE_STATUS_WINDOW_WIDTH_MIN, gui::DDE_STATUS_WINDOW_HEIGHT_MIN);
         if (ImGui::Begin(title, &isVisible,
             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
             if (guiMgr->getDDEStatusRenderer()) {
@@ -134,7 +127,7 @@ namespace {
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::SystemInfo);
         const char* title = mgr->GetName(WindowID::SystemInfo);
-        SetDpiScaledWindowConstraints(gui::SYSTEM_INFO_WINDOW_WIDTH_MIN, gui::SYSTEM_INFO_WINDOW_HEIGHT_MIN);
+        gui::SetDpiScaledWindowConstraints(gui::SYSTEM_INFO_WINDOW_WIDTH_MIN, gui::SYSTEM_INFO_WINDOW_HEIGHT_MIN);
         if (ImGui::Begin(title, &isVisible)) {
             guiMgr->renderOpticalSystemInfo();
         }
@@ -149,7 +142,7 @@ namespace {
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::SagAnalysis);
         const char* title = mgr->GetName(WindowID::SagAnalysis);
-        SetDpiScaledWindowConstraints(gui::SAG_ANALYSIS_WINDOW_WIDTH_MIN, gui::SAG_ANALYSIS_WINDOW_HEIGHT_MIN);
+        gui::SetDpiScaledWindowConstraints(gui::SAG_ANALYSIS_WINDOW_WIDTH_MIN, gui::SAG_ANALYSIS_WINDOW_HEIGHT_MIN);
         if (ImGui::Begin(title, &isVisible)) {
             guiMgr->renderSurfaceSagAnalysis();
         }
@@ -164,7 +157,7 @@ namespace {
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::SurfaceMapAnalysis);
         const char* title = mgr->GetName(WindowID::SurfaceMapAnalysis);
-        SetDpiScaledWindowConstraints(gui::SAG_ANALYSIS_WINDOW_WIDTH_MIN, gui::SAG_ANALYSIS_WINDOW_HEIGHT_MIN);
+        gui::SetDpiScaledWindowConstraints(gui::SAG_ANALYSIS_WINDOW_WIDTH_MIN, gui::SAG_ANALYSIS_WINDOW_HEIGHT_MIN);
         if (ImGui::Begin(title, &isVisible)) {
             guiMgr->renderSurfaceMapAnalysis();
         }
@@ -179,7 +172,7 @@ namespace {
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::DebugLog);
         const char* title = mgr->GetName(WindowID::DebugLog);
-        SetDpiScaledWindowConstraints(gui::DEBUG_LOG_WINDOW_WIDTH_MIN, gui::DEBUG_LOG_WINDOW_HEIGHT_MIN);
+        gui::SetDpiScaledWindowConstraints(gui::DEBUG_LOG_WINDOW_WIDTH_MIN, gui::DEBUG_LOG_WINDOW_HEIGHT_MIN);
         if (ImGui::Begin(title, &isVisible)) {
             guiMgr->renderDebugLog();
         }

--- a/src/gui/dockable_windows_manager.cpp
+++ b/src/gui/dockable_windows_manager.cpp
@@ -159,6 +159,21 @@ namespace {
         }
     }
 
+    void RenderSurfaceMapAnalysisWindow(gui::GuiManager* guiMgr) {
+        if (!guiMgr) return;
+        auto* mgr = guiMgr->getWindowManager();
+        bool isVisible = mgr->IsVisible(WindowID::SurfaceMapAnalysis);
+        const char* title = mgr->GetName(WindowID::SurfaceMapAnalysis);
+        SetDpiScaledWindowConstraints(gui::SAG_ANALYSIS_WINDOW_WIDTH_MIN, gui::SAG_ANALYSIS_WINDOW_HEIGHT_MIN);
+        if (ImGui::Begin(title, &isVisible)) {
+            guiMgr->renderSurfaceMapAnalysis();
+        }
+        ImGui::End();
+        if (!isVisible) {
+            guiMgr->getWindowManager()->SetVisible(WindowID::SurfaceMapAnalysis, false);
+        }
+    }
+
     void RenderDebugLogWindow(gui::GuiManager* guiMgr) {
         if (!guiMgr) return;
         auto* mgr = guiMgr->getWindowManager();
@@ -182,6 +197,8 @@ namespace {
                 return [guiMgr]() { RenderSystemInfoWindow(guiMgr); };
             case WindowID::SagAnalysis:
                 return [guiMgr]() { RenderSagAnalysisWindow(guiMgr); };
+            case WindowID::SurfaceMapAnalysis:
+                return [guiMgr]() { RenderSurfaceMapAnalysisWindow(guiMgr); };
             case WindowID::DebugLog:
                 return [guiMgr]() { RenderDebugLogWindow(guiMgr); };
             default:

--- a/src/gui/dockable_windows_manager.h
+++ b/src/gui/dockable_windows_manager.h
@@ -6,6 +6,7 @@
 
 enum class WindowID {
     SagAnalysis,
+    SurfaceMapAnalysis,
     DebugLog,
     SystemInfo,
     DDEStatus,
@@ -33,6 +34,7 @@ inline constexpr DockableWindowData DockableWindows[] = {
     { WindowID::DDEStatus, WindowCategory::DDE, "DDE Status", true, 0 },
     { WindowID::SystemInfo, WindowCategory::Tools, "Optical System Information", true, 0 },
     { WindowID::SagAnalysis, WindowCategory::Tools, "Surface Sag Cross Section Analysis", false, 1 },
+    { WindowID::SurfaceMapAnalysis, WindowCategory::Tools, "Surface Map Analysis", false, 2 },
     { WindowID::DebugLog, WindowCategory::Info, "Debug Log", true, 0 },
 };
 

--- a/src/gui/graphics_backend.cpp
+++ b/src/gui/graphics_backend.cpp
@@ -7,6 +7,7 @@
 
 #include "lib/imgui/imgui.h"
 #include "lib/implot/implot.h"
+#include "lib/implot3d/implot3d.h"
 #include "lib/imgui/backends/imgui_impl_glfw.h"
 #include "lib/imgui/backends/imgui_impl_opengl3.h"
 
@@ -22,6 +23,7 @@ namespace gui {
             ImGui_ImplOpenGL3_DestroyDeviceObjects();
             ImGui_ImplOpenGL3_Shutdown();
             ImGui_ImplGlfw_Shutdown();
+            ImPlot3D::DestroyContext();
             ImPlot::DestroyContext();
             ImGui::DestroyContext();
         }
@@ -38,6 +40,7 @@ namespace gui {
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
         ImPlot::CreateContext();
+        ImPlot3D::CreateContext();
 
         ImGuiIO& io = ImGui::GetIO();
         io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -12,6 +12,7 @@
 #include "gui/constants.h"
 #include "gui/utils.h"
 #include "gui/sag_analysis_service.h"
+#include "gui/sag_map_analysis_service.h"
 #include "windows_dockable/dde_status.h"
 #include "gui/menu_bar_controller.h"
 #include "gui/graphics_backend.h"
@@ -61,6 +62,7 @@ namespace gui {
 
             GraphicsBackend m_graphics;
             std::unique_ptr<SagAnalysisService> m_sagService;
+            std::unique_ptr<SagMapAnalysisService> m_sagMapService;
             std::unique_ptr<DDEConnectionManager> m_ddeConnectionManager;
             std::unique_ptr<MenuBarController> m_menuBarController;
             std::unique_ptr<DDEStatus> m_ddeStatusRenderer;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -47,6 +47,7 @@ namespace gui {
 
             void renderOpticalSystemInfo();
             void renderSurfaceSagAnalysis();
+            void renderSurfaceMapAnalysis();
             void renderDebugLog();
 
             [[nodiscard]] bool shouldClose() const noexcept { return m_glfwWindow ? glfwWindowShouldClose(m_glfwWindow) : true; }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -29,7 +29,7 @@ class Logger;
 namespace gui {
     class GuiManager {
         public:
-            GuiManager(GLFWwindow* glfwWindow, HWND hwndClient, ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger);
+            GuiManager(GLFWwindow* glfwWindow, DDEConnectionManager* ddeConnectionManager, Logger& logger);
             ~GuiManager();
 
             void initialize(float dpiScale = 1.0f);
@@ -42,6 +42,7 @@ namespace gui {
             MenuBarController* getMenuBarController() { return m_menuBarController.get(); }
             void setWindowManager(DockableWindowsManager* wndMgr) { m_pWndMgr = wndMgr; }
             DockableWindowsManager* getWindowManager() const { return m_pWndMgr; }
+            DDEConnectionManager* getDDEConnectionManager() const { return m_ddeConnectionManager; }
             ZemaxDDE::ZemaxDDEClient* getDDEClient() const { return m_zemaxDDEClient; }
             Logger& getLogger() const { return m_logger; }
             DDEStatus* getDDEStatusRenderer() const { return m_ddeStatusRenderer.get(); }
@@ -55,15 +56,14 @@ namespace gui {
             [[nodiscard]] bool isDDEInitialized() const noexcept { return m_zemaxDDEClient != nullptr && m_zemaxDDEClient->isConnected(); }
 
         private:
-            GLFWwindow* m_glfwWindow;                             // Pointer to handle of GLFW graphics window used for rendering interface
-            HWND m_hwndClient;                                    // DDE client window handle
-            ZemaxDDE::ZemaxDDEClient* m_zemaxDDEClient;           // Pointer to a DDE client instance
-            Logger& m_logger;                                     // Logger instance (dependency injection)
+            GLFWwindow* m_glfwWindow;
+            DDEConnectionManager* m_ddeConnectionManager;
+            ZemaxDDE::ZemaxDDEClient* m_zemaxDDEClient;
+            Logger& m_logger;
 
             GraphicsBackend m_graphics;
             std::unique_ptr<SagAnalysisService> m_sagService;
             std::unique_ptr<SagMapAnalysisService> m_sagMapService;
-            std::unique_ptr<DDEConnectionManager> m_ddeConnectionManager;
             std::unique_ptr<MenuBarController> m_menuBarController;
             std::unique_ptr<DDEStatus> m_ddeStatusRenderer;
             std::unique_ptr<DebugLog> m_debugLogRenderer;

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -2,6 +2,7 @@
 #include <imgui.h>
 #include <imgui_internal.h>
 #include "gui/sag_analysis_service.h"
+#include "gui/sag_map_analysis_service.h"
 #include "gui/menu_bar_controller.h"
 #include "gui/dockable_windows_manager.h"
 #include "dde/dde_connection_manager.h"
@@ -16,6 +17,7 @@ namespace gui {
 , m_logger(logger)
 {
     m_sagService = std::make_unique<SagAnalysisService>(ddeClient, logger);
+    m_sagMapService = std::make_unique<SagMapAnalysisService>(ddeClient, logger);
     m_ddeConnectionManager = std::make_unique<DDEConnectionManager>(m_zemaxDDEClient, m_logger);
     m_menuBarController = std::make_unique<MenuBarController>(m_logger, m_ddeConnectionManager.get());
     m_menuBarController->setExitCallback([this]() {

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -28,7 +28,7 @@ namespace gui {
     m_menuBarController->setUpdatesCallback([this]() {
         m_showUpdatesPopup = true;
     });
-    m_ddeStatusRenderer = std::make_unique<DDEStatus>(m_zemaxDDEClient);
+    m_ddeStatusRenderer = std::make_unique<DDEStatus>(m_ddeConnectionManager);
     m_debugLogRenderer = std::make_unique<DebugLog>();
     m_aboutDialog        = std::make_unique<AboutDialog>();
     m_updateChecker      = std::make_unique<UpdateChecker>();

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -10,16 +10,15 @@
 #include "logger/logger.h"
 
 namespace gui {
-    GuiManager::GuiManager(GLFWwindow* glfwWindow, HWND hwndClient, ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger)
+    GuiManager::GuiManager(GLFWwindow* glfwWindow, DDEConnectionManager* ddeConnectionManager, Logger& logger)
 : m_glfwWindow(glfwWindow)
-, m_hwndClient(hwndClient)
-, m_zemaxDDEClient(ddeClient)
+, m_ddeConnectionManager(ddeConnectionManager)
+, m_zemaxDDEClient(ddeConnectionManager ? ddeConnectionManager->getActiveClient() : nullptr)
 , m_logger(logger)
 {
-    m_sagService = std::make_unique<SagAnalysisService>(ddeClient, logger);
-    m_sagMapService = std::make_unique<SagMapAnalysisService>(ddeClient, logger);
-    m_ddeConnectionManager = std::make_unique<DDEConnectionManager>(m_logger);
-    m_menuBarController = std::make_unique<MenuBarController>(m_logger, m_ddeConnectionManager.get());
+    m_sagService = std::make_unique<SagAnalysisService>(m_zemaxDDEClient, logger);
+    m_sagMapService = std::make_unique<SagMapAnalysisService>(m_zemaxDDEClient, logger);
+    m_menuBarController = std::make_unique<MenuBarController>(m_logger, m_ddeConnectionManager);
     m_menuBarController->setExitCallback([this]() {
         if (m_glfwWindow) glfwSetWindowShouldClose(m_glfwWindow, true);
     });

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -16,8 +16,8 @@ namespace gui {
 , m_zemaxDDEClient(ddeConnectionManager ? ddeConnectionManager->getActiveClient() : nullptr)
 , m_logger(logger)
 {
-    m_sagService = std::make_unique<SagAnalysisService>(m_zemaxDDEClient, logger);
-    m_sagMapService = std::make_unique<SagMapAnalysisService>(m_zemaxDDEClient, logger);
+    m_sagService = std::make_unique<SagAnalysisService>(m_ddeConnectionManager, logger);
+    m_sagMapService = std::make_unique<SagMapAnalysisService>(m_ddeConnectionManager, logger);
     m_menuBarController = std::make_unique<MenuBarController>(m_logger, m_ddeConnectionManager);
     m_menuBarController->setExitCallback([this]() {
         if (m_glfwWindow) glfwSetWindowShouldClose(m_glfwWindow, true);

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -71,35 +71,37 @@ void GuiManager::render() {
         m_pWndMgr->RenderAll();
     }
 
-    if (m_sagService->m_showTolerancedSagWindow) {
-        auto* surface = m_zemaxDDEClient->getTolerancedSurface();
-        if (surface->isValid()) {
-            std::string title = std::format("Toleranced Surface Cross Section ({}°, {} pts)", surface->angle, surface->sampling);
-            m_sagService->renderCrossSectionWindow(title.c_str(), "Toleranced", *surface, &m_sagService->m_showTolerancedSagWindow);
+    if (m_zemaxDDEClient) {
+        if (m_sagService->m_showTolerancedSagWindow) {
+            auto* surface = m_zemaxDDEClient->getTolerancedSurface();
+            if (surface->isValid()) {
+                std::string title = std::format("Toleranced Surface Cross Section ({}°, {} pts)", surface->angle, surface->sampling);
+                m_sagService->renderCrossSectionWindow(title.c_str(), "Toleranced", *surface, &m_sagService->m_showTolerancedSagWindow);
+            }
         }
-    }
 
-    if (m_sagService->m_showNominalSagWindow) {
-        auto* surface = m_zemaxDDEClient->getNominalSurface();
-        if (surface->isValid()) {
-            std::string title = std::format("Nominal Surface Cross Section ({}°, {} pts)", surface->angle, surface->sampling);
-            m_sagService->renderCrossSectionWindow(title.c_str(), "Nominal", *surface, &m_sagService->m_showNominalSagWindow);
+        if (m_sagService->m_showNominalSagWindow) {
+            auto* surface = m_zemaxDDEClient->getNominalSurface();
+            if (surface->isValid()) {
+                std::string title = std::format("Nominal Surface Cross Section ({}°, {} pts)", surface->angle, surface->sampling);
+                m_sagService->renderCrossSectionWindow(title.c_str(), "Nominal", *surface, &m_sagService->m_showNominalSagWindow);
+            }
         }
-    }
 
-    if (m_sagService->m_showComparisonWindow) {
-        auto* nom = m_zemaxDDEClient->getNominalSurface();
-        auto* tol = m_zemaxDDEClient->getTolerancedSurface();
-        if (nom->isValid() && tol->isValid()) {
-            m_sagService->renderComparisonWindow(*nom, *tol, &m_sagService->m_showComparisonWindow);
+        if (m_sagService->m_showComparisonWindow) {
+            auto* nom = m_zemaxDDEClient->getNominalSurface();
+            auto* tol = m_zemaxDDEClient->getTolerancedSurface();
+            if (nom->isValid() && tol->isValid()) {
+                m_sagService->renderComparisonWindow(*nom, *tol, &m_sagService->m_showComparisonWindow);
+            }
         }
-    }
 
-    if (m_sagService->m_showErrorWindow) {
-        auto* nom = m_zemaxDDEClient->getNominalSurface();
-        auto* tol = m_zemaxDDEClient->getTolerancedSurface();
-        if (nom->isValid() && tol->isValid() && nom->sagDataPoints.size() == tol->sagDataPoints.size()) {
-            m_sagService->renderErrorWindow(*nom, *tol, &m_sagService->m_showErrorWindow);
+        if (m_sagService->m_showErrorWindow) {
+            auto* nom = m_zemaxDDEClient->getNominalSurface();
+            auto* tol = m_zemaxDDEClient->getTolerancedSurface();
+            if (nom->isValid() && tol->isValid() && nom->sagDataPoints.size() == tol->sagDataPoints.size()) {
+                m_sagService->renderErrorWindow(*nom, *tol, &m_sagService->m_showErrorWindow);
+            }
         }
     }
 

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -68,34 +68,34 @@ void GuiManager::render() {
     }
 
     if (m_sagService->m_showTolerancedSagWindow) {
-        auto& surface = m_zemaxDDEClient->getTolerancedSurface();
-        if (surface.isValid()) {
-            std::string title = std::format("Toleranced Surface Cross Section ({}°, {} pts)", surface.angle, surface.sampling);
-            m_sagService->renderCrossSectionWindow(title.c_str(), "Toleranced", surface, &m_sagService->m_showTolerancedSagWindow);
+        auto* surface = m_zemaxDDEClient->getTolerancedSurface();
+        if (surface->isValid()) {
+            std::string title = std::format("Toleranced Surface Cross Section ({}°, {} pts)", surface->angle, surface->sampling);
+            m_sagService->renderCrossSectionWindow(title.c_str(), "Toleranced", *surface, &m_sagService->m_showTolerancedSagWindow);
         }
     }
 
     if (m_sagService->m_showNominalSagWindow) {
-        auto& surface = m_zemaxDDEClient->getNominalSurface();
-        if (surface.isValid()) {
-            std::string title = std::format("Nominal Surface Cross Section ({}°, {} pts)", surface.angle, surface.sampling);
-            m_sagService->renderCrossSectionWindow(title.c_str(), "Nominal", surface, &m_sagService->m_showNominalSagWindow);
+        auto* surface = m_zemaxDDEClient->getNominalSurface();
+        if (surface->isValid()) {
+            std::string title = std::format("Nominal Surface Cross Section ({}°, {} pts)", surface->angle, surface->sampling);
+            m_sagService->renderCrossSectionWindow(title.c_str(), "Nominal", *surface, &m_sagService->m_showNominalSagWindow);
         }
     }
 
     if (m_sagService->m_showComparisonWindow) {
-        auto& nom = m_zemaxDDEClient->getNominalSurface();
-        auto& tol = m_zemaxDDEClient->getTolerancedSurface();
-        if (nom.isValid() && tol.isValid()) {
-            m_sagService->renderComparisonWindow(nom, tol, &m_sagService->m_showComparisonWindow);
+        auto* nom = m_zemaxDDEClient->getNominalSurface();
+        auto* tol = m_zemaxDDEClient->getTolerancedSurface();
+        if (nom->isValid() && tol->isValid()) {
+            m_sagService->renderComparisonWindow(*nom, *tol, &m_sagService->m_showComparisonWindow);
         }
     }
 
     if (m_sagService->m_showErrorWindow) {
-        auto& nom = m_zemaxDDEClient->getNominalSurface();
-        auto& tol = m_zemaxDDEClient->getTolerancedSurface();
-        if (nom.isValid() && tol.isValid() && nom.sagDataPoints.size() == tol.sagDataPoints.size()) {
-            m_sagService->renderErrorWindow(nom, tol, &m_sagService->m_showErrorWindow);
+        auto* nom = m_zemaxDDEClient->getNominalSurface();
+        auto* tol = m_zemaxDDEClient->getTolerancedSurface();
+        if (nom->isValid() && tol->isValid() && nom->sagDataPoints.size() == tol->sagDataPoints.size()) {
+            m_sagService->renderErrorWindow(*nom, *tol, &m_sagService->m_showErrorWindow);
         }
     }
 

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -41,6 +41,9 @@ void GuiManager::initialize(float dpiScale) {
 }
 
 void GuiManager::render() {
+    // Refresh active DDE client in case connection changed via DDE Status UI
+    m_zemaxDDEClient = m_ddeConnectionManager ? m_ddeConnectionManager->getActiveClient() : nullptr;
+
     m_graphics.beginFrame();
     if (m_menuBarController) {
         m_menuBarController->render();

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -18,7 +18,7 @@ namespace gui {
 {
     m_sagService = std::make_unique<SagAnalysisService>(ddeClient, logger);
     m_sagMapService = std::make_unique<SagMapAnalysisService>(ddeClient, logger);
-    m_ddeConnectionManager = std::make_unique<DDEConnectionManager>(m_zemaxDDEClient, m_logger);
+    m_ddeConnectionManager = std::make_unique<DDEConnectionManager>(m_logger);
     m_menuBarController = std::make_unique<MenuBarController>(m_logger, m_ddeConnectionManager.get());
     m_menuBarController->setExitCallback([this]() {
         if (m_glfwWindow) glfwSetWindowShouldClose(m_glfwWindow, true);

--- a/src/gui/menu_bar_controller.cpp
+++ b/src/gui/menu_bar_controller.cpp
@@ -45,15 +45,6 @@ namespace gui {
                 ImGui::EndMenu();
             }
             if (ImGui::BeginMenu("DDE")) {
-                if (m_pDDEClientMgr) {
-                    if (ImGui::MenuItem("Connect to Zemax")) {
-                        m_pDDEClientMgr->connect();
-                    }
-                    if (ImGui::MenuItem("Disconnect from Zemax")) {
-                        m_pDDEClientMgr->disconnect();
-                    }
-                }
-                ImGui::Separator();
                 if (m_pWndMgr) {
                     bool showDDEStatus = m_pWndMgr->IsVisible(WindowID::DDEStatus);
                     if (ImGui::MenuItem("Show DDE Status", nullptr, &showDDEStatus)) {

--- a/src/gui/popups/connect_dde.cpp
+++ b/src/gui/popups/connect_dde.cpp
@@ -1,0 +1,82 @@
+#include <format>
+
+#include "connect_dde.h"
+#include "app/zemax_window_enumerator.h"
+#include "gui/utils.h"
+#include "gui/constants.h"
+#include "lib/imgui/imgui.h"
+#include "logger/logger.h"
+
+namespace gui {
+    void ConnectDDEPopup::render(bool& showFlag, Logger& logger) {
+        if (!showFlag) return;
+
+        constexpr const char* POPUP_TITLE = "Connect to Zemax – select a window";
+
+        ImGui::OpenPopup(POPUP_TITLE);
+        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+        SetDpiScaledWindowConstraints(CONNECT_DDE_POPUP_WIDTH_MIN, CONNECT_DDE_POPUP_HEIGHT_MIN);
+        // ImGui::SetNextWindowSize(ImVec2(920, 400), ImGuiCond_FirstUseEver);
+
+        if (ImGui::BeginPopupModal(POPUP_TITLE, &showFlag, ImGuiWindowFlags_None)) {
+            auto windows = app::ZemaxWindowEnumerator::enumerate();
+
+            ImGui::BeginChild("ZemaxWindowList", ImVec2(0, -ImGui::GetFrameHeightWithSpacing() - 10), ImGuiChildFlags_Borders);
+
+            for (size_t i = 0; i < windows.size(); ++i) {
+                const auto& wnd = windows[i];
+                std::string title(wnd.title.begin(), wnd.title.end());
+                std::string label = std::format("[PID: {}] {}", wnd.pid, title);
+
+                if (ImGui::Selectable(label.c_str(), m_selectedWindowIndex == static_cast<int>(i))) {
+                    m_selectedWindowIndex = static_cast<int>(i);
+                }
+            }
+
+            if (windows.empty()) {
+                ImGui::TextDisabled("No Zemax windows found");
+            }
+
+            ImGui::EndChild();
+
+            bool canConnect = (m_selectedWindowIndex >= 0 && m_selectedWindowIndex < static_cast<int>(windows.size()));
+
+            if (!canConnect) {
+                ImGui::BeginDisabled();
+            }
+
+            if (ImGui::Button("Connect", ImVec2(120, 0))) {
+                const auto& wnd = windows[m_selectedWindowIndex];
+                int slot = m_connectionManager->connectToZemax(wnd.hwnd, wnd.title);
+                if (slot >= 0) {
+                    showFlag = false;
+                    m_selectedWindowIndex = -1;
+                } else {
+                    std::string title(wnd.title.begin(), wnd.title.end());
+                    logger.addLog(std::format("[DDE] Failed to connect to: {}", title));
+                }
+            }
+
+            if (!canConnect) {
+                ImGui::EndDisabled();
+            }
+
+            ImGui::SameLine();
+
+            if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+                showFlag = false;
+                m_selectedWindowIndex = -1;
+            }
+
+            ImGui::SameLine();
+            float remainingWidth = ImGui::GetContentRegionAvail().x;
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + remainingWidth - 120.0f);
+            if (ImGui::Button("Refresh", ImVec2(120, 0))) {
+                m_selectedWindowIndex = -1;
+            }
+
+            ImGui::EndPopup();
+        }
+    }
+}

--- a/src/gui/popups/connect_dde.h
+++ b/src/gui/popups/connect_dde.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "dde/dde_connection_manager.h"
+
+namespace gui {
+    class ConnectDDEPopup {
+    public:
+        explicit ConnectDDEPopup(DDEConnectionManager* connectionManager)
+            : m_connectionManager(connectionManager) {}
+
+        void render(bool& showFlag, Logger& logger);
+
+    private:
+        DDEConnectionManager* m_connectionManager;
+        int m_selectedWindowIndex = -1;
+    };
+}

--- a/src/gui/sag_analysis_service.cpp
+++ b/src/gui/sag_analysis_service.cpp
@@ -8,6 +8,7 @@
 #include "lib/implot/implot.h"
 
 #include "gui/sag_analysis_service.h"
+#include "dde/operation_monitor.h"
 #include "gui/gui.h"
 #include "logger/logger.h"
 
@@ -44,38 +45,42 @@ namespace gui {
             return;
         }
 
+        auto* monitor = getMonitor();
+        m_operationId = monitor ? monitor->registerOperation("SagAnalysis", sampling) : 0;
+
         m_calcState = SagCalcState::FetchingSurfaceData;
         m_calcError.clear();
         m_targetSurface = surface;
         m_targetSampling = sampling;
         m_targetAngle = angle;
         m_sagPointIndex = 0;
+        m_skippedPoints = 0;
         m_resultSurface = {};
         m_resultSurface.id = surface;
         m_resultSurface.sagDataPoints.clear();
-        m_pendingSurfaceRequests = 2;
+        m_surfaceRequestsRemaining = 2;
 
         m_logger.addLog(std::format("[SagService] Starting async sag calc for surface {} ({} pts, {}°)", surface, sampling, angle));
 
-        client->sendRequest(
+        client->enqueueRequest(
             std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::TYPE_NAME),
             [this](const std::string& result) {
                 onSurfaceDataReceived(ZemaxDDE::SurfaceDataCode::TYPE_NAME, result);
             },
             [this](const std::string& error) {
                 onError(std::format("GetSurfaceData(TYPE_NAME) failed: {}", error));
-            }
-        );
+            },
+            2000, 1, "SagAnalysis");
 
-        client->sendRequest(
+        client->enqueueRequest(
             std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER),
             [this](const std::string& result) {
                 onSurfaceDataReceived(ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER, result);
             },
             [this](const std::string& error) {
                 onError(std::format("GetSurfaceData(SEMI_DIAMETER) failed: {}", error));
-            }
-        );
+            },
+            2000, 1, "SagAnalysis");
     }
 
     void SagAnalysisService::onSurfaceDataReceived(int code, const std::string& value) {
@@ -96,7 +101,7 @@ namespace gui {
             }
         }
 
-        if (--m_pendingSurfaceRequests > 0) return;
+        if (--m_surfaceRequestsRemaining > 0) return;
 
         m_calcState = SagCalcState::FetchingSagPoints;
         sendNextSagRequest();
@@ -107,9 +112,34 @@ namespace gui {
             m_resultSurface.sampling = m_targetSampling;
             m_resultSurface.angle = m_targetAngle;
             m_calcState = SagCalcState::Completed;
+
+            auto* monitor = getMonitor();
+            if (monitor) {
+                auto msg = m_skippedPoints > 0
+                    ? std::format("Completed ({} points, {} skipped)", m_resultSurface.sagDataPoints.size(), m_skippedPoints)
+                    : std::format("Completed ({} points)", m_resultSurface.sagDataPoints.size());
+                monitor->reportProgress(m_operationId, m_targetSampling, msg);
+                monitor->onCompleted(m_operationId);
+            }
+
             m_logger.addLog(std::format("[SagService] Sag calc completed: {} points", m_resultSurface.sagDataPoints.size()));
             if (onCalculationComplete) onCalculationComplete();
             return;
+        }
+
+        auto* monitor = getMonitor();
+        if (monitor && monitor->isCancelled(m_operationId)) {
+            m_calcState = SagCalcState::Failed;
+            m_calcError = "Cancelled";
+            monitor->onError(m_operationId, "Cancelled");
+            m_logger.addLog("[SagService] Calculation cancelled by user");
+            if (onCalculationComplete) onCalculationComplete();
+            return;
+        }
+
+        if (monitor) {
+            monitor->reportProgress(m_operationId, m_sagPointIndex,
+                std::format("Point {}/{}", m_sagPointIndex, m_targetSampling));
         }
 
         constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
@@ -126,15 +156,19 @@ namespace gui {
             return;
         }
 
-        client->sendRequest(
+        client->enqueueRequest(
             std::format("GetSag,{},{},{}", m_targetSurface, x, y),
             [this](const std::string& result) {
                 onSagDataReceived(result);
             },
             [this](const std::string& error) {
-                onError(std::format("GetSag failed: {}", error));
-            }
-        );
+                if (error == "Timeout") {
+                    onSagTimeout();
+                } else {
+                    onError(std::format("GetSag failed: {}", error));
+                }
+            },
+            1000, 1, "SagAnalysis");
     }
 
     void SagAnalysisService::onSagDataReceived(const std::string& buffer) {
@@ -166,11 +200,32 @@ namespace gui {
         sendNextSagRequest();
     }
 
+    void SagAnalysisService::onSagTimeout() {
+        m_logger.addLog(std::format("[SagService] Point {} timed out, skipping", m_sagPointIndex));
+        m_skippedPoints++;
+        m_sagPointIndex++;
+        sendNextSagRequest();
+    }
+
     void SagAnalysisService::onError(const std::string& error) {
         m_calcState = SagCalcState::Failed;
         m_calcError = error;
+
+        auto* monitor = getMonitor();
+        if (monitor) monitor->onError(m_operationId, error);
+
         m_logger.addLog(std::format("[SagService] {}", error));
         if (onCalculationComplete) onCalculationComplete();
+    }
+
+    void SagAnalysisService::cancelCalculation() {
+        auto* monitor = getMonitor();
+        if (monitor && m_operationId > 0) monitor->requestCancel(m_operationId);
+    }
+
+    ZemaxDDE::OperationMonitor* SagAnalysisService::getMonitor() const {
+        auto* client = getClient();
+        return client ? client->getOperationMonitor() : nullptr;
     }
 
     void SagAnalysisService::saveCrossSectionToFile(const ZemaxDDE::SurfaceData& surface) {

--- a/src/gui/sag_analysis_service.cpp
+++ b/src/gui/sag_analysis_service.cpp
@@ -1,6 +1,8 @@
-#include <fstream>
-#include <ranges>
+#include <format>
 #include <cmath>
+
+#include "dde/constants.h"
+#include "dde/utils.h"
 
 #include "lib/imgui/imgui.h"
 #include "lib/implot/implot.h"
@@ -33,40 +35,142 @@ namespace gui {
         return {std::move(x_vals), std::move(y_vals)};
     }
 
-    void SagAnalysisService::calculateSagCrossSection(int surface, int sampling, double angle) {
-        const ZemaxDDE::SurfaceData* targetSurface = getClient()->getCurrentStorage();
+    void SagAnalysisService::startAsyncSagCalculation(int surface, int sampling, double angle) {
+        auto* client = getClient();
+        if (!client) {
+            m_calcState = SagCalcState::Failed;
+            m_calcError = "No active DDE connection";
+            if (onCalculationComplete) onCalculationComplete();
+            return;
+        }
 
-        if (targetSurface->id != surface || !targetSurface->isValid()) [[unlikely]] {
-            m_logger.addLog(std::format("[GUI] Surface {} does not exist in the current optical system", surface));
+        m_calcState = SagCalcState::FetchingSurfaceData;
+        m_calcError.clear();
+        m_targetSurface = surface;
+        m_targetSampling = sampling;
+        m_targetAngle = angle;
+        m_sagPointIndex = 0;
+        m_resultSurface = {};
+        m_resultSurface.id = surface;
+        m_resultSurface.sagDataPoints.clear();
+        m_pendingSurfaceRequests = 2;
+
+        m_logger.addLog(std::format("[SagService] Starting async sag calc for surface {} ({} pts, {}°)", surface, sampling, angle));
+
+        client->sendRequest(
+            std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::TYPE_NAME),
+            [this](const std::string& result) {
+                onSurfaceDataReceived(ZemaxDDE::SurfaceDataCode::TYPE_NAME, result);
+            },
+            [this](const std::string& error) {
+                onError(std::format("GetSurfaceData(TYPE_NAME) failed: {}", error));
+            }
+        );
+
+        client->sendRequest(
+            std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER),
+            [this](const std::string& result) {
+                onSurfaceDataReceived(ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER, result);
+            },
+            [this](const std::string& error) {
+                onError(std::format("GetSurfaceData(SEMI_DIAMETER) failed: {}", error));
+            }
+        );
+    }
+
+    void SagAnalysisService::onSurfaceDataReceived(int code, const std::string& value) {
+        auto tokens = ZemaxDDE::tokenize(value);
+        if (tokens.empty()) {
+            onError(std::format("GetSurfaceData({}): empty response", code));
+            return;
+        }
+
+        if (code == ZemaxDDE::SurfaceDataCode::TYPE_NAME) {
+            m_resultSurface.type = tokens[0];
+        } else if (code == ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER) {
+            try {
+                m_resultSurface.semiDiameter = std::stod(tokens[0]);
+            } catch (...) {
+                onError("GetSurfaceData(SEMI_DIAMETER): invalid number");
+                return;
+            }
+        }
+
+        if (--m_pendingSurfaceRequests > 0) return;
+
+        m_calcState = SagCalcState::FetchingSagPoints;
+        sendNextSagRequest();
+    }
+
+    void SagAnalysisService::sendNextSagRequest() {
+        if (m_sagPointIndex >= m_targetSampling) {
+            m_resultSurface.sampling = m_targetSampling;
+            m_resultSurface.angle = m_targetAngle;
+            m_calcState = SagCalcState::Completed;
+            m_logger.addLog(std::format("[SagService] Sag calc completed: {} points", m_resultSurface.sagDataPoints.size()));
+            if (onCalculationComplete) onCalculationComplete();
             return;
         }
 
         constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
-        const double rad = angle * DEG_TO_RAD;
-        const double cosAngle = cos(rad);
-        const double sinAngle = sin(rad);
-        double semiDiameter = targetSurface->semiDiameter;
-        double step = targetSurface->diameter() / (sampling - 1);
+        const double rad = m_targetAngle * DEG_TO_RAD;
+        double semiDiameter = m_resultSurface.semiDiameter;
+        double step = (2.0 * semiDiameter) / (m_targetSampling - 1);
+        double r = -semiDiameter + m_sagPointIndex * step;
+        double x = r * std::cos(rad);
+        double y = r * std::sin(rad);
 
-        #ifdef DEBUG_LOG
-        m_logger.addLog(std::format("[GUI] Requesting Sag Cross Section for surface {} at angle {}° with {} points", surface, angle, sampling));
-        #endif
-
-        for (int i : std::views::iota(0, sampling)) {
-            const double r = -semiDiameter + i * step;
-            const double x = r * cosAngle;
-            const double y = r * sinAngle;
-            getClient()->getSag(surface, x, y);
+        auto* client = getClient();
+        if (!client) {
+            onError("Connection lost during sag calculation");
+            return;
         }
 
-        getClient()->setSurfaceProfileMetadata(
-            {.angle = angle, .sampling = sampling}
+        client->sendRequest(
+            std::format("GetSag,{},{},{}", m_targetSurface, x, y),
+            [this](const std::string& result) {
+                onSagDataReceived(result);
+            },
+            [this](const std::string& error) {
+                onError(std::format("GetSag failed: {}", error));
+            }
         );
+    }
 
-        // Auto-update state after successful calculation
-        m_surfaceSagAnalysisPageState.tolerancedSurfaceIndex = surface;
-        m_surfaceSagAnalysisPageState.tolerancedSampling = sampling;
-        m_surfaceSagAnalysisPageState.tolerancedAngle = angle;
+    void SagAnalysisService::onSagDataReceived(const std::string& buffer) {
+        auto tokens = ZemaxDDE::tokenize(buffer);
+        if (tokens.size() < 2) {
+            onError("GetSag: invalid response format");
+            return;
+        }
+
+        constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
+        const double rad = m_targetAngle * DEG_TO_RAD;
+        double semiDiameter = m_resultSurface.semiDiameter;
+        double step = (2.0 * semiDiameter) / (m_targetSampling - 1);
+        double r = -semiDiameter + m_sagPointIndex * step;
+
+        try {
+            ZemaxDDE::SagData point;
+            point.x = r * std::cos(rad);
+            point.y = r * std::sin(rad);
+            point.sag = std::stod(tokens[0]);
+            point.alternateSag = std::stod(tokens[1]);
+            m_resultSurface.sagDataPoints.push_back(point);
+        } catch (...) {
+            onError("GetSag: failed to parse sag values");
+            return;
+        }
+
+        m_sagPointIndex++;
+        sendNextSagRequest();
+    }
+
+    void SagAnalysisService::onError(const std::string& error) {
+        m_calcState = SagCalcState::Failed;
+        m_calcError = error;
+        m_logger.addLog(std::format("[SagService] {}", error));
+        if (onCalculationComplete) onCalculationComplete();
     }
 
     void SagAnalysisService::saveCrossSectionToFile(const ZemaxDDE::SurfaceData& surface) {

--- a/src/gui/sag_analysis_service.cpp
+++ b/src/gui/sag_analysis_service.cpp
@@ -34,18 +34,9 @@ namespace gui {
     }
 
     void SagAnalysisService::calculateSagCrossSection(int surface, int sampling, double angle) {
-        const auto targetStorage = m_ddeClient->getStorageTarget();
-        if (targetStorage != ZemaxDDE::StorageTarget::NOMINAL && targetStorage != ZemaxDDE::StorageTarget::TOLERANCED) {
-            m_logger.addLog("[GUI] Invalid storage target for Sag calculation");
-            return;
-        }
+        const ZemaxDDE::SurfaceData* targetSurface = m_ddeClient->getCurrentStorage();
 
-        const ZemaxDDE::SurfaceData& targetSurface =
-            (targetStorage == ZemaxDDE::StorageTarget::NOMINAL)
-                ? m_ddeClient->getNominalSurface()
-                : m_ddeClient->getTolerancedSurface();
-
-        if (targetSurface.id != surface || !targetSurface.isValid()) [[unlikely]] {
+        if (targetSurface->id != surface || !targetSurface->isValid()) [[unlikely]] {
             m_logger.addLog(std::format("[GUI] Surface {} does not exist in the current optical system", surface));
             return;
         }
@@ -54,8 +45,8 @@ namespace gui {
         const double rad = angle * DEG_TO_RAD;
         const double cosAngle = cos(rad);
         const double sinAngle = sin(rad);
-        double semiDiameter = targetSurface.semiDiameter;
-        double step = targetSurface.diameter() / (sampling - 1);
+        double semiDiameter = targetSurface->semiDiameter;
+        double step = targetSurface->diameter() / (sampling - 1);
 
         #ifdef DEBUG_LOG
         m_logger.addLog(std::format("[GUI] Requesting Sag Cross Section for surface {} at angle {}° with {} points", surface, angle, sampling));
@@ -69,7 +60,6 @@ namespace gui {
         }
 
         m_ddeClient->setSurfaceProfileMetadata(
-            targetStorage,
             {.angle = angle, .sampling = sampling}
         );
 

--- a/src/gui/sag_analysis_service.cpp
+++ b/src/gui/sag_analysis_service.cpp
@@ -10,8 +10,8 @@
 #include "logger/logger.h"
 
 namespace gui {
-    SagAnalysisService::SagAnalysisService(ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger)
-        : m_ddeClient(ddeClient)
+    SagAnalysisService::SagAnalysisService(DDEConnectionManager* connectionManager, Logger& logger)
+        : m_connectionManager(connectionManager)
         , m_logger(logger)
     {
     }
@@ -34,7 +34,7 @@ namespace gui {
     }
 
     void SagAnalysisService::calculateSagCrossSection(int surface, int sampling, double angle) {
-        const ZemaxDDE::SurfaceData* targetSurface = m_ddeClient->getCurrentStorage();
+        const ZemaxDDE::SurfaceData* targetSurface = getClient()->getCurrentStorage();
 
         if (targetSurface->id != surface || !targetSurface->isValid()) [[unlikely]] {
             m_logger.addLog(std::format("[GUI] Surface {} does not exist in the current optical system", surface));
@@ -56,10 +56,10 @@ namespace gui {
             const double r = -semiDiameter + i * step;
             const double x = r * cosAngle;
             const double y = r * sinAngle;
-            m_ddeClient->getSag(surface, x, y);
+            getClient()->getSag(surface, x, y);
         }
 
-        m_ddeClient->setSurfaceProfileMetadata(
+        getClient()->setSurfaceProfileMetadata(
             {.angle = angle, .sampling = sampling}
         );
 
@@ -170,5 +170,9 @@ namespace gui {
             }
         }
         ImGui::End();
+    }
+
+    ZemaxDDE::ZemaxDDEClient* SagAnalysisService::getClient() const {
+        return m_connectionManager ? m_connectionManager->getActiveClient() : nullptr;
     }
 }

--- a/src/gui/sag_analysis_service.h
+++ b/src/gui/sag_analysis_service.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <filesystem>
+#include <functional>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -11,6 +13,15 @@
 class Logger;
 
 namespace gui {
+
+    enum class SagCalcState {
+        Idle,
+        FetchingSurfaceData,
+        FetchingSagPoints,
+        Completed,
+        Failed
+    };
+
     struct SagAnalysisState {
         int tolerancedSurfaceIndex = 0;
         int nominalSurfaceIndex = 0;
@@ -21,17 +32,15 @@ namespace gui {
         double nominalAngle = 0.0;
     };
 
-    // Free utility function — extracts X and Sag coordinates from surface data
     std::pair<std::vector<double>, std::vector<double>> extractSagCoordinates(const ZemaxDDE::SurfaceData& surface);
 
-    // Write sag cross section data to a temporary text file
     std::optional<std::filesystem::path> writeToTemporaryFile(const std::string& filename, const std::string& content);
 
     class SagAnalysisService {
         public:
             SagAnalysisService(DDEConnectionManager* connectionManager, Logger& logger);
 
-            void calculateSagCrossSection(int surface, int sampling, double angle = 0.0);
+            void startAsyncSagCalculation(int surface, int sampling, double angle);
             void saveCrossSectionToFile(const ZemaxDDE::SurfaceData& surface);
 
             void renderCrossSectionWindow(const char* title, const char* label, const ZemaxDDE::SurfaceData& surface, bool* openFlag);
@@ -45,10 +54,30 @@ namespace gui {
 
             SagAnalysisState m_surfaceSagAnalysisPageState;
 
+            SagCalcState getCalcState() const { return m_calcState; }
+            const std::string& getCalcError() const { return m_calcError; }
+            const ZemaxDDE::SurfaceData& getResult() const { return m_resultSurface; }
+            std::function<void()> onCalculationComplete;
+
         private:
             ZemaxDDE::ZemaxDDEClient* getClient() const;
+            void sendNextSagRequest();
+            void onSurfaceDataReceived(int code, const std::string& value);
+            void onSagDataReceived(const std::string& buffer);
+            void onError(const std::string& error);
 
             DDEConnectionManager* m_connectionManager;
             Logger& m_logger;
+
+            SagCalcState m_calcState = SagCalcState::Idle;
+            std::string m_calcError;
+
+            int m_targetSurface = 0;
+            int m_targetSampling = 0;
+            double m_targetAngle = 0.0;
+            int m_sagPointIndex = 0;
+            int m_pendingSurfaceRequests = 0;
+
+            ZemaxDDE::SurfaceData m_resultSurface;
     };
 }

--- a/src/gui/sag_analysis_service.h
+++ b/src/gui/sag_analysis_service.h
@@ -57,14 +57,24 @@ namespace gui {
             SagCalcState getCalcState() const { return m_calcState; }
             const std::string& getCalcError() const { return m_calcError; }
             const ZemaxDDE::SurfaceData& getResult() const { return m_resultSurface; }
+
+            uint64_t getOperationId() const { return m_operationId; }
+            int getTotalSteps() const { return m_targetSampling; }
+            int getCurrentStep() const { return m_sagPointIndex; }
+            int getSkippedPoints() const { return m_skippedPoints; }
+
+            void cancelCalculation();
+
             std::function<void()> onCalculationComplete;
 
         private:
             ZemaxDDE::ZemaxDDEClient* getClient() const;
+            ZemaxDDE::OperationMonitor* getMonitor() const;
             void sendNextSagRequest();
             void onSurfaceDataReceived(int code, const std::string& value);
             void onSagDataReceived(const std::string& buffer);
             void onError(const std::string& error);
+            void onSagTimeout();
 
             DDEConnectionManager* m_connectionManager;
             Logger& m_logger;
@@ -76,7 +86,9 @@ namespace gui {
             int m_targetSampling = 0;
             double m_targetAngle = 0.0;
             int m_sagPointIndex = 0;
-            int m_pendingSurfaceRequests = 0;
+            int m_surfaceRequestsRemaining = 0;
+            uint64_t m_operationId = 0;
+            int m_skippedPoints = 0;
 
             ZemaxDDE::SurfaceData m_resultSurface;
     };

--- a/src/gui/sag_analysis_service.h
+++ b/src/gui/sag_analysis_service.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "dde/dde_connection_manager.h"
 #include "dde/client.h"
 
 class Logger;
@@ -26,34 +27,28 @@ namespace gui {
     // Write sag cross section data to a temporary text file
     std::optional<std::filesystem::path> writeToTemporaryFile(const std::string& filename, const std::string& content);
 
-    /**
-     * @brief Sag analysis service — business logic for surface sag cross section analysis.
-     *        Handles data calculation, export, and ImPlot rendering.
-     */
     class SagAnalysisService {
         public:
-            SagAnalysisService(ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger);
+            SagAnalysisService(DDEConnectionManager* connectionManager, Logger& logger);
 
-            // Business logic
             void calculateSagCrossSection(int surface, int sampling, double angle = 0.0);
             void saveCrossSectionToFile(const ZemaxDDE::SurfaceData& surface);
 
-            // Detached plot windows
             void renderCrossSectionWindow(const char* title, const char* label, const ZemaxDDE::SurfaceData& surface, bool* openFlag);
             void renderComparisonWindow(const ZemaxDDE::SurfaceData& nominal, const ZemaxDDE::SurfaceData& toleranced, bool* openFlag);
             void renderErrorWindow(const ZemaxDDE::SurfaceData& nominal, const ZemaxDDE::SurfaceData& toleranced, bool* openFlag);
 
-            // Window visibility state
             bool m_showTolerancedSagWindow{false};
             bool m_showNominalSagWindow{false};
             bool m_showComparisonWindow{false};
             bool m_showErrorWindow{false};
 
-            // Page state
             SagAnalysisState m_surfaceSagAnalysisPageState;
 
         private:
-            ZemaxDDE::ZemaxDDEClient* m_ddeClient;
+            ZemaxDDE::ZemaxDDEClient* getClient() const;
+
+            DDEConnectionManager* m_connectionManager;
             Logger& m_logger;
     };
 }

--- a/src/gui/sag_map_analysis_service.cpp
+++ b/src/gui/sag_map_analysis_service.cpp
@@ -1,0 +1,118 @@
+#include <algorithm>
+#include <cmath>
+#include <format>
+#include <ranges>
+
+#include "sag_map_analysis_service.h"
+#include "logger/logger.h"
+
+namespace {
+    constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
+}
+
+namespace gui {
+    SagMapAnalysisService::SagMapAnalysisService(ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger)
+        : m_ddeClient(ddeClient)
+        , m_logger(logger)
+    {
+    }
+
+    void SagMapAnalysisService::calculateSurfaceMap(int surface, int radialSampling, double angleStepDeg) {
+        if (angleStepDeg <= 0.0 || angleStepDeg > 180.0) {
+            m_logger.addLog("[SagMap] Invalid angle step, must be in range (0, 180]");
+            return;
+        }
+
+        clearData();
+
+        m_logger.addLog(std::format("[SagMap] Calculating surface map for surface {}, sampling={}, angle step={} deg",
+            surface, radialSampling, angleStepDeg));
+
+        m_ddeClient->setStorageTarget(m_ddeClient->getNominalSurface());
+        m_ddeClient->getSurfaceData(surface, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
+        m_ddeClient->getSurfaceData(surface, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
+
+        const ZemaxDDE::SurfaceData* nominalSurface = m_ddeClient->getNominalSurface();
+        if (!nominalSurface->isValid()) {
+            m_logger.addLog("[SagMap] Failed to get nominal surface data");
+            return;
+        }
+
+        double semiDiameter = nominalSurface->semiDiameter;
+        if (semiDiameter <= 0.0) {
+            m_logger.addLog("[SagMap] Invalid semi-diameter");
+            return;
+        }
+
+        double step = nominalSurface->diameter() / (radialSampling - 1);
+        int numAngles = static_cast<int>(180.0 / angleStepDeg) + 1;
+
+        m_ddeClient->setStorageTarget(m_ddeClient->getTolerancedSurface());
+
+        for (int i = 0; i < numAngles; ++i) {
+            double angle = i * angleStepDeg;
+            double rad = angle * DEG_TO_RAD;
+            double cosAngle = std::cos(rad);
+            double sinAngle = std::sin(rad);
+
+            m_ddeClient->getTolerancedSurface()->clear();
+            m_ddeClient->getTolerancedSurface()->id = surface;
+            m_ddeClient->getTolerancedSurface()->units = nominalSurface->units;
+            m_ddeClient->getTolerancedSurface()->semiDiameter = semiDiameter;
+            m_ddeClient->getTolerancedSurface()->type = nominalSurface->type;
+            m_ddeClient->getTolerancedSurface()->fileName = nominalSurface->fileName;
+
+            for (int j : std::views::iota(0, radialSampling)) {
+                double r = -semiDiameter + j * step;
+                double x = r * cosAngle;
+                double y = r * sinAngle;
+                m_ddeClient->getSag(surface, x, y);
+            }
+
+            m_sections.push_back(*m_ddeClient->getTolerancedSurface());
+        }
+
+        m_state.tolerancedSurfaceIndex = surface;
+        m_state.tolerancedSampling = radialSampling;
+        m_state.tolerancedAngleStep = angleStepDeg;
+
+        m_logger.addLog(std::format("[SagMap] Surface map calculated: {} sections", m_sections.size()));
+    }
+
+    std::optional<MaxPVResult> SagMapAnalysisService::findMaxPVSection() const {
+        if (m_sections.empty()) {
+            m_logger.addLog("[SagMap] No data available for Max-PV search");
+            return std::nullopt;
+        }
+
+        MaxPVResult worst;
+        worst.pv = 0.0;
+
+        for (const auto& section : m_sections) {
+            if (section.sagDataPoints.empty()) {
+                continue;
+            }
+
+            double localPeak = -1e100;
+            double localValley = 1e100;
+
+            for (const auto& point : section.sagDataPoints) {
+                localPeak = std::max(localPeak, point.sag);
+                localValley = std::min(localValley, point.sag);
+            }
+
+            double pv = localPeak - localValley;
+            if (pv > worst.pv) {
+                worst.angle = section.angle;
+                worst.peak = localPeak;
+                worst.valley = localValley;
+                worst.pv = pv;
+            }
+        }
+
+        m_logger.addLog(std::format("[SagMap] Max-PV found at {:.2f} deg: Peak={:.6f}, Valley={:.6f}, PV={:.6f}",
+            worst.angle, worst.peak, worst.valley, worst.pv));
+
+        return worst;
+    }
+}

--- a/src/gui/sag_map_analysis_service.cpp
+++ b/src/gui/sag_map_analysis_service.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <format>
 #include "dde/constants.h"
+#include "dde/operation_monitor.h"
 #include "dde/utils.h"
 
 #include "sag_map_analysis_service.h"
@@ -36,6 +37,10 @@ namespace gui {
             return;
         }
 
+        int totalPoints = numRadii * static_cast<int>(360.0 / angleStepDeg);
+        auto* monitor = getMonitor();
+        m_operationId = monitor ? monitor->registerOperation("SagMapAnalysis", totalPoints) : 0;
+
         m_mapState = SagMapState::FetchingSurfaceData;
         m_mapError.clear();
         m_targetSurface = surface;
@@ -44,32 +49,33 @@ namespace gui {
         m_numAngles = static_cast<int>(360.0 / angleStepDeg);
         m_currentRing = 0;
         m_currentAngle = 0;
+        m_skippedPoints = 0;
         m_sections.clear();
-        m_pendingSurfaceRequests = 2;
+        m_surfaceRequestsRemaining = 2;
         m_units = client->getOpticalSystemData().units;
 
-        m_logger.addLog(std::format("[SagMap] Starting async surface map: surface {}, radii={}, angle step={} deg",
-            surface, numRadii, angleStepDeg));
+        m_logger.addLog(std::format("[SagMap] Starting async surface map: surface {}, radii={}, angle step={} deg ({} total points)",
+            surface, numRadii, angleStepDeg, totalPoints));
 
-        client->sendRequest(
+        client->enqueueRequest(
             std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::TYPE_NAME),
             [this](const std::string& result) {
                 onSurfaceDataReceived(ZemaxDDE::SurfaceDataCode::TYPE_NAME, result);
             },
             [this](const std::string& error) {
                 onMapError(std::format("GetSurfaceData(TYPE_NAME): {}", error));
-            }
-        );
+            },
+            2000, 1, "SagMapAnalysis");
 
-        client->sendRequest(
+        client->enqueueRequest(
             std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER),
             [this](const std::string& result) {
                 onSurfaceDataReceived(ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER, result);
             },
             [this](const std::string& error) {
                 onMapError(std::format("GetSurfaceData(SEMI_DIAMETER): {}", error));
-            }
-        );
+            },
+            2000, 1, "SagMapAnalysis");
     }
 
     void SagMapAnalysisService::onSurfaceDataReceived(int code, const std::string& value) {
@@ -90,7 +96,7 @@ namespace gui {
             }
         }
 
-        if (--m_pendingSurfaceRequests > 0) return;
+        if (--m_surfaceRequestsRemaining > 0) return;
 
         if (m_semiDiameter <= 0.0) {
             onMapError("Surface semi-diameter is zero or negative");
@@ -113,6 +119,16 @@ namespace gui {
             m_state.tolerancedSurfaceIndex = m_targetSurface;
             m_state.tolerancedSampling = m_numRadii;
             m_state.tolerancedAngleStep = m_angleStepDeg;
+
+            auto* monitor = getMonitor();
+            if (monitor) {
+                auto msg = m_skippedPoints > 0
+                    ? std::format("Completed ({} rings, {} skipped)", m_sections.size(), m_skippedPoints)
+                    : std::format("Completed ({} rings)", m_sections.size());
+                monitor->reportProgress(m_operationId, m_numRadii * m_numAngles, msg);
+                monitor->onCompleted(m_operationId);
+            }
+
             m_logger.addLog(std::format("[SagMap] Surface map completed: {} rings", m_sections.size()));
             if (onCalculationComplete) onCalculationComplete();
             return;
@@ -130,6 +146,22 @@ namespace gui {
             return;
         }
 
+        auto* monitor = getMonitor();
+        if (monitor && monitor->isCancelled(m_operationId)) {
+            m_mapState = SagMapState::Failed;
+            m_mapError = "Cancelled";
+            monitor->onError(m_operationId, "Cancelled");
+            m_logger.addLog("[SagMap] Map calculation cancelled by user");
+            if (onCalculationComplete) onCalculationComplete();
+            return;
+        }
+
+        if (monitor) {
+            int currentPoint = m_currentRing * m_numAngles + m_currentAngle;
+            monitor->reportProgress(m_operationId, currentPoint,
+                std::format("Ring {}/{} angle {}/{}", m_currentRing + 1, m_numRadii, m_currentAngle, m_numAngles));
+        }
+
         double radiusStep = m_semiDiameter / (m_numRadii - 1);
         double r = m_currentRing * radiusStep;
         double angle = m_currentAngle * m_angleStepDeg;
@@ -143,15 +175,19 @@ namespace gui {
             return;
         }
 
-        client->sendRequest(
+        client->enqueueRequest(
             std::format("GetSag,{},{},{}", m_targetSurface, x, y),
             [this](const std::string& result) {
                 onSagPointReceived(result);
             },
             [this](const std::string& error) {
-                onMapError(std::format("GetSag failed: {}", error));
-            }
-        );
+                if (error == "Timeout") {
+                    onSagTimeout();
+                } else {
+                    onMapError(std::format("GetSag failed: {}", error));
+                }
+            },
+            1000, 1, "SagMapAnalysis");
     }
 
     void SagMapAnalysisService::onSagPointReceived(const std::string& buffer) {
@@ -182,11 +218,33 @@ namespace gui {
         sendNextSagPoint();
     }
 
+    void SagMapAnalysisService::onSagTimeout() {
+        m_logger.addLog(std::format("[SagMap] Point (ring {}, angle {}) timed out, skipping",
+            m_currentRing, m_currentAngle));
+        m_skippedPoints++;
+        m_currentAngle++;
+        sendNextSagPoint();
+    }
+
     void SagMapAnalysisService::onMapError(const std::string& error) {
         m_mapState = SagMapState::Failed;
         m_mapError = error;
+
+        auto* monitor = getMonitor();
+        if (monitor) monitor->onError(m_operationId, error);
+
         m_logger.addLog(std::format("[SagMap] {}", error));
         if (onCalculationComplete) onCalculationComplete();
+    }
+
+    void SagMapAnalysisService::cancelCalculation() {
+        auto* monitor = getMonitor();
+        if (monitor && m_operationId > 0) monitor->requestCancel(m_operationId);
+    }
+
+    ZemaxDDE::OperationMonitor* SagMapAnalysisService::getMonitor() const {
+        auto* client = getClient();
+        return client ? client->getOperationMonitor() : nullptr;
     }
 
     bool SagMapAnalysisService::hasNominalReference() const {

--- a/src/gui/sag_map_analysis_service.cpp
+++ b/src/gui/sag_map_analysis_service.cpp
@@ -17,88 +17,98 @@ namespace gui {
     {
     }
 
-    void SagMapAnalysisService::calculateSurfaceMap(int surface, int radialSampling, double angleStepDeg) {
-        if (angleStepDeg <= 0.0 || angleStepDeg > 180.0) {
-            m_logger.addLog("[SagMap] Invalid angle step, must be in range (0, 180]");
+    void SagMapAnalysisService::calculateSurfaceMap(int surface, int numRadii, double angleStepDeg) {
+        if (angleStepDeg <= 0.0 || angleStepDeg > 360.0) {
+            m_logger.addLog("[SagMap] Invalid angle step, must be in range (0, 360]");
+            return;
+        }
+
+        if (numRadii < 2) {
+            m_logger.addLog("[SagMap] Invalid number of radii, must be >= 2");
             return;
         }
 
         clearData();
 
-        m_logger.addLog(std::format("[SagMap] Calculating surface map for surface {}, sampling={}, angle step={} deg",
-            surface, radialSampling, angleStepDeg));
+        m_logger.addLog(std::format("[SagMap] Calculating surface map for surface {}, radii={}, angle step={} deg",
+            surface, numRadii, angleStepDeg));
 
-        m_ddeClient->setStorageTarget(m_ddeClient->getNominalSurface());
-        m_ddeClient->getSurfaceData(surface, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
-        m_ddeClient->getSurfaceData(surface, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
-
-        const ZemaxDDE::SurfaceData* nominalSurface = m_ddeClient->getNominalSurface();
-        if (!nominalSurface->isValid()) {
-            m_logger.addLog("[SagMap] Failed to get nominal surface data");
+        auto* toleranced = m_ddeClient->getTolerancedSurface();
+        if (!toleranced->isValid() || toleranced->semiDiameter <= 0.0) {
+            m_logger.addLog("[SagMap] Toleranced surface not initialized or invalid");
             return;
         }
 
-        double semiDiameter = nominalSurface->semiDiameter;
-        if (semiDiameter <= 0.0) {
-            m_logger.addLog("[SagMap] Invalid semi-diameter");
-            return;
-        }
+        double semiDiameter = toleranced->semiDiameter;
+        double radiusStep = semiDiameter / (numRadii - 1);
+        int numAngles = static_cast<int>(360.0 / angleStepDeg);
 
-        double step = nominalSurface->diameter() / (radialSampling - 1);
-        int numAngles = static_cast<int>(180.0 / angleStepDeg) + 1;
+        for (int i = 0; i < numRadii; ++i) {
+            double r = i * radiusStep;
 
-        m_ddeClient->setStorageTarget(m_ddeClient->getTolerancedSurface());
+            ZemaxDDE::SurfaceData ring;
+            ring.id = surface;
+            ring.semiDiameter = semiDiameter;
+            ring.units = toleranced->units;
+            ring.type = toleranced->type;
+            ring.fileName = toleranced->fileName;
 
-        for (int i = 0; i < numAngles; ++i) {
-            double angle = i * angleStepDeg;
-            double rad = angle * DEG_TO_RAD;
-            double cosAngle = std::cos(rad);
-            double sinAngle = std::sin(rad);
+            for (int j = 0; j < numAngles; ++j) {
+                double angle = j * angleStepDeg;
+                double rad = angle * DEG_TO_RAD;
+                double x = r * std::cos(rad);
+                double y = r * std::sin(rad);
 
-            m_ddeClient->getTolerancedSurface()->clear();
-            m_ddeClient->getTolerancedSurface()->id = surface;
-            m_ddeClient->getTolerancedSurface()->units = nominalSurface->units;
-            m_ddeClient->getTolerancedSurface()->semiDiameter = semiDiameter;
-            m_ddeClient->getTolerancedSurface()->type = nominalSurface->type;
-            m_ddeClient->getTolerancedSurface()->fileName = nominalSurface->fileName;
-
-            for (int j : std::views::iota(0, radialSampling)) {
-                double r = -semiDiameter + j * step;
-                double x = r * cosAngle;
-                double y = r * sinAngle;
+                toleranced->sagDataPoints.clear();
                 m_ddeClient->getSag(surface, x, y);
+
+                if (!toleranced->sagDataPoints.empty()) {
+                    ring.sagDataPoints.push_back(toleranced->sagDataPoints.back());
+                }
             }
 
-            m_sections.push_back(*m_ddeClient->getTolerancedSurface());
+            m_sections.push_back(ring);
         }
 
         m_state.tolerancedSurfaceIndex = surface;
-        m_state.tolerancedSampling = radialSampling;
+        m_state.tolerancedSampling = numRadii;
         m_state.tolerancedAngleStep = angleStepDeg;
 
-        m_logger.addLog(std::format("[SagMap] Surface map calculated: {} sections", m_sections.size()));
+        m_logger.addLog(std::format("[SagMap] Surface map calculated: {} rings", m_sections.size()));
     }
 
+    // TODO: Re-enable Max-PV analysis
+    /*
     std::optional<MaxPVResult> SagMapAnalysisService::findMaxPVSection() const {
-        if (m_sections.empty()) {
+        if (m_sections.empty() || !hasNominalReference()) {
             m_logger.addLog("[SagMap] No data available for Max-PV search");
+            return std::nullopt;
+        }
+
+        const auto* nominal = m_ddeClient->getNominalSurface();
+        if (nominal->sagDataPoints.empty()) {
+            m_logger.addLog("[SagMap] Nominal reference has no sag data");
             return std::nullopt;
         }
 
         MaxPVResult worst;
         worst.pv = 0.0;
+        worst.angle = 0.0;
+        worst.peak = 0.0;
+        worst.valley = 0.0;
 
         for (const auto& section : m_sections) {
-            if (section.sagDataPoints.empty()) {
+            if (section.sagDataPoints.size() != nominal->sagDataPoints.size()) {
                 continue;
             }
 
             double localPeak = -1e100;
             double localValley = 1e100;
 
-            for (const auto& point : section.sagDataPoints) {
-                localPeak = std::max(localPeak, point.sag);
-                localValley = std::min(localValley, point.sag);
+            for (size_t i = 0; i < section.sagDataPoints.size(); ++i) {
+                double deviation = section.sagDataPoints[i].sag - nominal->sagDataPoints[i].sag;
+                localPeak = std::max(localPeak, deviation);
+                localValley = std::min(localValley, deviation);
             }
 
             double pv = localPeak - localValley;
@@ -115,4 +125,5 @@ namespace gui {
 
         return worst;
     }
+    */
 }

--- a/src/gui/sag_map_analysis_service.cpp
+++ b/src/gui/sag_map_analysis_service.cpp
@@ -1,7 +1,7 @@
-#include <algorithm>
 #include <cmath>
 #include <format>
-#include <ranges>
+#include "dde/constants.h"
+#include "dde/utils.h"
 
 #include "sag_map_analysis_service.h"
 #include "logger/logger.h"
@@ -17,70 +17,176 @@ namespace gui {
     {
     }
 
-    void SagMapAnalysisService::calculateSurfaceMap(int surface, int numRadii, double angleStepDeg) {
+    void SagMapAnalysisService::startAsyncMapCalculation(int surface, int numRadii, double angleStepDeg) {
+        auto* client = getClient();
+        if (!client) {
+            m_mapState = SagMapState::Failed;
+            m_mapError = "No active DDE connection";
+            if (onCalculationComplete) onCalculationComplete();
+            return;
+        }
+
         if (angleStepDeg <= 0.0 || angleStepDeg > 360.0) {
-            m_logger.addLog("[SagMap] Invalid angle step, must be in range (0, 360]");
+            onMapError("Invalid angle step, must be in range (0, 360]");
             return;
         }
 
         if (numRadii < 2) {
-            m_logger.addLog("[SagMap] Invalid number of radii, must be >= 2");
+            onMapError("Invalid number of radii, must be >= 2");
             return;
         }
 
-        clearData();
+        m_mapState = SagMapState::FetchingSurfaceData;
+        m_mapError.clear();
+        m_targetSurface = surface;
+        m_numRadii = numRadii;
+        m_angleStepDeg = angleStepDeg;
+        m_numAngles = static_cast<int>(360.0 / angleStepDeg);
+        m_currentRing = 0;
+        m_currentAngle = 0;
+        m_sections.clear();
+        m_pendingSurfaceRequests = 2;
+        m_units = client->getOpticalSystemData().units;
 
-        m_logger.addLog(std::format("[SagMap] Calculating surface map for surface {}, radii={}, angle step={} deg",
+        m_logger.addLog(std::format("[SagMap] Starting async surface map: surface {}, radii={}, angle step={} deg",
             surface, numRadii, angleStepDeg));
+
+        client->sendRequest(
+            std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::TYPE_NAME),
+            [this](const std::string& result) {
+                onSurfaceDataReceived(ZemaxDDE::SurfaceDataCode::TYPE_NAME, result);
+            },
+            [this](const std::string& error) {
+                onMapError(std::format("GetSurfaceData(TYPE_NAME): {}", error));
+            }
+        );
+
+        client->sendRequest(
+            std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER),
+            [this](const std::string& result) {
+                onSurfaceDataReceived(ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER, result);
+            },
+            [this](const std::string& error) {
+                onMapError(std::format("GetSurfaceData(SEMI_DIAMETER): {}", error));
+            }
+        );
+    }
+
+    void SagMapAnalysisService::onSurfaceDataReceived(int code, const std::string& value) {
+        auto tokens = ZemaxDDE::tokenize(value);
+        if (tokens.empty()) {
+            onMapError(std::format("GetSurfaceData({}): empty response", code));
+            return;
+        }
+
+        if (code == ZemaxDDE::SurfaceDataCode::TYPE_NAME) {
+            // type stored per ring, not needed here
+        } else if (code == ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER) {
+            try {
+                m_semiDiameter = std::stod(tokens[0]);
+            } catch (...) {
+                onMapError("GetSurfaceData(SEMI_DIAMETER): invalid number");
+                return;
+            }
+        }
+
+        if (--m_pendingSurfaceRequests > 0) return;
+
+        if (m_semiDiameter <= 0.0) {
+            onMapError("Surface semi-diameter is zero or negative");
+            return;
+        }
+
+        m_mapState = SagMapState::FetchingSagPoints;
+        m_currentRing = 0;
+        m_currentAngle = 0;
+        m_currentRingData = {};
+        m_currentRingData.id = m_targetSurface;
+        m_currentRingData.semiDiameter = m_semiDiameter;
+        m_currentRingData.units = m_units;
+        sendNextSagPoint();
+    }
+
+    void SagMapAnalysisService::sendNextSagPoint() {
+        if (m_currentRing >= m_numRadii) {
+            m_mapState = SagMapState::Completed;
+            m_state.tolerancedSurfaceIndex = m_targetSurface;
+            m_state.tolerancedSampling = m_numRadii;
+            m_state.tolerancedAngleStep = m_angleStepDeg;
+            m_logger.addLog(std::format("[SagMap] Surface map completed: {} rings", m_sections.size()));
+            if (onCalculationComplete) onCalculationComplete();
+            return;
+        }
+
+        if (m_currentAngle >= m_numAngles) {
+            m_sections.push_back(m_currentRingData);
+            m_currentRing++;
+            m_currentAngle = 0;
+            m_currentRingData = {};
+            m_currentRingData.id = m_targetSurface;
+            m_currentRingData.semiDiameter = m_semiDiameter;
+            m_currentRingData.units = m_units;
+            sendNextSagPoint();
+            return;
+        }
+
+        double radiusStep = m_semiDiameter / (m_numRadii - 1);
+        double r = m_currentRing * radiusStep;
+        double angle = m_currentAngle * m_angleStepDeg;
+        double rad = angle * DEG_TO_RAD;
+        double x = r * std::cos(rad);
+        double y = r * std::sin(rad);
 
         auto* client = getClient();
         if (!client) {
-            m_logger.addLog("[SagMap] No active DDE connection");
+            onMapError("Connection lost during map calculation");
             return;
         }
 
-        auto* toleranced = client->getTolerancedSurface();
-        if (!toleranced->isValid() || toleranced->semiDiameter <= 0.0) {
-            m_logger.addLog("[SagMap] Toleranced surface not initialized or invalid");
-            return;
-        }
-
-        double semiDiameter = toleranced->semiDiameter;
-        double radiusStep = semiDiameter / (numRadii - 1);
-        int numAngles = static_cast<int>(360.0 / angleStepDeg);
-
-        for (int i = 0; i < numRadii; ++i) {
-            double r = i * radiusStep;
-
-            ZemaxDDE::SurfaceData ring;
-            ring.id = surface;
-            ring.semiDiameter = semiDiameter;
-            ring.units = toleranced->units;
-            ring.type = toleranced->type;
-            ring.fileName = toleranced->fileName;
-
-            for (int j = 0; j < numAngles; ++j) {
-                double angle = j * angleStepDeg;
-                double rad = angle * DEG_TO_RAD;
-                double x = r * std::cos(rad);
-                double y = r * std::sin(rad);
-
-                toleranced->sagDataPoints.clear();
-                client->getSag(surface, x, y);
-
-                if (!toleranced->sagDataPoints.empty()) {
-                    ring.sagDataPoints.push_back(toleranced->sagDataPoints.back());
-                }
+        client->sendRequest(
+            std::format("GetSag,{},{},{}", m_targetSurface, x, y),
+            [this](const std::string& result) {
+                onSagPointReceived(result);
+            },
+            [this](const std::string& error) {
+                onMapError(std::format("GetSag failed: {}", error));
             }
+        );
+    }
 
-            m_sections.push_back(ring);
+    void SagMapAnalysisService::onSagPointReceived(const std::string& buffer) {
+        auto tokens = ZemaxDDE::tokenize(buffer);
+        if (tokens.size() < 2) {
+            onMapError("GetSag: invalid response format");
+            return;
         }
 
-        m_state.tolerancedSurfaceIndex = surface;
-        m_state.tolerancedSampling = numRadii;
-        m_state.tolerancedAngleStep = angleStepDeg;
+        double radiusStep = m_semiDiameter / (m_numRadii - 1);
+        double r = m_currentRing * radiusStep;
+        double angle = m_currentAngle * m_angleStepDeg;
+        double rad = angle * DEG_TO_RAD;
 
-        m_logger.addLog(std::format("[SagMap] Surface map calculated: {} rings", m_sections.size()));
+        try {
+            ZemaxDDE::SagData point;
+            point.x = r * std::cos(rad);
+            point.y = r * std::sin(rad);
+            point.sag = std::stod(tokens[0]);
+            point.alternateSag = std::stod(tokens[1]);
+            m_currentRingData.sagDataPoints.push_back(point);
+        } catch (...) {
+            onMapError("GetSag: failed to parse sag values");
+            return;
+        }
+
+        m_currentAngle++;
+        sendNextSagPoint();
+    }
+
+    void SagMapAnalysisService::onMapError(const std::string& error) {
+        m_mapState = SagMapState::Failed;
+        m_mapError = error;
+        m_logger.addLog(std::format("[SagMap] {}", error));
+        if (onCalculationComplete) onCalculationComplete();
     }
 
     bool SagMapAnalysisService::hasNominalReference() const {
@@ -91,54 +197,4 @@ namespace gui {
     const ZemaxDDE::SurfaceData& SagMapAnalysisService::getNominalReference() const {
         return *getClient()->getNominalSurface();
     }
-
-    // TODO: Re-enable Max-PV analysis
-    /*
-    std::optional<MaxPVResult> SagMapAnalysisService::findMaxPVSection() const {
-        if (m_sections.empty() || !hasNominalReference()) {
-            m_logger.addLog("[SagMap] No data available for Max-PV search");
-            return std::nullopt;
-        }
-
-        const auto* nominal = getClient()->getNominalSurface();
-        if (nominal->sagDataPoints.empty()) {
-            m_logger.addLog("[SagMap] Nominal reference has no sag data");
-            return std::nullopt;
-        }
-
-        MaxPVResult worst;
-        worst.pv = 0.0;
-        worst.angle = 0.0;
-        worst.peak = 0.0;
-        worst.valley = 0.0;
-
-        for (const auto& section : m_sections) {
-            if (section.sagDataPoints.size() != nominal->sagDataPoints.size()) {
-                continue;
-            }
-
-            double localPeak = -1e100;
-            double localValley = 1e100;
-
-            for (size_t i = 0; i < section.sagDataPoints.size(); ++i) {
-                double deviation = section.sagDataPoints[i].sag - nominal->sagDataPoints[i].sag;
-                localPeak = std::max(localPeak, deviation);
-                localValley = std::min(localValley, deviation);
-            }
-
-            double pv = localPeak - localValley;
-            if (pv > worst.pv) {
-                worst.angle = section.angle;
-                worst.peak = localPeak;
-                worst.valley = localValley;
-                worst.pv = pv;
-            }
-        }
-
-        m_logger.addLog(std::format("[SagMap] Max-PV found at {:.2f} deg: Peak={:.6f}, Valley={:.6f}, PV={:.6f}",
-            worst.angle, worst.peak, worst.valley, worst.pv));
-
-        return worst;
-    }
-    */
 }

--- a/src/gui/sag_map_analysis_service.cpp
+++ b/src/gui/sag_map_analysis_service.cpp
@@ -11,8 +11,8 @@ namespace {
 }
 
 namespace gui {
-    SagMapAnalysisService::SagMapAnalysisService(ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger)
-        : m_ddeClient(ddeClient)
+    SagMapAnalysisService::SagMapAnalysisService(DDEConnectionManager* connectionManager, Logger& logger)
+        : m_connectionManager(connectionManager)
         , m_logger(logger)
     {
     }
@@ -33,7 +33,13 @@ namespace gui {
         m_logger.addLog(std::format("[SagMap] Calculating surface map for surface {}, radii={}, angle step={} deg",
             surface, numRadii, angleStepDeg));
 
-        auto* toleranced = m_ddeClient->getTolerancedSurface();
+        auto* client = getClient();
+        if (!client) {
+            m_logger.addLog("[SagMap] No active DDE connection");
+            return;
+        }
+
+        auto* toleranced = client->getTolerancedSurface();
         if (!toleranced->isValid() || toleranced->semiDiameter <= 0.0) {
             m_logger.addLog("[SagMap] Toleranced surface not initialized or invalid");
             return;
@@ -60,7 +66,7 @@ namespace gui {
                 double y = r * std::sin(rad);
 
                 toleranced->sagDataPoints.clear();
-                m_ddeClient->getSag(surface, x, y);
+                client->getSag(surface, x, y);
 
                 if (!toleranced->sagDataPoints.empty()) {
                     ring.sagDataPoints.push_back(toleranced->sagDataPoints.back());
@@ -77,6 +83,15 @@ namespace gui {
         m_logger.addLog(std::format("[SagMap] Surface map calculated: {} rings", m_sections.size()));
     }
 
+    bool SagMapAnalysisService::hasNominalReference() const {
+        auto* client = getClient();
+        return client && client->getNominalSurface()->isValid();
+    }
+
+    const ZemaxDDE::SurfaceData& SagMapAnalysisService::getNominalReference() const {
+        return *getClient()->getNominalSurface();
+    }
+
     // TODO: Re-enable Max-PV analysis
     /*
     std::optional<MaxPVResult> SagMapAnalysisService::findMaxPVSection() const {
@@ -85,7 +100,7 @@ namespace gui {
             return std::nullopt;
         }
 
-        const auto* nominal = m_ddeClient->getNominalSurface();
+        const auto* nominal = getClient()->getNominalSurface();
         if (nominal->sagDataPoints.empty()) {
             m_logger.addLog("[SagMap] Nominal reference has no sag data");
             return std::nullopt;

--- a/src/gui/sag_map_analysis_service.h
+++ b/src/gui/sag_map_analysis_service.h
@@ -10,6 +10,10 @@
 
 class Logger;
 
+namespace ZemaxDDE {
+    class OperationMonitor;
+}
+
 namespace gui {
 
     enum class SagMapState {
@@ -53,15 +57,25 @@ namespace gui {
 
             SagMapState getMapState() const { return m_mapState; }
             const std::string& getMapError() const { return m_mapError; }
+
+            uint64_t getOperationId() const { return m_operationId; }
+            int getTotalSteps() const { return m_numRadii * m_numAngles; }
+            int getCurrentStep() const { return m_currentRing * m_numAngles + m_currentAngle; }
+            int getSkippedPoints() const { return m_skippedPoints; }
+
+            void cancelCalculation();
+
             std::function<void()> onCalculationComplete;
 
             SagMapAnalysisState m_state;
 
         private:
             ZemaxDDE::ZemaxDDEClient* getClient() const { return m_connectionManager ? m_connectionManager->getActiveClient() : nullptr; }
+            ZemaxDDE::OperationMonitor* getMonitor() const;
             void sendNextSagPoint();
             void onSurfaceDataReceived(int code, const std::string& value);
             void onSagPointReceived(const std::string& buffer);
+            void onSagTimeout();
             void onMapError(const std::string& error);
 
             DDEConnectionManager* m_connectionManager;
@@ -78,7 +92,9 @@ namespace gui {
             int m_numAngles = 0;
             double m_semiDiameter = 0.0;
             int m_units = 0;
-            int m_pendingSurfaceRequests = 0;
+            int m_surfaceRequestsRemaining = 0;
+            uint64_t m_operationId = 0;
+            int m_skippedPoints = 0;
 
             int m_currentRing = 0;
             int m_currentAngle = 0;

--- a/src/gui/sag_map_analysis_service.h
+++ b/src/gui/sag_map_analysis_service.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <functional>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "dde/dde_connection_manager.h"
@@ -9,6 +11,15 @@
 class Logger;
 
 namespace gui {
+
+    enum class SagMapState {
+        Idle,
+        FetchingSurfaceData,
+        FetchingSagPoints,
+        Completed,
+        Failed
+    };
+
     struct SagMapAnalysisState {
         int nominalSurfaceIndex = 0;
         int nominalSampling = 128;
@@ -30,7 +41,7 @@ namespace gui {
         public:
             SagMapAnalysisService(DDEConnectionManager* connectionManager, Logger& logger);
 
-            void calculateSurfaceMap(int surface, int numRadii, double angleStepDeg);
+            void startAsyncMapCalculation(int surface, int numRadii, double angleStepDeg);
 
             bool hasNominalReference() const;
             const ZemaxDDE::SurfaceData& getNominalReference() const;
@@ -40,14 +51,37 @@ namespace gui {
 
             const std::vector<ZemaxDDE::SurfaceData>& getSections() const { return m_sections; }
 
+            SagMapState getMapState() const { return m_mapState; }
+            const std::string& getMapError() const { return m_mapError; }
+            std::function<void()> onCalculationComplete;
+
             SagMapAnalysisState m_state;
 
         private:
             ZemaxDDE::ZemaxDDEClient* getClient() const { return m_connectionManager ? m_connectionManager->getActiveClient() : nullptr; }
+            void sendNextSagPoint();
+            void onSurfaceDataReceived(int code, const std::string& value);
+            void onSagPointReceived(const std::string& buffer);
+            void onMapError(const std::string& error);
 
             DDEConnectionManager* m_connectionManager;
             Logger& m_logger;
 
             std::vector<ZemaxDDE::SurfaceData> m_sections;
+
+            SagMapState m_mapState = SagMapState::Idle;
+            std::string m_mapError;
+
+            int m_targetSurface = 0;
+            int m_numRadii = 0;
+            double m_angleStepDeg = 0.0;
+            int m_numAngles = 0;
+            double m_semiDiameter = 0.0;
+            int m_units = 0;
+            int m_pendingSurfaceRequests = 0;
+
+            int m_currentRing = 0;
+            int m_currentAngle = 0;
+            ZemaxDDE::SurfaceData m_currentRingData;
     };
 }

--- a/src/gui/sag_map_analysis_service.h
+++ b/src/gui/sag_map_analysis_service.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "dde/client.h"
+
+class Logger;
+
+namespace gui {
+    struct SagMapAnalysisState {
+        int nominalSurfaceIndex = 0;
+        int nominalSampling = 128;
+        double nominalAngle = 0.0;
+
+        int tolerancedSurfaceIndex = 0;
+        int tolerancedSampling = 128;
+        double tolerancedAngleStep = 1.0;
+    };
+
+    struct MaxPVResult {
+        double angle;
+        double peak;
+        double valley;
+        double pv;
+    };
+
+    class SagMapAnalysisService {
+        public:
+            SagMapAnalysisService(ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger);
+
+            void calculateSurfaceMap(int surface, int radialSampling, double angleStepDeg);
+            std::optional<MaxPVResult> findMaxPVSection() const;
+
+            bool hasData() const { return !m_sections.empty(); }
+            void clearData() { m_sections.clear(); }
+
+            const std::vector<ZemaxDDE::SurfaceData>& getSections() const { return m_sections; }
+
+            SagMapAnalysisState m_state;
+
+        private:
+            ZemaxDDE::ZemaxDDEClient* m_ddeClient;
+            Logger& m_logger;
+
+            std::vector<ZemaxDDE::SurfaceData> m_sections;
+    };
+}

--- a/src/gui/sag_map_analysis_service.h
+++ b/src/gui/sag_map_analysis_service.h
@@ -29,8 +29,12 @@ namespace gui {
         public:
             SagMapAnalysisService(ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger);
 
-            void calculateSurfaceMap(int surface, int radialSampling, double angleStepDeg);
-            std::optional<MaxPVResult> findMaxPVSection() const;
+            void calculateSurfaceMap(int surface, int numRadii, double angleStepDeg);
+            // TODO: Re-enable Max-PV analysis
+            // std::optional<MaxPVResult> findMaxPVSection() const;
+
+            bool hasNominalReference() const { return m_ddeClient->getNominalSurface()->isValid(); }
+            const ZemaxDDE::SurfaceData& getNominalReference() const { return *m_ddeClient->getNominalSurface(); }
 
             bool hasData() const { return !m_sections.empty(); }
             void clearData() { m_sections.clear(); }

--- a/src/gui/sag_map_analysis_service.h
+++ b/src/gui/sag_map_analysis_service.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <vector>
 
+#include "dde/dde_connection_manager.h"
 #include "dde/client.h"
 
 class Logger;
@@ -27,14 +28,12 @@ namespace gui {
 
     class SagMapAnalysisService {
         public:
-            SagMapAnalysisService(ZemaxDDE::ZemaxDDEClient* ddeClient, Logger& logger);
+            SagMapAnalysisService(DDEConnectionManager* connectionManager, Logger& logger);
 
             void calculateSurfaceMap(int surface, int numRadii, double angleStepDeg);
-            // TODO: Re-enable Max-PV analysis
-            // std::optional<MaxPVResult> findMaxPVSection() const;
 
-            bool hasNominalReference() const { return m_ddeClient->getNominalSurface()->isValid(); }
-            const ZemaxDDE::SurfaceData& getNominalReference() const { return *m_ddeClient->getNominalSurface(); }
+            bool hasNominalReference() const;
+            const ZemaxDDE::SurfaceData& getNominalReference() const;
 
             bool hasData() const { return !m_sections.empty(); }
             void clearData() { m_sections.clear(); }
@@ -44,7 +43,9 @@ namespace gui {
             SagMapAnalysisState m_state;
 
         private:
-            ZemaxDDE::ZemaxDDEClient* m_ddeClient;
+            ZemaxDDE::ZemaxDDEClient* getClient() const { return m_connectionManager ? m_connectionManager->getActiveClient() : nullptr; }
+
+            DDEConnectionManager* m_connectionManager;
             Logger& m_logger;
 
             std::vector<ZemaxDDE::SurfaceData> m_sections;

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -56,4 +56,12 @@ namespace gui {
         ImVec2 center = ImGui::GetMainViewport()->GetCenter();
         ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
     }
+
+    void SetDpiScaledWindowConstraints(float minWidth, float minHeight) {
+        float dpiScale = ImGui::GetWindowDpiScale();
+        ImGui::SetNextWindowSizeConstraints(
+            ImVec2(minWidth * dpiScale, minHeight * dpiScale),
+            ImVec2(FLT_MAX, FLT_MAX)
+        );
+    }
 }

--- a/src/gui/utils.h
+++ b/src/gui/utils.h
@@ -9,5 +9,6 @@ namespace gui {
     const char* getRayAimingTypeString(int rayAimingType);
     void HelpMarker(const char* desc);
     void SetPopupWindowPosition();
+    void SetDpiScaledWindowConstraints(float minWidth, float minHeight);
     std::optional<std::filesystem::path> writeToTemporaryFile(const std::string& filename, const std::string& content);
 }

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -1,35 +1,90 @@
-#include <stdexcept>
+#include <format>
+
 #include "windows_dockable/dde_status.h"
-#include "gui/gui.h"
 #include "gui/constants.h"
+#include "app/zemax_window_enumerator.h"
 #include "lib/imgui/imgui.h"
 #include "logger/logger.h"
 
 namespace gui {
     void DDEStatus::render(Logger& logger) {
+        if (!m_connectionManager) return;
+
         ImGui::BeginChild("DDE Status Content",
             ImVec2(gui::DDE_STATUS_CONTENT_WIDTH, gui::DDE_STATUS_CONTENT_HEIGHT),
             ImGuiChildFlags_Borders,
             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse
         );
 
-        const char* label = "Zemax DDE Status:";
-        const char* value = m_ddeClient && m_ddeClient->isConnected() ? "Connected" : "Disconnected";
+        int connectionCount = 0;
+        for (int i = 0; i < DDEConnectionManager::MAX_CONNECTIONS; ++i) {
+            auto* conn = m_connectionManager->getConnection(i);
+            if (conn && conn->isConnected) ++connectionCount;
+        }
+        int activeIdx = m_connectionManager->getActiveIndex();
 
-        float availableWidth = ImGui::GetContentRegionAvail().x;
-        float labelWidth = ImGui::CalcTextSize(label).x;
-        float valueWidth = ImGui::CalcTextSize(value).x;
-        float totalWidth = labelWidth + valueWidth + 4.0f;
-        float offsetX = (availableWidth - totalWidth) * 0.5f;
-        if (offsetX > 0.0f) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + offsetX);
+        // --- Connection status indicator ---
+        {
+            const bool connected = (activeIdx >= 0);
+            const char* label = "Zemax DDE Status:";
+            const char* value = connected ? "Connected" : "Disconnected";
 
-        ImGui::TextUnformatted(label);
-        ImGui::SameLine(0.0f, 4.0f);
+            float availableWidth = ImGui::GetContentRegionAvail().x;
+            float labelWidth = ImGui::CalcTextSize(label).x;
+            float valueWidth = ImGui::CalcTextSize(value).x;
+            float totalWidth = labelWidth + valueWidth + 4.0f;
+            float offsetX = (availableWidth - totalWidth) * 0.5f;
+            if (offsetX > 0.0f) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + offsetX);
 
-        bool connected = m_ddeClient && m_ddeClient->isConnected();
-        ImGui::PushStyleColor(ImGuiCol_Text, connected ? gui::DDE_STATUS_COLOR_CONNECTED : gui::DDE_STATUS_COLOR_DISCONNECTED);
-        ImGui::TextUnformatted(value);
-        ImGui::PopStyleColor();
+            ImGui::TextUnformatted(label);
+            ImGui::SameLine(0.0f, 4.0f);
+
+            ImGui::PushStyleColor(ImGuiCol_Text, connected ? gui::DDE_STATUS_COLOR_CONNECTED : gui::DDE_STATUS_COLOR_DISCONNECTED);
+            ImGui::TextUnformatted(value);
+            ImGui::PopStyleColor();
+        }
+
+        // --- Active target dropdown (only when connected) ---
+        if (connectionCount > 0) {
+            ImGui::Separator();
+            ImGui::Text("Active Target:");
+
+            std::string preview;
+            for (int i = 0; i < DDEConnectionManager::MAX_CONNECTIONS; ++i) {
+                auto* conn = m_connectionManager->getConnection(i);
+                if (!conn || !conn->isConnected) continue;
+                std::string title(conn->serverTitle.begin(), conn->serverTitle.end());
+                std::string itemLabel = std::format("[{}] {}", i, title);
+                if (i == activeIdx) {
+                    preview = itemLabel;
+                }
+            }
+
+            ImGui::SetNextItemWidth(-1.0f);
+            if (ImGui::BeginCombo("##TargetCombo", preview.c_str())) {
+                for (int i = 0; i < DDEConnectionManager::MAX_CONNECTIONS; ++i) {
+                    auto* conn = m_connectionManager->getConnection(i);
+                    if (!conn || !conn->isConnected) continue;
+                    std::string title(conn->serverTitle.begin(), conn->serverTitle.end());
+                    std::string itemLabel = std::format("[{}] {}", i, title);
+
+                    bool isSelected = (i == activeIdx);
+                    if (ImGui::Selectable(itemLabel.c_str(), isSelected)) {
+                        m_connectionManager->setActiveConnection(i);
+                        logger.addLog(std::format("[DDE] Switched active target to [{}] {}", i, title));
+                    }
+                    if (isSelected) {
+                        ImGui::SetItemDefaultFocus();
+                    }
+                }
+                ImGui::EndCombo();
+            }
+        }
+
+        ImGui::Separator();
+
+        // --- Connect / Disconnect button ---
+        bool connected = (activeIdx >= 0);
 
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(-1.0f, 4.0f));
         ImGui::PushStyleColor(ImGuiCol_Button, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_NORMAL : gui::DDE_BUTTON_CONNECT_COLOR_NORMAL);
@@ -37,19 +92,12 @@ namespace gui {
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_ACTIVE : gui::DDE_BUTTON_CONNECT_COLOR_ACTIVE);
         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.5f, 0.5f));
 
-        if (ImGui::Button(connected ? "Disconnect from Zemax" : "Connect to Zemax", ImVec2(-1.0f, 0.0f))) {
-            try {
-                if (!connected) {
-                    m_ddeClient->initiateDDE();
-                } else {
-                    m_ddeClient->terminateDDE();
-                }
-                
-                #ifdef DEBUG_LOG
-                logger.addLog("[GUI] " + std::string(connected ? "Connected to Zemax" : "Disconnected from Zemax"));
-                #endif
-            } catch (const std::runtime_error& e) {
-                logger.addLog("[GUI] DDE connection failed: " + std::string(e.what()));
+        if (ImGui::Button(connected ? "Disconnect" : "Connect to Zemax...", ImVec2(-1.0f, 0.0f))) {
+            if (connected) {
+                m_connectionManager->disconnect(activeIdx);
+                logger.addLog("[DDE] Disconnected from Zemax");
+            } else {
+                m_showConnectPopup = true;
             }
         }
 
@@ -58,5 +106,85 @@ namespace gui {
         ImGui::PopStyleVar();
 
         ImGui::EndChild();
+
+        // --- Connect popup ---
+        if (m_showConnectPopup) {
+            renderConnectPopup(logger);
+        }
+    }
+
+    void DDEStatus::renderConnectPopup(Logger& logger) {
+        ImGui::OpenPopup("Connect to Zemax");
+        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+        ImGui::SetNextWindowSize(ImVec2(500, 300), ImGuiCond_Appearing);
+
+        if (ImGui::BeginPopupModal("Connect to Zemax", &m_showConnectPopup, ImGuiWindowFlags_NoResize)) {
+            ImGui::TextWrapped("Select a Zemax window to connect to:");
+
+            ImGui::Separator();
+
+            // Refresh button
+            if (ImGui::Button("Refresh")) {
+                m_selectedWindowIndex = -1;
+            }
+
+            ImGui::SameLine();
+
+            // Scan & list windows
+            auto windows = app::ZemaxWindowEnumerator::enumerate();
+
+            ImGui::BeginChild("ZemaxWindowList", ImVec2(0, -ImGui::GetFrameHeightWithSpacing() - 10), ImGuiChildFlags_Borders);
+
+            for (size_t i = 0; i < windows.size(); ++i) {
+                const auto& wnd = windows[i];
+                std::string title(wnd.title.begin(), wnd.title.end());
+                std::string label = std::format("{} (PID: {})", title, wnd.pid);
+
+                if (ImGui::Selectable(label.c_str(), m_selectedWindowIndex == static_cast<int>(i))) {
+                    m_selectedWindowIndex = static_cast<int>(i);
+                }
+            }
+
+            if (windows.empty()) {
+                ImGui::TextDisabled("No Zemax windows found");
+            }
+
+            ImGui::EndChild();
+
+            // Bottom buttons
+            bool canConnect = (m_selectedWindowIndex >= 0 && m_selectedWindowIndex < static_cast<int>(windows.size()));
+
+            if (!canConnect) {
+                ImGui::BeginDisabled();
+            }
+
+            if (ImGui::Button("Connect", ImVec2(120, 0))) {
+                const auto& wnd = windows[m_selectedWindowIndex];
+                int slot = m_connectionManager->connectToZemax(wnd.hwnd, wnd.title);
+                if (slot >= 0) {
+                    std::string title(wnd.title.begin(), wnd.title.end());
+                    logger.addLog(std::format("[DDE] Connected to Zemax: {} (PID: {})", title, wnd.pid));
+                    m_showConnectPopup = false;
+                    m_selectedWindowIndex = -1;
+                } else {
+                    std::string title(wnd.title.begin(), wnd.title.end());
+                    logger.addLog(std::format("[DDE] Failed to connect to: {}", title));
+                }
+            }
+
+            if (!canConnect) {
+                ImGui::EndDisabled();
+            }
+
+            ImGui::SameLine();
+
+            if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+                m_showConnectPopup = false;
+                m_selectedWindowIndex = -1;
+            }
+
+            ImGui::EndPopup();
+        }
     }
 }

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -2,7 +2,6 @@
 
 #include "windows_dockable/dde_status.h"
 #include "gui/constants.h"
-#include "app/zemax_window_enumerator.h"
 #include "lib/imgui/imgui.h"
 #include "logger/logger.h"
 
@@ -23,7 +22,6 @@ namespace gui {
         }
         int activeIdx = m_connectionManager->getActiveIndex();
 
-        // --- Connection status indicator ---
         {
             const bool connected = (activeIdx >= 0);
             const char* label = "Zemax DDE Status:";
@@ -44,7 +42,6 @@ namespace gui {
             ImGui::PopStyleColor();
         }
 
-        // --- Active target dropdown (only when connected) ---
         if (connectionCount > 0) {
             ImGui::Separator();
             ImGui::Text("Active Target:");
@@ -77,13 +74,20 @@ namespace gui {
                         ImGui::SetItemDefaultFocus();
                     }
                 }
+
+                if (connectionCount < DDEConnectionManager::MAX_CONNECTIONS) {
+                    ImGui::Separator();
+                    if (ImGui::Selectable("+ Connect to another Zemax...")) {
+                        m_showConnectPopup = true;
+                    }
+                }
+
                 ImGui::EndCombo();
             }
         }
 
         ImGui::Separator();
 
-        // --- Connect / Disconnect button ---
         bool connected = (activeIdx >= 0);
 
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(-1.0f, 4.0f));
@@ -92,7 +96,7 @@ namespace gui {
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_ACTIVE : gui::DDE_BUTTON_CONNECT_COLOR_ACTIVE);
         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.5f, 0.5f));
 
-        if (ImGui::Button(connected ? "Disconnect" : "Connect to Zemax...", ImVec2(-1.0f, 0.0f))) {
+        if (ImGui::Button(connected ? "Disconnect from Zemax" : "Connect to Zemax", ImVec2(-1.0f, 0.0f))) {
             if (connected) {
                 m_connectionManager->disconnect(activeIdx);
                 logger.addLog("[DDE] Disconnected from Zemax");
@@ -107,84 +111,8 @@ namespace gui {
 
         ImGui::EndChild();
 
-        // --- Connect popup ---
-        if (m_showConnectPopup) {
-            renderConnectPopup(logger);
-        }
-    }
-
-    void DDEStatus::renderConnectPopup(Logger& logger) {
-        ImGui::OpenPopup("Connect to Zemax");
-        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-        ImGui::SetNextWindowSize(ImVec2(500, 300), ImGuiCond_Appearing);
-
-        if (ImGui::BeginPopupModal("Connect to Zemax", &m_showConnectPopup, ImGuiWindowFlags_NoResize)) {
-            ImGui::TextWrapped("Select a Zemax window to connect to:");
-
-            ImGui::Separator();
-
-            // Refresh button
-            if (ImGui::Button("Refresh")) {
-                m_selectedWindowIndex = -1;
-            }
-
-            ImGui::SameLine();
-
-            // Scan & list windows
-            auto windows = app::ZemaxWindowEnumerator::enumerate();
-
-            ImGui::BeginChild("ZemaxWindowList", ImVec2(0, -ImGui::GetFrameHeightWithSpacing() - 10), ImGuiChildFlags_Borders);
-
-            for (size_t i = 0; i < windows.size(); ++i) {
-                const auto& wnd = windows[i];
-                std::string title(wnd.title.begin(), wnd.title.end());
-                std::string label = std::format("{} (PID: {})", title, wnd.pid);
-
-                if (ImGui::Selectable(label.c_str(), m_selectedWindowIndex == static_cast<int>(i))) {
-                    m_selectedWindowIndex = static_cast<int>(i);
-                }
-            }
-
-            if (windows.empty()) {
-                ImGui::TextDisabled("No Zemax windows found");
-            }
-
-            ImGui::EndChild();
-
-            // Bottom buttons
-            bool canConnect = (m_selectedWindowIndex >= 0 && m_selectedWindowIndex < static_cast<int>(windows.size()));
-
-            if (!canConnect) {
-                ImGui::BeginDisabled();
-            }
-
-            if (ImGui::Button("Connect", ImVec2(120, 0))) {
-                const auto& wnd = windows[m_selectedWindowIndex];
-                int slot = m_connectionManager->connectToZemax(wnd.hwnd, wnd.title);
-                if (slot >= 0) {
-                    std::string title(wnd.title.begin(), wnd.title.end());
-                    logger.addLog(std::format("[DDE] Connected to Zemax: {} (PID: {})", title, wnd.pid));
-                    m_showConnectPopup = false;
-                    m_selectedWindowIndex = -1;
-                } else {
-                    std::string title(wnd.title.begin(), wnd.title.end());
-                    logger.addLog(std::format("[DDE] Failed to connect to: {}", title));
-                }
-            }
-
-            if (!canConnect) {
-                ImGui::EndDisabled();
-            }
-
-            ImGui::SameLine();
-
-            if (ImGui::Button("Cancel", ImVec2(120, 0))) {
-                m_showConnectPopup = false;
-                m_selectedWindowIndex = -1;
-            }
-
-            ImGui::EndPopup();
+        if (m_showConnectPopup && m_connectPopup) {
+            m_connectPopup->render(m_showConnectPopup, logger);
         }
     }
 }

--- a/src/gui/windows_dockable/dde_status.h
+++ b/src/gui/windows_dockable/dde_status.h
@@ -1,23 +1,23 @@
 #pragma once
 
+#include <memory>
+
 #include "gui/constants.h"
+#include "gui/popups/connect_dde.h"
 #include "dde/dde_connection_manager.h"
 
 namespace gui {
     class DDEStatus {
     public:
         explicit DDEStatus(DDEConnectionManager* connectionManager)
-            : m_connectionManager(connectionManager) {}
+            : m_connectionManager(connectionManager)
+            , m_connectPopup(std::make_unique<ConnectDDEPopup>(connectionManager)) {}
 
         void render(Logger& logger);
 
     private:
-        void renderConnectPopup(Logger& logger);
-        void renderChangeTargetPopup(Logger& logger);
-
         DDEConnectionManager* m_connectionManager;
+        std::unique_ptr<ConnectDDEPopup> m_connectPopup;
         bool m_showConnectPopup = false;
-        int m_selectedTargetIndex = -1;
-        int m_selectedWindowIndex = -1;
     };
 }

--- a/src/gui/windows_dockable/dde_status.h
+++ b/src/gui/windows_dockable/dde_status.h
@@ -1,19 +1,23 @@
 #pragma once
 
-#include <functional>
-
 #include "gui/constants.h"
-#include "logger/logger.h"
-#include "dde/client.h"
-
-class ZemaxDDEClient;
+#include "dde/dde_connection_manager.h"
 
 namespace gui {
     class DDEStatus {
     public:
-        DDEStatus(ZemaxDDE::ZemaxDDEClient* ddeClient) : m_ddeClient(ddeClient) {}
+        explicit DDEStatus(DDEConnectionManager* connectionManager)
+            : m_connectionManager(connectionManager) {}
+
         void render(Logger& logger);
+
     private:
-        ZemaxDDE::ZemaxDDEClient* m_ddeClient;
+        void renderConnectPopup(Logger& logger);
+        void renderChangeTargetPopup(Logger& logger);
+
+        DDEConnectionManager* m_connectionManager;
+        bool m_showConnectPopup = false;
+        int m_selectedTargetIndex = -1;
+        int m_selectedWindowIndex = -1;
     };
 }

--- a/src/gui/windows_dockable/surface_map_analysis.cpp
+++ b/src/gui/windows_dockable/surface_map_analysis.cpp
@@ -35,6 +35,7 @@ namespace {
 
 namespace gui {
     void GuiManager::renderSurfaceMapAnalysis() {
+        if (!m_zemaxDDEClient) return;
         auto& state = m_sagMapService->m_state;
 
         ImGui::SeparatorText("Nominal surface parameters");

--- a/src/gui/windows_dockable/surface_map_analysis.cpp
+++ b/src/gui/windows_dockable/surface_map_analysis.cpp
@@ -1,11 +1,18 @@
 #include <algorithm>
+#include <cmath>
 #include <format>
+#include <vector>
+#include <numbers>
 
 #include "gui/gui.h"
 #include "gui/constants.h"
 #include "lib/imgui/imgui.h"
+#include "lib/implot/implot.h"
+#include "lib/implot3d/implot3d.h"
 
 namespace {
+    constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
+
     std::string getSamplingTooltip() {
         return std::format(
             "Number of points to sample along the surface diameter (min={}, max={}).\n"
@@ -15,8 +22,9 @@ namespace {
     }
 
     std::string getAngleStepTooltip() {
-        return "Angular step between cross sections in degrees (0-180).\n"
-               "Smaller step = more detailed map, slower calculation.";
+        return "Angular step between points on each ring in degrees.\n"
+               "Full circle: 0° to 360°.\n"
+               "Smaller step = more detailed surface, slower calculation.";
     }
 
     std::string getAngleTooltip() {
@@ -26,13 +34,7 @@ namespace {
 
 namespace gui {
     void GuiManager::renderSurfaceMapAnalysis() {
-        static int nominalSurfaceIndex = 0;
-        static int nominalSampling = 128;
-        static double nominalAngle = 0.0;
-
-        static int tolerancedSurfaceIndex = 0;
-        static int tolerancedSampling = 128;
-        static double tolerancedAngleStep = 1.0;
+        auto& state = m_sagMapService->m_state;
 
         ImGui::SeparatorText("Nominal surface parameters");
 
@@ -48,31 +50,37 @@ namespace gui {
         ImGui::Text("Surface number:");
         ImGui::SameLine();
         ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
-        ImGui::InputInt("##nominal_surf_num", &nominalSurfaceIndex, 1, 10);
-        nominalSurfaceIndex = std::max(0, std::min(m_zemaxDDEClient->getOpticalSystemData().numSurfs, nominalSurfaceIndex));
+        ImGui::InputInt("##nominal_surf_num", &state.nominalSurfaceIndex, 1, 10);
+        state.nominalSurfaceIndex = std::max(0, std::min(m_zemaxDDEClient->getOpticalSystemData().numSurfs, state.nominalSurfaceIndex));
 
         ImGui::Text("Sampling:");
         ImGui::SameLine();
         ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
-        ImGui::InputInt("##nominal_sampling", &nominalSampling, 10, 50);
-        nominalSampling = std::max(gui::MIN_SAMPLING, std::min(gui::MAX_SAMPLING, nominalSampling));
+        ImGui::InputInt("##nominal_sampling", &state.nominalSampling, 10, 50);
+        state.nominalSampling = std::max(gui::MIN_SAMPLING, std::min(gui::MAX_SAMPLING, state.nominalSampling));
         ImGui::SameLine();
         HelpMarker(getSamplingTooltip().c_str());
 
         ImGui::Text("Angle:");
         ImGui::SameLine();
         ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
-        ImGui::InputDouble("##nominal_angle", &nominalAngle, 1.0, 10.0, "%.2f");
-        nominalAngle = std::clamp(nominalAngle, -360.0, 360.0);
+        ImGui::InputDouble("##nominal_angle", &state.nominalAngle, 1.0, 10.0, "%.2f");
+        state.nominalAngle = std::clamp(state.nominalAngle, -360.0, 360.0);
         ImGui::SameLine();
         HelpMarker(getAngleTooltip().c_str());
 
         if (ImGui::Button("Get nominal surface data")) {
             if (isDDEInitialized()) {
-                m_zemaxDDEClient->setStorageTarget(m_zemaxDDEClient->getNominalSurface());
-                m_zemaxDDEClient->getSurfaceData(nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
-                m_zemaxDDEClient->getSurfaceData(nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
-                m_sagService->calculateSagCrossSection(nominalSurfaceIndex, nominalSampling, nominalAngle);
+                auto* nominal = m_zemaxDDEClient->getNominalSurface();
+                nominal->units = m_zemaxDDEClient->getOpticalSystemData().units;
+                nominal->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+
+                m_zemaxDDEClient->setStorageTarget(nominal);
+                m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
+                m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
+                m_sagService->calculateSagCrossSection(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
+
+                m_logger.addLog("[SagMap] Nominal reference set for surface map analysis");
             }
         }
 
@@ -94,22 +102,22 @@ namespace gui {
         ImGui::Text("Surface number:");
         ImGui::SameLine();
         ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
-        ImGui::InputInt("##toleranced_surf_num", &tolerancedSurfaceIndex, 1, 10);
-        tolerancedSurfaceIndex = std::max(0, std::min(m_zemaxDDEClient->getOpticalSystemData().numSurfs, tolerancedSurfaceIndex));
+        ImGui::InputInt("##toleranced_surf_num", &state.tolerancedSurfaceIndex, 1, 10);
+        state.tolerancedSurfaceIndex = std::max(0, std::min(m_zemaxDDEClient->getOpticalSystemData().numSurfs, state.tolerancedSurfaceIndex));
 
         ImGui::Text("Sampling:");
         ImGui::SameLine();
         ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
-        ImGui::InputInt("##toleranced_sampling", &tolerancedSampling, 10, 50);
-        tolerancedSampling = std::max(gui::MIN_SAMPLING, std::min(gui::MAX_SAMPLING, tolerancedSampling));
+        ImGui::InputInt("##toleranced_sampling", &state.tolerancedSampling, 10, 50);
+        state.tolerancedSampling = std::max(gui::MIN_SAMPLING, std::min(gui::MAX_SAMPLING, state.tolerancedSampling));
         ImGui::SameLine();
         HelpMarker(getSamplingTooltip().c_str());
 
         ImGui::Text("Angle step:");
         ImGui::SameLine();
         ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
-        ImGui::InputDouble("##toleranced_angle_step", &tolerancedAngleStep, 0.1, 1.0, "%.2f");
-        tolerancedAngleStep = std::clamp(tolerancedAngleStep, 0.01, 180.0);
+        ImGui::InputDouble("##toleranced_angle_step", &state.tolerancedAngleStep, 0.1, 1.0, "%.2f");
+        state.tolerancedAngleStep = std::clamp(state.tolerancedAngleStep, 0.01, 360.0);
         ImGui::SameLine();
         HelpMarker(getAngleStepTooltip().c_str());
 
@@ -121,8 +129,138 @@ namespace gui {
 
         ImGui::BeginDisabled(!isDDEInitialized());
         if (ImGui::Button("Calculate Surface Map")) {
-            // TODO: implement calculation
+            auto* toleranced = m_zemaxDDEClient->getTolerancedSurface();
+            toleranced->clear();
+            toleranced->units = m_zemaxDDEClient->getOpticalSystemData().units;
+            toleranced->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+
+            m_zemaxDDEClient->setStorageTarget(toleranced);
+            m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
+            m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
+
+            toleranced->sampling = state.tolerancedSampling;
+
+            m_sagMapService->calculateSurfaceMap(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngleStep);
         }
         ImGui::EndDisabled();
+
+        // TODO: Re-enable Max-PV analysis
+        /*
+        ImGui::SameLine();
+
+        ImGui::BeginDisabled(!isDDEInitialized() || !hasData || !hasNominal);
+        if (ImGui::Button("Find Max-PV Section")) {
+            auto result = m_sagMapService->findMaxPVSection();
+            if (result.has_value()) {
+                m_logger.addLog(std::format("[SagMap] Max-PV: Angle={:.2f}°, Peak={:.6f}, Valley={:.6f}, PV={:.6f}",
+                    result->angle, result->peak, result->valley, result->pv));
+            }
+        }
+        ImGui::EndDisabled();
+        */
+
+        bool hasData = m_sagMapService->hasData();
+
+        if (hasData) {
+            ImGui::SeparatorText("Results");
+            ImGui::Text(std::format("Rings calculated: {}", m_sagMapService->getSections().size()).c_str());
+
+            const auto& sections = m_sagMapService->getSections();
+            int numRadii = static_cast<int>(sections.size());
+            if (numRadii > 0) {
+                int numAngles = static_cast<int>(sections[0].sagDataPoints.size());
+                double semiDiameter = sections[0].semiDiameter;
+                double angleStepDeg = m_sagMapService->m_state.tolerancedAngleStep;
+                double radiusStep = semiDiameter / (numRadii - 1);
+
+                std::vector<float> X(numRadii * numAngles);
+                std::vector<float> Y(numRadii * numAngles);
+                std::vector<float> Z(numRadii * numAngles);
+
+                float zMin = 0, zMax = 0;
+                bool first = true;
+
+                for (int i = 0; i < numRadii; ++i) {
+                    double r = i * radiusStep;
+                    for (int j = 0; j < numAngles; ++j) {
+                        double angle = j * angleStepDeg * DEG_TO_RAD;
+                        X[i * numAngles + j] = static_cast<float>(r * std::cos(angle));
+                        Y[i * numAngles + j] = static_cast<float>(r * std::sin(angle));
+
+                        const auto& pt = sections[i].sagDataPoints[j];
+                        Z[i * numAngles + j] = static_cast<float>(pt.sag);
+
+                        if (first) {
+                            zMin = pt.sag;
+                            zMax = pt.sag;
+                            first = false;
+                        } else {
+                            zMin = std::min(zMin, static_cast<float>(pt.sag));
+                            zMax = std::max(zMax, static_cast<float>(pt.sag));
+                        }
+                    }
+                }
+
+                ImGui::Text("Toleranced Surface (absolute sag):");
+                if (ImPlot3D::BeginPlot("##Surface3D", ImVec2(-1, 400))) {
+                    ImPlot3D::SetupAxes("X (mm)", "Y (mm)", "Z (mm)");
+                    ImPlot3D::PlotSurface("Lens Surface", X.data(), Y.data(), Z.data(),
+                                          numRadii, numAngles, zMin, zMax);
+                    ImPlot3D::EndPlot();
+                }
+
+                // TODO: Re-enable deviation heatmap
+                /*
+                if (hasNominal) {
+                    const auto& nominal = m_sagMapService->getNominalReference();
+                    if (nominal.sagDataPoints.size() == numRadialPoints) {
+                        std::vector<double> deviationValues(numAngles * numRadialPoints);
+                        double devMin = 0, devMax = 0;
+                        bool first = true;
+
+                        for (int i = 0; i < numAngles; ++i) {
+                            for (int j = 0; j < numRadialPoints; ++j) {
+                                double deviation = sections[i].sagDataPoints[j].sag - nominal.sagDataPoints[j].sag;
+                                deviationValues[i * numRadialPoints + j] = deviation;
+                                if (first) {
+                                    devMin = deviation;
+                                    devMax = deviation;
+                                    first = false;
+                                } else {
+                                    devMin = std::min(devMin, deviation);
+                                    devMax = std::max(devMax, deviation);
+                                }
+                            }
+                        }
+
+                        double absMax = std::max(std::abs(devMin), std::abs(devMax));
+
+                        ImGui::Spacing();
+                        ImGui::Text("Deviation (Toleranced - Nominal):");
+                        if (ImPlot::BeginPlot("##DeviationMap", ImVec2(-1, 200))) {
+                            ImPlot::SetupAxes("Angle (deg)", "Radial Position");
+                            ImPlot::PlotHeatmap("##DeviationHeatmap", deviationValues.data(), numAngles, numRadialPoints,
+                                -absMax, absMax, nullptr,
+                                ImPlotPoint(0, 0), ImPlotPoint(180, numRadialPoints));
+                            ImPlot::EndPlot();
+                        }
+                    }
+                }
+                */
+
+                // TODO: Re-enable Max-PV analysis
+                /*
+                auto maxPV = m_sagMapService->findMaxPVSection();
+                if (maxPV.has_value()) {
+                    ImGui::SeparatorText("Max-PV Result");
+                    auto& pv = maxPV.value();
+                    ImGui::TextUnformatted(std::format("Max-PV Section at {:.2f}°", pv.angle).c_str());
+                    ImGui::TextUnformatted(std::format("Peak: {:.6f} mm", pv.peak).c_str());
+                    ImGui::TextUnformatted(std::format("Valley: {:.6f} mm", pv.valley).c_str());
+                    ImGui::TextUnformatted(std::format("PV: {:.6f} mm", pv.pv).c_str());
+                }
+                */
+            }
+        }
     }
 }

--- a/src/gui/windows_dockable/surface_map_analysis.cpp
+++ b/src/gui/windows_dockable/surface_map_analysis.cpp
@@ -74,28 +74,42 @@ namespace gui {
         bool isSagCalculating = (m_sagService->getCalcState() == SagCalcState::FetchingSurfaceData ||
                                  m_sagService->getCalcState() == SagCalcState::FetchingSagPoints);
 
-        if (isSagCalculating) ImGui::BeginDisabled();
+        if (isSagCalculating) {
+            float progress = m_sagService->getTotalSteps() > 0
+                ? static_cast<float>(m_sagService->getCurrentStep()) / m_sagService->getTotalSteps()
+                : 0.0f;
+            ImGui::ProgressBar(progress, ImVec2(-1, 0),
+                std::format("{}/{}", m_sagService->getCurrentStep(), m_sagService->getTotalSteps()).c_str());
 
-        if (ImGui::Button(isSagCalculating ? "Calculating..." : "Get nominal surface data")) {
-            if (isDDEInitialized()) {
-                auto* nominal = m_zemaxDDEClient->getNominalSurface();
-                nominal->units = m_zemaxDDEClient->getOpticalSystemData().units;
-                nominal->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+            ImGui::SameLine();
+            if (ImGui::Button("Cancel")) {
+                m_sagService->cancelCalculation();
+            }
 
-                m_sagService->onCalculationComplete = [this]() {
-                    const auto& result = m_sagService->getResult();
+            if (m_sagService->getSkippedPoints() > 0) {
+                ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
+                    "%d points skipped (timeout)", m_sagService->getSkippedPoints());
+            }
+        } else {
+            if (ImGui::Button("Get nominal surface data")) {
+                if (isDDEInitialized()) {
                     auto* nominal = m_zemaxDDEClient->getNominalSurface();
-                    nominal->semiDiameter = result.semiDiameter;
-                    nominal->sampling = result.sampling;
-                    nominal->angle = result.angle;
-                    nominal->sagDataPoints = result.sagDataPoints;
-                    m_logger.addLog("[SagMap] Nominal reference set for surface map analysis");
-                };
-                m_sagService->startAsyncSagCalculation(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
+                    nominal->units = m_zemaxDDEClient->getOpticalSystemData().units;
+                    nominal->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+
+                    m_sagService->onCalculationComplete = [this]() {
+                        const auto& result = m_sagService->getResult();
+                        auto* nominal = m_zemaxDDEClient->getNominalSurface();
+                        nominal->semiDiameter = result.semiDiameter;
+                        nominal->sampling = result.sampling;
+                        nominal->angle = result.angle;
+                        nominal->sagDataPoints = result.sagDataPoints;
+                        m_logger.addLog("[SagMap] Nominal reference set for surface map analysis");
+                    };
+                    m_sagService->startAsyncSagCalculation(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
+                }
             }
         }
-
-        if (isSagCalculating) ImGui::EndDisabled();
 
         ImGui::EndDisabled();
 
@@ -143,11 +157,29 @@ namespace gui {
         bool isMapCalculating = (m_sagMapService->getMapState() == SagMapState::FetchingSurfaceData ||
                                  m_sagMapService->getMapState() == SagMapState::FetchingSagPoints);
 
-        ImGui::BeginDisabled(!isDDEInitialized() || isMapCalculating);
-        if (ImGui::Button(isMapCalculating ? "Calculating..." : "Calculate Surface Map")) {
-            m_sagMapService->startAsyncMapCalculation(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngleStep);
+        if (isMapCalculating) {
+            int total = m_sagMapService->getTotalSteps();
+            int current = m_sagMapService->getCurrentStep();
+            float progress = total > 0 ? static_cast<float>(current) / total : 0.0f;
+            ImGui::ProgressBar(progress, ImVec2(-1, 0),
+                std::format("{}/{}", current, total).c_str());
+
+            ImGui::SameLine();
+            if (ImGui::Button("Cancel")) {
+                m_sagMapService->cancelCalculation();
+            }
+
+            if (m_sagMapService->getSkippedPoints() > 0) {
+                ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
+                    "%d points skipped (timeout)", m_sagMapService->getSkippedPoints());
+            }
+        } else {
+            ImGui::BeginDisabled(!isDDEInitialized());
+            if (ImGui::Button("Calculate Surface Map")) {
+                m_sagMapService->startAsyncMapCalculation(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngleStep);
+            }
+            ImGui::EndDisabled();
         }
-        ImGui::EndDisabled();
 
         // TODO: Re-enable Max-PV analysis
         /*

--- a/src/gui/windows_dockable/surface_map_analysis.cpp
+++ b/src/gui/windows_dockable/surface_map_analysis.cpp
@@ -6,6 +6,7 @@
 
 #include "gui/gui.h"
 #include "gui/constants.h"
+#include "logger/logger.h"
 #include "lib/imgui/imgui.h"
 #include "lib/implot/implot.h"
 #include "lib/implot3d/implot3d.h"

--- a/src/gui/windows_dockable/surface_map_analysis.cpp
+++ b/src/gui/windows_dockable/surface_map_analysis.cpp
@@ -71,20 +71,31 @@ namespace gui {
         ImGui::SameLine();
         HelpMarker(getAngleTooltip().c_str());
 
-        if (ImGui::Button("Get nominal surface data")) {
+        bool isSagCalculating = (m_sagService->getCalcState() == SagCalcState::FetchingSurfaceData ||
+                                 m_sagService->getCalcState() == SagCalcState::FetchingSagPoints);
+
+        if (isSagCalculating) ImGui::BeginDisabled();
+
+        if (ImGui::Button(isSagCalculating ? "Calculating..." : "Get nominal surface data")) {
             if (isDDEInitialized()) {
                 auto* nominal = m_zemaxDDEClient->getNominalSurface();
                 nominal->units = m_zemaxDDEClient->getOpticalSystemData().units;
                 nominal->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
 
-                m_zemaxDDEClient->setStorageTarget(nominal);
-                m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
-                m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
-                m_sagService->calculateSagCrossSection(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
-
-                m_logger.addLog("[SagMap] Nominal reference set for surface map analysis");
+                m_sagService->onCalculationComplete = [this]() {
+                    const auto& result = m_sagService->getResult();
+                    auto* nominal = m_zemaxDDEClient->getNominalSurface();
+                    nominal->semiDiameter = result.semiDiameter;
+                    nominal->sampling = result.sampling;
+                    nominal->angle = result.angle;
+                    nominal->sagDataPoints = result.sagDataPoints;
+                    m_logger.addLog("[SagMap] Nominal reference set for surface map analysis");
+                };
+                m_sagService->startAsyncSagCalculation(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
             }
         }
+
+        if (isSagCalculating) ImGui::EndDisabled();
 
         ImGui::EndDisabled();
 
@@ -129,20 +140,12 @@ namespace gui {
 
         ImGui::SeparatorText("Analysis");
 
-        ImGui::BeginDisabled(!isDDEInitialized());
-        if (ImGui::Button("Calculate Surface Map")) {
-            auto* toleranced = m_zemaxDDEClient->getTolerancedSurface();
-            toleranced->clear();
-            toleranced->units = m_zemaxDDEClient->getOpticalSystemData().units;
-            toleranced->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+        bool isMapCalculating = (m_sagMapService->getMapState() == SagMapState::FetchingSurfaceData ||
+                                 m_sagMapService->getMapState() == SagMapState::FetchingSagPoints);
 
-            m_zemaxDDEClient->setStorageTarget(toleranced);
-            m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
-            m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
-
-            toleranced->sampling = state.tolerancedSampling;
-
-            m_sagMapService->calculateSurfaceMap(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngleStep);
+        ImGui::BeginDisabled(!isDDEInitialized() || isMapCalculating);
+        if (ImGui::Button(isMapCalculating ? "Calculating..." : "Calculate Surface Map")) {
+            m_sagMapService->startAsyncMapCalculation(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngleStep);
         }
         ImGui::EndDisabled();
 

--- a/src/gui/windows_dockable/surface_map_analysis.cpp
+++ b/src/gui/windows_dockable/surface_map_analysis.cpp
@@ -1,0 +1,128 @@
+#include <algorithm>
+#include <format>
+
+#include "gui/gui.h"
+#include "gui/constants.h"
+#include "lib/imgui/imgui.h"
+
+namespace {
+    std::string getSamplingTooltip() {
+        return std::format(
+            "Number of points to sample along the surface diameter (min={}, max={}).\n"
+            "Higher values = smoother profile, slower calculation.",
+            gui::MIN_SAMPLING, gui::MAX_SAMPLING
+        );
+    }
+
+    std::string getAngleStepTooltip() {
+        return "Angular step between cross sections in degrees (0-180).\n"
+               "Smaller step = more detailed map, slower calculation.";
+    }
+
+    std::string getAngleTooltip() {
+        return "Orientation angle in degrees relative to the local x axis.";
+    }
+}
+
+namespace gui {
+    void GuiManager::renderSurfaceMapAnalysis() {
+        static int nominalSurfaceIndex = 0;
+        static int nominalSampling = 128;
+        static double nominalAngle = 0.0;
+
+        static int tolerancedSurfaceIndex = 0;
+        static int tolerancedSampling = 128;
+        static double tolerancedAngleStep = 1.0;
+
+        ImGui::SeparatorText("Nominal surface parameters");
+
+        ImGui::BeginChild(
+            "NominalSurfaceContent",
+            ImVec2(0.0f, 0.0f),
+            ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_FrameStyle,
+            ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBackground
+        );
+
+        ImGui::BeginDisabled(!isDDEInitialized());
+
+        ImGui::Text("Surface number:");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
+        ImGui::InputInt("##nominal_surf_num", &nominalSurfaceIndex, 1, 10);
+        nominalSurfaceIndex = std::max(0, std::min(m_zemaxDDEClient->getOpticalSystemData().numSurfs, nominalSurfaceIndex));
+
+        ImGui::Text("Sampling:");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
+        ImGui::InputInt("##nominal_sampling", &nominalSampling, 10, 50);
+        nominalSampling = std::max(gui::MIN_SAMPLING, std::min(gui::MAX_SAMPLING, nominalSampling));
+        ImGui::SameLine();
+        HelpMarker(getSamplingTooltip().c_str());
+
+        ImGui::Text("Angle:");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
+        ImGui::InputDouble("##nominal_angle", &nominalAngle, 1.0, 10.0, "%.2f");
+        nominalAngle = std::clamp(nominalAngle, -360.0, 360.0);
+        ImGui::SameLine();
+        HelpMarker(getAngleTooltip().c_str());
+
+        if (ImGui::Button("Get nominal surface data")) {
+            if (isDDEInitialized()) {
+                m_zemaxDDEClient->setStorageTarget(m_zemaxDDEClient->getNominalSurface());
+                m_zemaxDDEClient->getSurfaceData(nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
+                m_zemaxDDEClient->getSurfaceData(nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
+                m_sagService->calculateSagCrossSection(nominalSurfaceIndex, nominalSampling, nominalAngle);
+            }
+        }
+
+        ImGui::EndDisabled();
+
+        ImGui::EndChild();
+
+        ImGui::SeparatorText("Toleranced surface parameters");
+
+        ImGui::BeginChild(
+            "TolerancedSurfaceContent",
+            ImVec2(0.0f, 0.0f),
+            ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_FrameStyle,
+            ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBackground
+        );
+
+        ImGui::BeginDisabled(!isDDEInitialized());
+
+        ImGui::Text("Surface number:");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
+        ImGui::InputInt("##toleranced_surf_num", &tolerancedSurfaceIndex, 1, 10);
+        tolerancedSurfaceIndex = std::max(0, std::min(m_zemaxDDEClient->getOpticalSystemData().numSurfs, tolerancedSurfaceIndex));
+
+        ImGui::Text("Sampling:");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
+        ImGui::InputInt("##toleranced_sampling", &tolerancedSampling, 10, 50);
+        tolerancedSampling = std::max(gui::MIN_SAMPLING, std::min(gui::MAX_SAMPLING, tolerancedSampling));
+        ImGui::SameLine();
+        HelpMarker(getSamplingTooltip().c_str());
+
+        ImGui::Text("Angle step:");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8.0f);
+        ImGui::InputDouble("##toleranced_angle_step", &tolerancedAngleStep, 0.1, 1.0, "%.2f");
+        tolerancedAngleStep = std::clamp(tolerancedAngleStep, 0.01, 180.0);
+        ImGui::SameLine();
+        HelpMarker(getAngleStepTooltip().c_str());
+
+        ImGui::EndDisabled();
+
+        ImGui::EndChild();
+
+        ImGui::SeparatorText("Analysis");
+
+        ImGui::BeginDisabled(!isDDEInitialized());
+        if (ImGui::Button("Calculate Surface Map")) {
+            // TODO: implement calculation
+        }
+        ImGui::EndDisabled();
+    }
+}

--- a/src/gui/windows_dockable/surface_sag_analysis.cpp
+++ b/src/gui/windows_dockable/surface_sag_analysis.cpp
@@ -41,6 +41,7 @@ namespace {
 
 namespace gui {
     void GuiManager::renderSurfaceSagAnalysis() {
+        if (!m_zemaxDDEClient) return;
         auto& state = m_sagService->m_surfaceSagAnalysisPageState;
         auto* nominal = m_zemaxDDEClient->getNominalSurface();
         auto* toleranced = m_zemaxDDEClient->getTolerancedSurface();

--- a/src/gui/windows_dockable/surface_sag_analysis.cpp
+++ b/src/gui/windows_dockable/surface_sag_analysis.cpp
@@ -42,8 +42,8 @@ namespace {
 namespace gui {
     void GuiManager::renderSurfaceSagAnalysis() {
         auto& state = m_sagService->m_surfaceSagAnalysisPageState;
-        auto& nominal = m_zemaxDDEClient->getNominalSurface();
-        auto& toleranced = m_zemaxDDEClient->getTolerancedSurface();
+        auto* nominal = m_zemaxDDEClient->getNominalSurface();
+        auto* toleranced = m_zemaxDDEClient->getTolerancedSurface();
 
         ImGui::SeparatorText("Toleranced surface parameters");
         ImGui::BeginChild(
@@ -53,17 +53,19 @@ namespace gui {
             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBackground
         );
 
-        if (toleranced.isValid() && toleranced.id == state.tolerancedSurfaceIndex) {
-            ImGui::TextUnformatted("Optical system: null");
-            ImGui::TextUnformatted(std::format("Surface index: {}", toleranced.id).c_str());
-            ImGui::TextUnformatted(std::format("Surface type: {}", toleranced.type).c_str());
-            ImGui::TextUnformatted(std::format("Semi-diameter: {:.3f} {}", toleranced.semiDiameter, getUnitString(toleranced.units)).c_str());
-            ImGui::TextUnformatted(std::format("Diameter: {:.3f} {}", toleranced.diameter(), getUnitString(toleranced.units)).c_str());
+        if (toleranced->isValid() && toleranced->id == state.tolerancedSurfaceIndex) {
+            ImGui::TextUnformatted(std::format("Optical system: {}", toleranced->fileName).c_str());
+            ImGui::TextUnformatted(std::format("Sampling: {}", toleranced->sampling).c_str());
+            ImGui::TextUnformatted(std::format("Angle: {}°", toleranced->angle).c_str());
+            ImGui::TextUnformatted(std::format("Surface index: {}", toleranced->id).c_str());
+            ImGui::TextUnformatted(std::format("Surface type: {}", toleranced->type).c_str());
+            ImGui::TextUnformatted(std::format("Semi-diameter: {:.3f} {}", toleranced->semiDiameter, getUnitString(toleranced->units)).c_str());
+            ImGui::TextUnformatted(std::format("Diameter: {:.3f} {}", toleranced->diameter(), getUnitString(toleranced->units)).c_str());
             ImGui::Text("Surface sag data:");
             ImGui::SameLine();
 
             if (ImGui::Button("Text")) {
-                m_sagService->saveCrossSectionToFile(toleranced);
+                m_sagService->saveCrossSectionToFile(*toleranced);
             }
 
             ImGui::SameLine();
@@ -76,7 +78,7 @@ namespace gui {
 
             if (ImGui::Button("Clear data")) {
                 m_sagService->m_showTolerancedSagWindow = false;
-                m_zemaxDDEClient->clearTolerancedSurface();
+                toleranced->clear();
             }
         } else {
             ImGui::BeginDisabled(!isDDEInitialized());
@@ -111,7 +113,7 @@ namespace gui {
 
             if (ImGui::Button("Get toleranced surface data")) {
                 if (isDDEInitialized()) {
-                    m_zemaxDDEClient->setStorageTarget(ZemaxDDE::StorageTarget::TOLERANCED);
+                    m_zemaxDDEClient->setStorageTarget(m_zemaxDDEClient->getTolerancedSurface());
                     m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
                     m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
                     m_sagService->calculateSagCrossSection(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngle);
@@ -129,17 +131,19 @@ namespace gui {
             ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_FrameStyle,
             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBackground
         );
-        if (nominal.isValid() && nominal.id == state.nominalSurfaceIndex) {
-            ImGui::TextUnformatted("Optical system: null");
-            ImGui::TextUnformatted(std::format("Surface index: {}", nominal.id).c_str());
-            ImGui::TextUnformatted(std::format("Surface type: {}", nominal.type).c_str());
-            ImGui::TextUnformatted(std::format("Semi-diameter: {:.3f} {}", nominal.semiDiameter, getUnitString(nominal.units)).c_str());
-            ImGui::TextUnformatted(std::format("Diameter: {:.3f} {}", nominal.diameter(), getUnitString(nominal.units)).c_str());
+        if (nominal->isValid() && nominal->id == state.nominalSurfaceIndex) {
+            ImGui::TextUnformatted(std::format("Optical system: {}", nominal->fileName).c_str());
+            ImGui::TextUnformatted(std::format("Sampling: {}", nominal->sampling).c_str());
+            ImGui::TextUnformatted(std::format("Angle: {}°", nominal->angle).c_str());
+            ImGui::TextUnformatted(std::format("Surface index: {}", nominal->id).c_str());
+            ImGui::TextUnformatted(std::format("Surface type: {}", nominal->type).c_str());
+            ImGui::TextUnformatted(std::format("Semi-diameter: {:.3f} {}", nominal->semiDiameter, getUnitString(nominal->units)).c_str());
+            ImGui::TextUnformatted(std::format("Diameter: {:.3f} {}", nominal->diameter(), getUnitString(nominal->units)).c_str());
             ImGui::Text("Surface sag data:");
             ImGui::SameLine();
 
             if (ImGui::Button("Text")) {
-                m_sagService->saveCrossSectionToFile(nominal);
+                m_sagService->saveCrossSectionToFile(*nominal);
             }
 
             ImGui::SameLine();
@@ -152,7 +156,7 @@ namespace gui {
 
             if (ImGui::Button("Clear data")) {
                 m_sagService->m_showNominalSagWindow = false;
-                m_zemaxDDEClient->clearNominalSurface();
+                nominal->clear();
             }
         } else {
             ImGui::BeginDisabled(!isDDEInitialized());
@@ -188,7 +192,7 @@ namespace gui {
 
             if (ImGui::Button("Get nominal surface data")) {
                 if (isDDEInitialized()) {
-                    m_zemaxDDEClient->setStorageTarget(ZemaxDDE::StorageTarget::NOMINAL);
+                    m_zemaxDDEClient->setStorageTarget(m_zemaxDDEClient->getNominalSurface());
                     m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
                     m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
                     m_sagService->calculateSagCrossSection(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
@@ -199,7 +203,7 @@ namespace gui {
         }
         ImGui::EndChild();
 
-        if (nominal.isValid() && toleranced.isValid()) {
+        if (nominal->isValid() && toleranced->isValid()) {
             ImGui::SeparatorText("Profile Comparison");
 
             if (ImGui::Button("Detach Comparison")) {
@@ -220,7 +224,7 @@ namespace gui {
             if (showProfiles || showErrorPlot) {
                 ImGui::BeginChild("ComparisonContent", ImVec2(0.0f, 0.0f), ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_FrameStyle, ImGuiWindowFlags_NoTitleBar);
 
-                auto data = prepareSagCrossSectionData(nominal, toleranced);
+                auto data = prepareSagCrossSectionData(*nominal, *toleranced);
 
                 if (showProfiles) {
                     if (ImPlot::BeginPlot("##Profiles", ImVec2(-1, 200))) {

--- a/src/gui/windows_dockable/surface_sag_analysis.cpp
+++ b/src/gui/windows_dockable/surface_sag_analysis.cpp
@@ -113,7 +113,11 @@ namespace gui {
 
             if (ImGui::Button("Get toleranced surface data")) {
                 if (isDDEInitialized()) {
-                    m_zemaxDDEClient->setStorageTarget(m_zemaxDDEClient->getTolerancedSurface());
+                    auto* surface = m_zemaxDDEClient->getTolerancedSurface();
+                    surface->units = m_zemaxDDEClient->getOpticalSystemData().units;
+                    surface->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+
+                    m_zemaxDDEClient->setStorageTarget(surface);
                     m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
                     m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
                     m_sagService->calculateSagCrossSection(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngle);
@@ -192,7 +196,11 @@ namespace gui {
 
             if (ImGui::Button("Get nominal surface data")) {
                 if (isDDEInitialized()) {
-                    m_zemaxDDEClient->setStorageTarget(m_zemaxDDEClient->getNominalSurface());
+                    auto* surface = m_zemaxDDEClient->getNominalSurface();
+                    surface->units = m_zemaxDDEClient->getOpticalSystemData().units;
+                    surface->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+
+                    m_zemaxDDEClient->setStorageTarget(surface);
                     m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
                     m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
                     m_sagService->calculateSagCrossSection(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);

--- a/src/gui/windows_dockable/surface_sag_analysis.cpp
+++ b/src/gui/windows_dockable/surface_sag_analysis.cpp
@@ -115,27 +115,41 @@ namespace gui {
             bool isCalculating = (m_sagService->getCalcState() == SagCalcState::FetchingSurfaceData ||
                                   m_sagService->getCalcState() == SagCalcState::FetchingSagPoints);
 
-            if (isCalculating) ImGui::BeginDisabled();
+            if (isCalculating) {
+                float progress = m_sagService->getTotalSteps() > 0
+                    ? static_cast<float>(m_sagService->getCurrentStep()) / m_sagService->getTotalSteps()
+                    : 0.0f;
+                ImGui::ProgressBar(progress, ImVec2(-1, 0),
+                    std::format("{}/{}", m_sagService->getCurrentStep(), m_sagService->getTotalSteps()).c_str());
 
-            if (ImGui::Button(isCalculating ? "Calculating..." : "Get toleranced surface data")) {
-                if (isDDEInitialized()) {
-                    auto* surface = m_zemaxDDEClient->getTolerancedSurface();
-                    surface->units = m_zemaxDDEClient->getOpticalSystemData().units;
-                    surface->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+                ImGui::SameLine();
+                if (ImGui::Button("Cancel")) {
+                    m_sagService->cancelCalculation();
+                }
 
-                    m_sagService->onCalculationComplete = [this]() {
-                        const auto& result = m_sagService->getResult();
+                if (m_sagService->getSkippedPoints() > 0) {
+                    ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
+                        "%d points skipped (timeout)", m_sagService->getSkippedPoints());
+                }
+            } else {
+                if (ImGui::Button("Get toleranced surface data")) {
+                    if (isDDEInitialized()) {
                         auto* surface = m_zemaxDDEClient->getTolerancedSurface();
-                        surface->semiDiameter = result.semiDiameter;
-                        surface->sampling = result.sampling;
-                        surface->angle = result.angle;
-                        surface->sagDataPoints = result.sagDataPoints;
-                    };
-                    m_sagService->startAsyncSagCalculation(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngle);
+                        surface->units = m_zemaxDDEClient->getOpticalSystemData().units;
+                        surface->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+
+                        m_sagService->onCalculationComplete = [this]() {
+                            const auto& result = m_sagService->getResult();
+                            auto* surface = m_zemaxDDEClient->getTolerancedSurface();
+                            surface->semiDiameter = result.semiDiameter;
+                            surface->sampling = result.sampling;
+                            surface->angle = result.angle;
+                            surface->sagDataPoints = result.sagDataPoints;
+                        };
+                        m_sagService->startAsyncSagCalculation(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngle);
+                    }
                 }
             }
-
-            if (isCalculating) ImGui::EndDisabled();
 
             ImGui::EndDisabled();
         }
@@ -207,21 +221,40 @@ namespace gui {
 
             ImGui::SameLine();
 
-            if (ImGui::Button("Get nominal surface data")) {
-                if (isDDEInitialized()) {
-                    auto* surface = m_zemaxDDEClient->getNominalSurface();
-                    surface->units = m_zemaxDDEClient->getOpticalSystemData().units;
-                    surface->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+            if (m_sagService->getCalcState() == SagCalcState::FetchingSurfaceData ||
+                m_sagService->getCalcState() == SagCalcState::FetchingSagPoints) {
+                float progress = m_sagService->getTotalSteps() > 0
+                    ? static_cast<float>(m_sagService->getCurrentStep()) / m_sagService->getTotalSteps()
+                    : 0.0f;
+                ImGui::ProgressBar(progress, ImVec2(-1, 0),
+                    std::format("{}/{}", m_sagService->getCurrentStep(), m_sagService->getTotalSteps()).c_str());
 
-                    m_sagService->onCalculationComplete = [this]() {
-                        const auto& result = m_sagService->getResult();
+                ImGui::SameLine();
+                if (ImGui::Button("Cancel")) {
+                    m_sagService->cancelCalculation();
+                }
+
+                if (m_sagService->getSkippedPoints() > 0) {
+                    ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
+                        "%d points skipped (timeout)", m_sagService->getSkippedPoints());
+                }
+            } else {
+                if (ImGui::Button("Get nominal surface data")) {
+                    if (isDDEInitialized()) {
                         auto* surface = m_zemaxDDEClient->getNominalSurface();
-                        surface->semiDiameter = result.semiDiameter;
-                        surface->sampling = result.sampling;
-                        surface->angle = result.angle;
-                        surface->sagDataPoints = result.sagDataPoints;
-                    };
-                    m_sagService->startAsyncSagCalculation(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
+                        surface->units = m_zemaxDDEClient->getOpticalSystemData().units;
+                        surface->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
+
+                        m_sagService->onCalculationComplete = [this]() {
+                            const auto& result = m_sagService->getResult();
+                            auto* surface = m_zemaxDDEClient->getNominalSurface();
+                            surface->semiDiameter = result.semiDiameter;
+                            surface->sampling = result.sampling;
+                            surface->angle = result.angle;
+                            surface->sagDataPoints = result.sagDataPoints;
+                        };
+                        m_sagService->startAsyncSagCalculation(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
+                    }
                 }
             }
 

--- a/src/gui/windows_dockable/surface_sag_analysis.cpp
+++ b/src/gui/windows_dockable/surface_sag_analysis.cpp
@@ -112,18 +112,30 @@ namespace gui {
 
             ImGui::SameLine();
 
-            if (ImGui::Button("Get toleranced surface data")) {
+            bool isCalculating = (m_sagService->getCalcState() == SagCalcState::FetchingSurfaceData ||
+                                  m_sagService->getCalcState() == SagCalcState::FetchingSagPoints);
+
+            if (isCalculating) ImGui::BeginDisabled();
+
+            if (ImGui::Button(isCalculating ? "Calculating..." : "Get toleranced surface data")) {
                 if (isDDEInitialized()) {
                     auto* surface = m_zemaxDDEClient->getTolerancedSurface();
                     surface->units = m_zemaxDDEClient->getOpticalSystemData().units;
                     surface->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
 
-                    m_zemaxDDEClient->setStorageTarget(surface);
-                    m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
-                    m_zemaxDDEClient->getSurfaceData(state.tolerancedSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
-                    m_sagService->calculateSagCrossSection(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngle);
+                    m_sagService->onCalculationComplete = [this]() {
+                        const auto& result = m_sagService->getResult();
+                        auto* surface = m_zemaxDDEClient->getTolerancedSurface();
+                        surface->semiDiameter = result.semiDiameter;
+                        surface->sampling = result.sampling;
+                        surface->angle = result.angle;
+                        surface->sagDataPoints = result.sagDataPoints;
+                    };
+                    m_sagService->startAsyncSagCalculation(state.tolerancedSurfaceIndex, state.tolerancedSampling, state.tolerancedAngle);
                 }
             }
+
+            if (isCalculating) ImGui::EndDisabled();
 
             ImGui::EndDisabled();
         }
@@ -201,10 +213,15 @@ namespace gui {
                     surface->units = m_zemaxDDEClient->getOpticalSystemData().units;
                     surface->fileName = m_zemaxDDEClient->getOpticalSystemData().fileName;
 
-                    m_zemaxDDEClient->setStorageTarget(surface);
-                    m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::TYPE_NAME);
-                    m_zemaxDDEClient->getSurfaceData(state.nominalSurfaceIndex, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER);
-                    m_sagService->calculateSagCrossSection(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
+                    m_sagService->onCalculationComplete = [this]() {
+                        const auto& result = m_sagService->getResult();
+                        auto* surface = m_zemaxDDEClient->getNominalSurface();
+                        surface->semiDiameter = result.semiDiameter;
+                        surface->sampling = result.sampling;
+                        surface->angle = result.angle;
+                        surface->sagDataPoints = result.sagDataPoints;
+                    };
+                    m_sagService->startAsyncSagCalculation(state.nominalSurfaceIndex, state.nominalSampling, state.nominalAngle);
                 }
             }
 


### PR DESCRIPTION
## Summary

Complete async DDE engine refactoring: replacing the old flat architecture with prefix-based routing with a FIFO queue and exact command matching, a rewritten OperationMonitor, and the addition of progress bars with cancellation support in the UI.

## Changes

### Core DDE (refactor)
- **FIFO queue** — std::deque<DdeRequest> + single active request replacing std::vector<PendingRequest>
- **Exact command matching** — == instead of find() prefix matching; stale responses are discarded
- **Per-request timeout** — configurable via nqueueRequest() argument (GetSurfaceData=2000ms, GetSag=1000ms)
- **Retry with 1.5x backoff** — replaces 3 immediate retries
- **OperationMonitor** — rewritten as observer: registerOperation, reportProgress, requestCancel, isCancelled
- **DDE ACK fix** — removed premature eturn 0 from GetSurfaceData/GetSag handlers

### Services (refactor)
- **InitialDataLoadService** — sequential chain (GetName -> GetFile -> GetSystem -> GetField -> ... -> GetWave -> Completed)
- **SagAnalysisService** — OperationMonitor integration, skip-on-timeout (timeout on a sag point skips it rather than aborting the entire calculation)
- **SagMapAnalysisService** — same pattern for polar grid

### UI (feat)
- **Progress bar** — ImGui::ProgressBar showing current/total points
- **Cancel button** — cancels the calculation via monitor->requestCancel()
- **Skipped points** — yellow counter showing points skipped due to timeout

## Commits

| Commit | Message |
|--------|---------|
| 03c888a | refactor(dde): replace PendingRequest with FIFO queue and exact command matching |
| 669a373 | refactor(dde): rewrite OperationMonitor as observer with progress/cancel |
| 5897c7a | refactor(dde): convert InitialDataLoadService to sequential FIFO chaining |
| 154f817 | refactor(gui): integrate OperationMonitor and skip-on-timeout into sag services |
| 9468b2f | feat(gui): add progress bar and cancel button to sag/map analysis UI |

## Testing
- Build: 38 files, 0 errors, 0 project warnings
- Verified: 128 sampling x 360 angles = 46k GetSag requests complete without hang