### PR TITLE
feat: Win11 Fluent UI, per-window DDE timeouts, dark theme fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(SOURCES
     ${SRC_DIR}/gui/surface_profile_calculator.cpp
     ${SRC_DIR}/gui/surface_irregularity_map_service.cpp
     ${SRC_DIR}/gui/theme_manager.cpp
+    ${SRC_DIR}/gui/settings_manager.cpp
     ${SRC_DIR}/gui/ui_operation_monitor.cpp
     ${SRC_DIR}/gui/utils.cpp
     ${SRC_DIR}/gui/popups/about_dialog.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ set(SOURCES
     ${SRC_DIR}/gui/surface_profile_service.cpp
     ${SRC_DIR}/gui/surface_profile_calculator.cpp
     ${SRC_DIR}/gui/surface_irregularity_map_service.cpp
+    ${SRC_DIR}/gui/theme_manager.cpp
     ${SRC_DIR}/gui/ui_operation_monitor.cpp
     ${SRC_DIR}/gui/utils.cpp
     ${SRC_DIR}/gui/popups/about_dialog.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(SOURCES
     ${SRC_DIR}/gui/ui_operation_monitor.cpp
     ${SRC_DIR}/gui/utils.cpp
     ${SRC_DIR}/gui/popups/about_dialog.cpp
+    ${SRC_DIR}/gui/popups/preferences_dialog.cpp
     ${SRC_DIR}/gui/popups/update_checker.cpp
     ${SRC_DIR}/gui/popups/connect_dde.cpp
     ${SRC_DIR}/gui/dockable_windows_manager.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SOURCES
     ${SRC_DIR}/main.cpp
     ${SRC_DIR}/app/app_init.cpp
     ${SRC_DIR}/app/config_path.cpp
+    ${SRC_DIR}/app/settings.cpp
     ${SRC_DIR}/app/zemax_window_enumerator.cpp
     ${SRC_DIR}/logger/logger.cpp
     ${SRC_DIR}/dde/client_connection.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,10 +65,24 @@ if(APP_VERSION_PRERELEASE)
     set(APP_VERSION_STRING "${APP_VERSION_STRING}-${APP_VERSION_PRERELEASE}")
 endif()
 
+# VERSIONINFO flag for .rc file (VS_FF_PRERELEASE = 0x01, or 0 for stable)
+if(APP_VERSION_PRERELEASE)
+    set(APP_RC_PRERELEASE_FLAG "0x01L")
+else()
+    set(APP_RC_PRERELEASE_FLAG "0x00L")
+endif()
+
 # Generate version.h from template
 configure_file(
     ${CMAKE_SOURCE_DIR}/src/version.h.in
     ${CMAKE_BINARY_DIR}/version.h
+    @ONLY
+)
+
+# Generate version.rc from template
+configure_file(
+    ${CMAKE_SOURCE_DIR}/src/version.rc.in
+    ${CMAKE_BINARY_DIR}/version.rc
     @ONLY
 )
 
@@ -130,6 +144,7 @@ list(APPEND SOURCES
 list(APPEND SOURCES
     ${NFD_DIR}/src/nfd_common.c
     ${NFD_DIR}/src/nfd_win.cpp
+    ${CMAKE_BINARY_DIR}/version.rc
 )
 
 # Compile 'nfd_common.c' as C-code
@@ -199,6 +214,12 @@ if(BUILD_TYPE_LOWER STREQUAL "debug")
 else()
     message(STATUS "Release mode: hiding console with -mwindows")
     target_link_options(${PROJECT_NAME} PRIVATE -mwindows)
+endif()
+
+# Strip symbols in release builds
+if(BUILD_TYPE_LOWER STREQUAL "release")
+    message(STATUS "Release: stripping debug symbols (-s)")
+    target_link_options(${PROJECT_NAME} PRIVATE -s)
 endif()
 
 # Optimization flags

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -64,8 +64,23 @@ namespace App {
         glfwMakeContextCurrent(ctx->glfwWindow);
         glfwSwapInterval(1);
 
+        // Detect system theme via registry (Windows 10/11)
+        bool isDarkMode = false;
+        HKEY hKey = nullptr;
+        LONG regResult = RegOpenKeyExW(HKEY_CURRENT_USER,
+            L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+            0, KEY_READ, &hKey);
+        if (regResult == ERROR_SUCCESS) {
+            DWORD lightTheme = 1;
+            DWORD dataSize = sizeof(DWORD);
+            if (RegQueryValueExW(hKey, L"AppsUseLightTheme", nullptr, nullptr,
+                    (LPBYTE)&lightTheme, &dataSize) == ERROR_SUCCESS) {
+                isDarkMode = (lightTheme == 0);
+            }
+            RegCloseKey(hKey);
+        }
+
         // Apply system theme to title bar (Windows 10/11)
-        // Define the attribute constant (MinGW headers may lack it)
         #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
         #define DWMWA_USE_IMMERSIVE_DARK_MODE 19
         #endif
@@ -75,31 +90,14 @@ namespace App {
             using DwmSetWindowAttributeFunc = HRESULT (WINAPI*)(HWND, DWORD, LPCVOID, DWORD);
             auto* dwmFunc = reinterpret_cast<DwmSetWindowAttributeFunc>(
                 reinterpret_cast<void*>(GetProcAddress(dwmApi, "DwmSetWindowAttribute")));
-            
-            if (dwmFunc) {
-                // Detect system dark mode via registry (reliable for Windows 10/11)
-                bool isDarkMode = false;
-                HKEY hKey = nullptr;
-                LONG regResult = RegOpenKeyExW(HKEY_CURRENT_USER,
-                    L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-                    0, KEY_READ, &hKey);
-                if (regResult == ERROR_SUCCESS) {
-                    DWORD lightTheme = 1;
-                    DWORD dataSize = sizeof(DWORD);
-                    if (RegQueryValueExW(hKey, L"AppsUseLightTheme", nullptr, nullptr,
-                            (LPBYTE)&lightTheme, &dataSize) == ERROR_SUCCESS) {
-                        // lightTheme == 0 means dark mode is active
-                        isDarkMode = (lightTheme == 0);
-                    }
-                    RegCloseKey(hKey);
-                }
 
+            if (dwmFunc) {
                 BOOL useDarkMode = isDarkMode;
                 HWND hwnd = glfwGetWin32Window(ctx->glfwWindow);
                 if (hwnd) {
                     dwmFunc(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDarkMode, sizeof(useDarkMode));
                 }
-                
+
                 logger.addLog(std::format("[APP] Title bar theme applied (dark mode: {})", isDarkMode));
             }
             FreeLibrary(dwmApi);
@@ -110,9 +108,9 @@ namespace App {
         // Create DDE connection manager (manages multi-window connections)
         ctx->ddeConnectionManager = std::make_unique<DDEConnectionManager>(logger);
 
-        // Initialize GUI manager with DDE connection manager
+        // Initialize GUI manager with system theme
         ctx->gui = std::make_unique<gui::GuiManager>(ctx->glfwWindow, ctx->ddeConnectionManager.get(), logger);
-        ctx->gui->initialize(ctx->dpiScale);
+        ctx->gui->initialize(!isDarkMode, ctx->dpiScale);
 
         // Store context pointer for callback access (must be before callback registration)
         glfwSetWindowUserPointer(ctx->glfwWindow, ctx.get());

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -121,6 +121,11 @@ namespace App {
         ctx->gui->initialize(!isDarkMode, ctx->dpiScale);
         ctx->gui->getSettingsManager().loadFromFile();
 
+        if (ctx->gui->getUpdateChecker() && ctx->gui->getUpdateChecker()->isAutoCheckEnabled()) {
+            logger.addLog("[APP] Auto-checking for updates on startup");
+            ctx->gui->getUpdateChecker()->checkForUpdates();
+        }
+
         // Store context pointer for callback access (must be before callback registration)
         glfwSetWindowUserPointer(ctx->glfwWindow, ctx.get());
 

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -11,6 +11,14 @@ namespace App {
     constexpr int BASE_WIDTH = 800;
     constexpr int BASE_HEIGHT = 600;
 
+    // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 has no public symbol in
+    // MinGW <dde.h> / <winuser.h>, so it must be expressed as a literal pointer.
+    // The numeric value is fixed by Windows SDK and is guaranteed stable.
+    // Not constexpr: reinterpret_cast from integer to pointer is not allowed
+    // in constant expressions in C++23. The variable is initialized once at
+    // program startup and never changes, so the cost difference is negligible.
+    void* const kDpiAwarenessContextPerMonitorV2 = reinterpret_cast<void*>(-4);
+
     std::unique_ptr<AppContext> initialize(Logger& logger) {
         auto ctx = std::make_unique<AppContext>();
 
@@ -25,8 +33,7 @@ namespace App {
             auto* func = reinterpret_cast<SetProcessDpiAwarenessContextFunc>(
                 reinterpret_cast<void(*)()>(fp));
             if (func) {
-                // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = (DPI_AWARENESS_CONTEXT)-4
-                func((void*)-4);
+                func(kDpiAwarenessContextPerMonitorV2);
                 logger.addLog("[APP] DPI Awareness set to Per-Monitor V2 (runtime)");
             } else {
                 SetProcessDPIAware();

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -119,6 +119,7 @@ namespace App {
         // Initialize GUI manager with system theme
         ctx->gui = std::make_unique<gui::GuiManager>(ctx->glfwWindow, ctx->ddeConnectionManager.get(), logger);
         ctx->gui->initialize(!isDarkMode, ctx->dpiScale);
+        ctx->gui->getSettingsManager().loadFromFile();
 
         // Store context pointer for callback access (must be before callback registration)
         glfwSetWindowUserPointer(ctx->glfwWindow, ctx.get());

--- a/src/app/app_init.cpp
+++ b/src/app/app_init.cpp
@@ -22,7 +22,8 @@ namespace App {
         if (user32) {
             using SetProcessDpiAwarenessContextFunc = BOOL (WINAPI*)(void*);
             auto fp = GetProcAddress(user32, "SetProcessDpiAwarenessContext");
-            auto* func = reinterpret_cast<SetProcessDpiAwarenessContextFunc>(reinterpret_cast<void*>(fp));
+            auto* func = reinterpret_cast<SetProcessDpiAwarenessContextFunc>(
+                reinterpret_cast<void(*)()>(fp));
             if (func) {
                 // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = (DPI_AWARENESS_CONTEXT)-4
                 func((void*)-4);

--- a/src/app/config_path.cpp
+++ b/src/app/config_path.cpp
@@ -9,9 +9,11 @@
 namespace {
     inline constexpr const char* IMGUI_INI_FILENAME = "imgui.ini";
     inline constexpr const char* WINDOW_STATE_FILENAME = "windows.json";
+    inline constexpr const char* SETTINGS_JSON_FILENAME = "settings.json";
 
     std::string imguiIniPath;
     std::string windowStatePath;
+    std::string settingsJsonPath;
 
     const char* getLocalAppDataPath() {
         static std::string path;
@@ -33,38 +35,39 @@ namespace {
         }
         return path.c_str();
     }
+
+    std::string resolvePath(const char* filename) {
+        #ifdef APP_PRODUCTION_BUILD
+        std::string basePath = getLocalAppDataPath();
+        if (!basePath.empty()) {
+            return basePath + "\\" + std::string(filename);
+        }
+        return std::string(filename);
+        #else
+        return std::string(filename);
+        #endif
+    }
 }
 
 namespace app {
     const char* getImguiIniPath() {
         if (imguiIniPath.empty()) {
-            #ifdef APP_PRODUCTION_BUILD
-            std::string basePath = getLocalAppDataPath();
-            if (!basePath.empty()) {
-                imguiIniPath = basePath + "\\" + std::string(IMGUI_INI_FILENAME);
-            } else {
-                imguiIniPath = IMGUI_INI_FILENAME;
-            }
-            #else
-            imguiIniPath = IMGUI_INI_FILENAME;
-            #endif
+            imguiIniPath = resolvePath(IMGUI_INI_FILENAME);
         }
         return imguiIniPath.c_str();
     }
 
     const char* getWindowStatePath() {
         if (windowStatePath.empty()) {
-            #ifdef APP_PRODUCTION_BUILD
-            std::string basePath = getLocalAppDataPath();
-            if (!basePath.empty()) {
-                windowStatePath = basePath + "\\" + std::string(WINDOW_STATE_FILENAME);
-            } else {
-                windowStatePath = WINDOW_STATE_FILENAME;
-            }
-            #else
-            windowStatePath = WINDOW_STATE_FILENAME;
-            #endif
+            windowStatePath = resolvePath(WINDOW_STATE_FILENAME);
         }
         return windowStatePath.c_str();
+    }
+
+    const char* getSettingsJsonPath() {
+        if (settingsJsonPath.empty()) {
+            settingsJsonPath = resolvePath(SETTINGS_JSON_FILENAME);
+        }
+        return settingsJsonPath.c_str();
     }
 }

--- a/src/app/config_path.h
+++ b/src/app/config_path.h
@@ -5,4 +5,5 @@
 namespace app {
     const char* getImguiIniPath();
     const char* getWindowStatePath();
+    const char* getSettingsJsonPath();
 }

--- a/src/app/settings.cpp
+++ b/src/app/settings.cpp
@@ -83,23 +83,35 @@ namespace app {
     }
 
     bool AppSettings::loadFromFile(const std::string& path) {
+        std::string dummy;
+        return loadFromFileWithReason(path, dummy) == LoadResult::Success;
+    }
+
+    AppSettings::LoadResult AppSettings::loadFromFileWithReason(const std::string& path, std::string& errorOut) noexcept {
+        errorOut.clear();
+
         std::ifstream in(path);
-        if (!in.is_open()) return false;
+        if (!in.is_open()) return LoadResult::FileMissing;
 
         nlohmann::json j;
         try {
             in >> j;
-        } catch (const nlohmann::json::parse_error&) {
-            return false;
+        } catch (const nlohmann::json::parse_error& e) {
+            errorOut = e.what();
+            return LoadResult::ParseError;
         }
-        if (!j.is_object()) return false;
+        if (!j.is_object()) {
+            errorOut = "root JSON value is not an object";
+            return LoadResult::NotAnObject;
+        }
 
         // Unknown version → fall back to defaults (forward-incompatible).
         if (j.contains("version") && j["version"].is_number_integer()) {
             int v = j["version"].get<int>();
             if (v != kCurrentVersion) {
+                errorOut = std::format("file version {} != supported version {}", v, kCurrentVersion);
                 reset();
-                return true;
+                return LoadResult::UnknownVersion;
             }
         }
 
@@ -162,7 +174,7 @@ namespace app {
                 updates.channel = updateChannelFromString(u["channel"].get<std::string_view>());
         }
 
-        return true;
+        return LoadResult::Success;
     }
 
     bool AppSettings::saveToFile(const std::string& path) const {

--- a/src/app/settings.cpp
+++ b/src/app/settings.cpp
@@ -1,0 +1,195 @@
+#include "app/settings.h"
+
+#include <algorithm>
+#include <fstream>
+#include <limits>
+
+#include <nlohmann/json.hpp>
+
+namespace app {
+
+    namespace {
+        constexpr int kMinTimeoutMs = 1000;
+        constexpr int kMaxTimeoutMs = 30000;
+        constexpr int kMinRetries = 1;
+        constexpr int kMaxRetries = 10;
+        constexpr int kMinConnections = 1;
+        constexpr int kMaxConnections = 4;
+        constexpr float kMinLineWeight = 1.0f;
+        constexpr float kMaxLineWeight = 3.0f;
+        constexpr float kMinMarkerSize = 0.0f;
+        constexpr float kMaxMarkerSize = 10.0f;
+
+        template <typename T>
+        T clampValue(T value, T min, T max, T fallback) {
+            if (value < min || value > max) return fallback;
+            return value;
+        }
+    }
+
+    std::string_view themeModeToString(ThemeMode mode) noexcept {
+        switch (mode) {
+            case ThemeMode::Light:  return "light";
+            case ThemeMode::Dark:   return "dark";
+            case ThemeMode::System: return "system";
+        }
+        return "system";
+    }
+
+    ThemeMode themeModeFromString(std::string_view str) noexcept {
+        if (str == "light") return ThemeMode::Light;
+        if (str == "dark")  return ThemeMode::Dark;
+        return ThemeMode::System;
+    }
+
+    std::string_view updateChannelToString(UpdateChannel channel) noexcept {
+        switch (channel) {
+            case UpdateChannel::Stable: return "stable";
+            case UpdateChannel::Beta:   return "beta";
+        }
+        return "stable";
+    }
+
+    UpdateChannel updateChannelFromString(std::string_view str) noexcept {
+        if (str == "beta") return UpdateChannel::Beta;
+        return UpdateChannel::Stable;
+    }
+
+    AppSettings AppSettings::defaults() {
+        AppSettings s;
+        s.reset();
+        return s;
+    }
+
+    void AppSettings::reset() {
+        version = kCurrentVersion;
+
+        general.showDebugLogOnStartup = true;
+        general.restoreWindowLayout = true;
+
+        appearance.themeMode = ThemeMode::System;
+        appearance.plotLineWeight = 1.0f;
+
+        dde.connectionTimeoutMs = 5000;
+        dde.maxRetryCount = 3;
+        dde.autoReconnect = true;
+        dde.maxConnections = 4;
+
+        plot.showGridByDefault = true;
+        plot.markerSize = 5.0f;
+
+        updates.autoCheckOnStartup = false;
+        updates.channel = UpdateChannel::Stable;
+    }
+
+    bool AppSettings::loadFromFile(const std::string& path) {
+        std::ifstream in(path);
+        if (!in.is_open()) return false;
+
+        nlohmann::json j;
+        try {
+            in >> j;
+        } catch (const nlohmann::json::parse_error&) {
+            return false;
+        }
+        if (!j.is_object()) return false;
+
+        // Unknown version → fall back to defaults (forward-incompatible).
+        if (j.contains("version") && j["version"].is_number_integer()) {
+            int v = j["version"].get<int>();
+            if (v != kCurrentVersion) {
+                reset();
+                return true;
+            }
+        }
+
+        // --- General ---
+        if (j.contains("general") && j["general"].is_object()) {
+            const auto& g = j["general"];
+            if (g.contains("showDebugLogOnStartup") && g["showDebugLogOnStartup"].is_boolean())
+                general.showDebugLogOnStartup = g["showDebugLogOnStartup"].get<bool>();
+            if (g.contains("restoreWindowLayout") && g["restoreWindowLayout"].is_boolean())
+                general.restoreWindowLayout = g["restoreWindowLayout"].get<bool>();
+        }
+
+        // --- Appearance ---
+        if (j.contains("appearance") && j["appearance"].is_object()) {
+            const auto& a = j["appearance"];
+            if (a.contains("themeMode") && a["themeMode"].is_string())
+                appearance.themeMode = themeModeFromString(a["themeMode"].get<std::string_view>());
+            if (a.contains("plotLineWeight") && a["plotLineWeight"].is_number()) {
+                appearance.plotLineWeight = clampValue(
+                    a["plotLineWeight"].get<float>(), kMinLineWeight, kMaxLineWeight, 1.0f);
+            }
+        }
+
+        // --- DDE ---
+        if (j.contains("dde") && j["dde"].is_object()) {
+            const auto& d = j["dde"];
+            if (d.contains("connectionTimeoutMs") && d["connectionTimeoutMs"].is_number_integer()) {
+                dde.connectionTimeoutMs = clampValue(
+                    d["connectionTimeoutMs"].get<int>(), kMinTimeoutMs, kMaxTimeoutMs, 5000);
+            }
+            if (d.contains("maxRetryCount") && d["maxRetryCount"].is_number_integer()) {
+                dde.maxRetryCount = clampValue(
+                    d["maxRetryCount"].get<int>(), kMinRetries, kMaxRetries, 3);
+            }
+            if (d.contains("autoReconnect") && d["autoReconnect"].is_boolean())
+                dde.autoReconnect = d["autoReconnect"].get<bool>();
+            if (d.contains("maxConnections") && d["maxConnections"].is_number_integer()) {
+                dde.maxConnections = clampValue(
+                    d["maxConnections"].get<int>(), kMinConnections, kMaxConnections, 4);
+            }
+        }
+
+        // --- Plot ---
+        if (j.contains("plot") && j["plot"].is_object()) {
+            const auto& p = j["plot"];
+            if (p.contains("showGridByDefault") && p["showGridByDefault"].is_boolean())
+                plot.showGridByDefault = p["showGridByDefault"].get<bool>();
+            if (p.contains("markerSize") && p["markerSize"].is_number()) {
+                plot.markerSize = clampValue(
+                    p["markerSize"].get<float>(), kMinMarkerSize, kMaxMarkerSize, 5.0f);
+            }
+        }
+
+        // --- Updates ---
+        if (j.contains("updates") && j["updates"].is_object()) {
+            const auto& u = j["updates"];
+            if (u.contains("autoCheckOnStartup") && u["autoCheckOnStartup"].is_boolean())
+                updates.autoCheckOnStartup = u["autoCheckOnStartup"].get<bool>();
+            if (u.contains("channel") && u["channel"].is_string())
+                updates.channel = updateChannelFromString(u["channel"].get<std::string_view>());
+        }
+
+        return true;
+    }
+
+    bool AppSettings::saveToFile(const std::string& path) const {
+        nlohmann::json j;
+        j["version"] = version;
+
+        j["general"]["showDebugLogOnStartup"] = general.showDebugLogOnStartup;
+        j["general"]["restoreWindowLayout"]   = general.restoreWindowLayout;
+
+        j["appearance"]["themeMode"]      = std::string{themeModeToString(appearance.themeMode)};
+        j["appearance"]["plotLineWeight"] = appearance.plotLineWeight;
+
+        j["dde"]["connectionTimeoutMs"] = dde.connectionTimeoutMs;
+        j["dde"]["maxRetryCount"]       = dde.maxRetryCount;
+        j["dde"]["autoReconnect"]       = dde.autoReconnect;
+        j["dde"]["maxConnections"]      = dde.maxConnections;
+
+        j["plot"]["showGridByDefault"] = plot.showGridByDefault;
+        j["plot"]["markerSize"]        = plot.markerSize;
+
+        j["updates"]["autoCheckOnStartup"] = updates.autoCheckOnStartup;
+        j["updates"]["channel"]            = std::string{updateChannelToString(updates.channel)};
+
+        std::ofstream out(path, std::ios::trunc);
+        if (!out.is_open()) return false;
+        out << j.dump(2);
+        return out.good();
+    }
+
+} // namespace app

--- a/src/app/settings.cpp
+++ b/src/app/settings.cpp
@@ -11,6 +11,8 @@ namespace app {
     namespace {
         constexpr int kMinTimeoutMs = 1000;
         constexpr int kMaxTimeoutMs = 30000;
+        constexpr int kMinRequestTimeoutMs = 100;
+        constexpr int kMaxRequestTimeoutMs = 30000;
         constexpr int kMinRetries = 1;
         constexpr int kMaxRetries = 10;
         constexpr int kMinConnections = 1;
@@ -73,6 +75,16 @@ namespace app {
         dde.maxRetryCount = 3;
         dde.autoReconnect = true;
         dde.maxConnections = 4;
+
+        dde.getNameTimeoutMs = 2000;
+        dde.getFileTimeoutMs = 2000;
+        dde.getSystemTimeoutMs = 2000;
+        dde.getFieldTimeoutMs = 2000;
+        dde.getWaveTimeoutMs = 2000;
+        dde.getSurfaceDataProfileTimeoutMs = 2000;
+        dde.getSagProfileTimeoutMs = 1000;
+        dde.getSurfaceDataMapTimeoutMs = 2000;
+        dde.getSagMapTimeoutMs = 1000;
 
         plot.showGridByDefault = true;
         plot.lineWeight = 1.0f;
@@ -148,6 +160,53 @@ namespace app {
                 dde.maxConnections = clampValue(
                     d["maxConnections"].get<int>(), kMinConnections, kMaxConnections, 4);
             }
+            if (d.contains("getNameTimeoutMs") && d["getNameTimeoutMs"].is_number_integer()) {
+                dde.getNameTimeoutMs = clampValue(
+                    d["getNameTimeoutMs"].get<int>(), kMinRequestTimeoutMs, kMaxRequestTimeoutMs, 2000);
+            }
+            if (d.contains("getFileTimeoutMs") && d["getFileTimeoutMs"].is_number_integer()) {
+                dde.getFileTimeoutMs = clampValue(
+                    d["getFileTimeoutMs"].get<int>(), kMinRequestTimeoutMs, kMaxRequestTimeoutMs, 2000);
+            }
+            if (d.contains("getSystemTimeoutMs") && d["getSystemTimeoutMs"].is_number_integer()) {
+                dde.getSystemTimeoutMs = clampValue(
+                    d["getSystemTimeoutMs"].get<int>(), kMinRequestTimeoutMs, kMaxRequestTimeoutMs, 2000);
+            }
+            if (d.contains("getFieldTimeoutMs") && d["getFieldTimeoutMs"].is_number_integer()) {
+                dde.getFieldTimeoutMs = clampValue(
+                    d["getFieldTimeoutMs"].get<int>(), kMinRequestTimeoutMs, kMaxRequestTimeoutMs, 2000);
+            }
+            if (d.contains("getWaveTimeoutMs") && d["getWaveTimeoutMs"].is_number_integer()) {
+                dde.getWaveTimeoutMs = clampValue(
+                    d["getWaveTimeoutMs"].get<int>(), kMinRequestTimeoutMs, kMaxRequestTimeoutMs, 2000);
+            }
+            // Per-window GetSurfaceData/GetSag with backward compat.
+            // Legacy: single getSurfaceDataTimeoutMs / getSagTimeoutMs shared by all windows.
+            auto loadPerWindow = [&](const char* newKey, int& target, int fallback) {
+                if (d.contains(newKey) && d[newKey].is_number_integer()) {
+                    target = clampValue(d[newKey].get<int>(), kMinRequestTimeoutMs, kMaxRequestTimeoutMs, fallback);
+                }
+            };
+            loadPerWindow("getSurfaceDataProfileTimeoutMs", dde.getSurfaceDataProfileTimeoutMs, 2000);
+            loadPerWindow("getSagProfileTimeoutMs",        dde.getSagProfileTimeoutMs,        1000);
+            loadPerWindow("getSurfaceDataMapTimeoutMs",     dde.getSurfaceDataMapTimeoutMs,     2000);
+            loadPerWindow("getSagMapTimeoutMs",             dde.getSagMapTimeoutMs,             1000);
+
+            // Backward compat: if legacy fields exist but new ones don't, use legacy values.
+            if (d.contains("getSurfaceDataTimeoutMs") && d["getSurfaceDataTimeoutMs"].is_number_integer()) {
+                int legacy = clampValue(d["getSurfaceDataTimeoutMs"].get<int>(), kMinRequestTimeoutMs, kMaxRequestTimeoutMs, 2000);
+                if (!d.contains("getSurfaceDataProfileTimeoutMs"))
+                    dde.getSurfaceDataProfileTimeoutMs = legacy;
+                if (!d.contains("getSurfaceDataMapTimeoutMs"))
+                    dde.getSurfaceDataMapTimeoutMs = legacy;
+            }
+            if (d.contains("getSagTimeoutMs") && d["getSagTimeoutMs"].is_number_integer()) {
+                int legacy = clampValue(d["getSagTimeoutMs"].get<int>(), kMinRequestTimeoutMs, kMaxRequestTimeoutMs, 1000);
+                if (!d.contains("getSagProfileTimeoutMs"))
+                    dde.getSagProfileTimeoutMs = legacy;
+                if (!d.contains("getSagMapTimeoutMs"))
+                    dde.getSagMapTimeoutMs = legacy;
+            }
         }
 
         // --- Plot ---
@@ -190,6 +249,16 @@ namespace app {
         j["dde"]["maxRetryCount"]       = dde.maxRetryCount;
         j["dde"]["autoReconnect"]       = dde.autoReconnect;
         j["dde"]["maxConnections"]      = dde.maxConnections;
+
+        j["dde"]["getNameTimeoutMs"]              = dde.getNameTimeoutMs;
+        j["dde"]["getFileTimeoutMs"]              = dde.getFileTimeoutMs;
+        j["dde"]["getSystemTimeoutMs"]            = dde.getSystemTimeoutMs;
+        j["dde"]["getFieldTimeoutMs"]             = dde.getFieldTimeoutMs;
+        j["dde"]["getWaveTimeoutMs"]              = dde.getWaveTimeoutMs;
+        j["dde"]["getSurfaceDataProfileTimeoutMs"] = dde.getSurfaceDataProfileTimeoutMs;
+        j["dde"]["getSagProfileTimeoutMs"]         = dde.getSagProfileTimeoutMs;
+        j["dde"]["getSurfaceDataMapTimeoutMs"]     = dde.getSurfaceDataMapTimeoutMs;
+        j["dde"]["getSagMapTimeoutMs"]             = dde.getSagMapTimeoutMs;
 
         j["plot"]["showGridByDefault"] = plot.showGridByDefault;
         j["plot"]["lineWeight"]        = plot.lineWeight;

--- a/src/app/settings.cpp
+++ b/src/app/settings.cpp
@@ -68,7 +68,6 @@ namespace app {
         general.restoreWindowLayout = true;
 
         appearance.themeMode = ThemeMode::System;
-        appearance.plotLineWeight = 1.0f;
 
         dde.connectionTimeoutMs = 5000;
         dde.maxRetryCount = 3;
@@ -76,6 +75,7 @@ namespace app {
         dde.maxConnections = 4;
 
         plot.showGridByDefault = true;
+        plot.lineWeight = 1.0f;
         plot.markerSize = 5.0f;
 
         updates.autoCheckOnStartup = false;
@@ -117,10 +117,6 @@ namespace app {
             const auto& a = j["appearance"];
             if (a.contains("themeMode") && a["themeMode"].is_string())
                 appearance.themeMode = themeModeFromString(a["themeMode"].get<std::string_view>());
-            if (a.contains("plotLineWeight") && a["plotLineWeight"].is_number()) {
-                appearance.plotLineWeight = clampValue(
-                    a["plotLineWeight"].get<float>(), kMinLineWeight, kMaxLineWeight, 1.0f);
-            }
         }
 
         // --- DDE ---
@@ -147,6 +143,10 @@ namespace app {
             const auto& p = j["plot"];
             if (p.contains("showGridByDefault") && p["showGridByDefault"].is_boolean())
                 plot.showGridByDefault = p["showGridByDefault"].get<bool>();
+            if (p.contains("lineWeight") && p["lineWeight"].is_number()) {
+                plot.lineWeight = clampValue(
+                    p["lineWeight"].get<float>(), kMinLineWeight, kMaxLineWeight, 1.0f);
+            }
             if (p.contains("markerSize") && p["markerSize"].is_number()) {
                 plot.markerSize = clampValue(
                     p["markerSize"].get<float>(), kMinMarkerSize, kMaxMarkerSize, 5.0f);
@@ -173,7 +173,6 @@ namespace app {
         j["general"]["restoreWindowLayout"]   = general.restoreWindowLayout;
 
         j["appearance"]["themeMode"]      = std::string{themeModeToString(appearance.themeMode)};
-        j["appearance"]["plotLineWeight"] = appearance.plotLineWeight;
 
         j["dde"]["connectionTimeoutMs"] = dde.connectionTimeoutMs;
         j["dde"]["maxRetryCount"]       = dde.maxRetryCount;
@@ -181,6 +180,7 @@ namespace app {
         j["dde"]["maxConnections"]      = dde.maxConnections;
 
         j["plot"]["showGridByDefault"] = plot.showGridByDefault;
+        j["plot"]["lineWeight"]        = plot.lineWeight;
         j["plot"]["markerSize"]        = plot.markerSize;
 
         j["updates"]["autoCheckOnStartup"] = updates.autoCheckOnStartup;

--- a/src/app/settings.h
+++ b/src/app/settings.h
@@ -56,9 +56,21 @@ namespace app {
         void reset();
         [[nodiscard]] static AppSettings defaults();
 
+        // Outcome of loadFromFileWithReason. FileMissing is NOT an error
+        // (first launch), all other non-Success values indicate a real
+        // problem that should be reported to the user.
+        enum class LoadResult {
+            Success,
+            FileMissing,
+            ParseError,
+            NotAnObject,
+            UnknownVersion,
+        };
+
         // Throws std::runtime_error if file missing and createIfMissing==false,
         // returns false on parse errors. Logs to logger; never throws from JSON layer.
         [[nodiscard]] bool loadFromFile(const std::string& path);
+        [[nodiscard]] LoadResult loadFromFileWithReason(const std::string& path, std::string& errorOut) noexcept;
         [[nodiscard]] bool saveToFile(const std::string& path) const;
     };
 

--- a/src/app/settings.h
+++ b/src/app/settings.h
@@ -30,6 +30,21 @@ namespace app {
         int maxRetryCount = 3;
         bool autoReconnect = true;
         int maxConnections = 4;
+
+        // Per-request timeout overrides — Initial Data Load (startup).
+        int getNameTimeoutMs = 2000;
+        int getFileTimeoutMs = 2000;
+        int getSystemTimeoutMs = 2000;
+        int getFieldTimeoutMs = 2000;
+        int getWaveTimeoutMs = 2000;
+
+        // Per-request timeout overrides — Surface Profile Inspector.
+        int getSurfaceDataProfileTimeoutMs = 2000;
+        int getSagProfileTimeoutMs = 1000;
+
+        // Per-request timeout overrides — Surface Irregularity Map.
+        int getSurfaceDataMapTimeoutMs = 2000;
+        int getSagMapTimeoutMs = 1000;
     };
 
     struct PlotSettings {

--- a/src/app/settings.h
+++ b/src/app/settings.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace app {
+
+    enum class ThemeMode {
+        Light,
+        Dark,
+        System,
+    };
+
+    enum class UpdateChannel {
+        Stable,
+        Beta,
+    };
+
+    struct GeneralSettings {
+        bool showDebugLogOnStartup = true;
+        bool restoreWindowLayout = true;
+    };
+
+    struct AppearanceSettings {
+        ThemeMode themeMode = ThemeMode::System;
+        float plotLineWeight = 1.0f;
+    };
+
+    struct DDESettings {
+        int connectionTimeoutMs = 5000;
+        int maxRetryCount = 3;
+        bool autoReconnect = true;
+        int maxConnections = 4;
+    };
+
+    struct PlotSettings {
+        bool showGridByDefault = true;
+        float markerSize = 5.0f;
+    };
+
+    struct UpdateSettings {
+        bool autoCheckOnStartup = false;
+        UpdateChannel channel = UpdateChannel::Stable;
+    };
+
+    struct AppSettings {
+        static constexpr int kCurrentVersion = 1;
+
+        int version = kCurrentVersion;
+        GeneralSettings general;
+        AppearanceSettings appearance;
+        DDESettings dde;
+        PlotSettings plot;
+        UpdateSettings updates;
+
+        void reset();
+        [[nodiscard]] static AppSettings defaults();
+
+        // Throws std::runtime_error if file missing and createIfMissing==false,
+        // returns false on parse errors. Logs to logger; never throws from JSON layer.
+        [[nodiscard]] bool loadFromFile(const std::string& path);
+        [[nodiscard]] bool saveToFile(const std::string& path) const;
+    };
+
+    // Enum <-> string helpers (used by JSON load/save).
+    [[nodiscard]] std::string_view themeModeToString(ThemeMode mode) noexcept;
+    [[nodiscard]] ThemeMode themeModeFromString(std::string_view str) noexcept;
+
+    [[nodiscard]] std::string_view updateChannelToString(UpdateChannel channel) noexcept;
+    [[nodiscard]] UpdateChannel updateChannelFromString(std::string_view str) noexcept;
+
+} // namespace app

--- a/src/app/settings.h
+++ b/src/app/settings.h
@@ -23,7 +23,6 @@ namespace app {
 
     struct AppearanceSettings {
         ThemeMode themeMode = ThemeMode::System;
-        float plotLineWeight = 1.0f;
     };
 
     struct DDESettings {
@@ -35,6 +34,7 @@ namespace app {
 
     struct PlotSettings {
         bool showGridByDefault = true;
+        float lineWeight = 1.0f;
         float markerSize = 5.0f;
     };
 

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -56,6 +56,27 @@ namespace ZemaxDDE {
             [[nodiscard]] DWORD getDefaultTimeoutMs() const noexcept { return m_defaultTimeoutMs; }
             [[nodiscard]] int   getDefaultRetries()   const noexcept { return m_defaultRetries; }
 
+            // Per-request timeout overrides. Updated by DDEConnectionManager.
+            void setGetNameTimeoutMs(DWORD ms) noexcept        { m_getNameTimeoutMs = ms; }
+            void setGetFileTimeoutMs(DWORD ms) noexcept        { m_getFileTimeoutMs = ms; }
+            void setGetSystemTimeoutMs(DWORD ms) noexcept      { m_getSystemTimeoutMs = ms; }
+            void setGetFieldTimeoutMs(DWORD ms) noexcept       { m_getFieldTimeoutMs = ms; }
+            void setGetWaveTimeoutMs(DWORD ms) noexcept        { m_getWaveTimeoutMs = ms; }
+            void setGetSurfaceDataProfileTimeoutMs(DWORD ms) noexcept { m_getSurfaceDataProfileTimeoutMs = ms; }
+            void setGetSagProfileTimeoutMs(DWORD ms) noexcept         { m_getSagProfileTimeoutMs = ms; }
+            void setGetSurfaceDataMapTimeoutMs(DWORD ms) noexcept     { m_getSurfaceDataMapTimeoutMs = ms; }
+            void setGetSagMapTimeoutMs(DWORD ms) noexcept             { m_getSagMapTimeoutMs = ms; }
+
+            [[nodiscard]] DWORD getGetNameTimeoutMs() const noexcept        { return m_getNameTimeoutMs; }
+            [[nodiscard]] DWORD getGetFileTimeoutMs() const noexcept        { return m_getFileTimeoutMs; }
+            [[nodiscard]] DWORD getGetSystemTimeoutMs() const noexcept      { return m_getSystemTimeoutMs; }
+            [[nodiscard]] DWORD getGetFieldTimeoutMs() const noexcept       { return m_getFieldTimeoutMs; }
+            [[nodiscard]] DWORD getGetWaveTimeoutMs() const noexcept        { return m_getWaveTimeoutMs; }
+            [[nodiscard]] DWORD getGetSurfaceDataProfileTimeoutMs() const noexcept { return m_getSurfaceDataProfileTimeoutMs; }
+            [[nodiscard]] DWORD getGetSagProfileTimeoutMs() const noexcept         { return m_getSagProfileTimeoutMs; }
+            [[nodiscard]] DWORD getGetSurfaceDataMapTimeoutMs() const noexcept     { return m_getSurfaceDataMapTimeoutMs; }
+            [[nodiscard]] DWORD getGetSagMapTimeoutMs() const noexcept             { return m_getSagMapTimeoutMs; }
+
             LRESULT handleDDEMessages(UINT iMsg, WPARAM wParam, LPARAM lParam);
 
             using OnDDEConnectedCallback = std::function<void(ZemaxDDEClient*)>;
@@ -105,5 +126,15 @@ namespace ZemaxDDE {
 
             DWORD m_defaultTimeoutMs = 1000;
             int   m_defaultRetries   = 1;
+
+            DWORD m_getNameTimeoutMs = 2000;
+            DWORD m_getFileTimeoutMs = 2000;
+            DWORD m_getSystemTimeoutMs = 2000;
+            DWORD m_getFieldTimeoutMs = 2000;
+            DWORD m_getWaveTimeoutMs = 2000;
+            DWORD m_getSurfaceDataProfileTimeoutMs = 2000;
+            DWORD m_getSagProfileTimeoutMs = 1000;
+            DWORD m_getSurfaceDataMapTimeoutMs = 2000;
+            DWORD m_getSagMapTimeoutMs = 1000;
     };
 }

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -48,18 +48,28 @@ namespace ZemaxDDE {
             void pumpMessages();
             void processTimeouts();
 
+            /// Default timeout/retries used by submitRequest when caller passes
+            /// the sentinel value (0 / -1). Updated by DDEConnectionManager from
+            /// AppSettings.dde at runtime.
+            void setDefaultTimeoutMs(DWORD ms) noexcept { m_defaultTimeoutMs = ms; }
+            void setDefaultRetries(int n) noexcept { m_defaultRetries = n; }
+            [[nodiscard]] DWORD getDefaultTimeoutMs() const noexcept { return m_defaultTimeoutMs; }
+            [[nodiscard]] int   getDefaultRetries()   const noexcept { return m_defaultRetries; }
+
             LRESULT handleDDEMessages(UINT iMsg, WPARAM wParam, LPARAM lParam);
 
             using OnDDEConnectedCallback = std::function<void(ZemaxDDEClient*)>;
             void setOnDDEConnectedCallback(OnDDEConnectedCallback callback);
 
             /// Submits a DDE request for processing and starts if the pipeline is idle.
+            /// @param timeoutMs 0 = use client's default (AppSettings.dde.connectionTimeoutMs).
+            /// @param retries   -1 = use client's default (AppSettings.dde.maxRetryCount).
             /// @return Unique request ID for logging.
             uint64_t submitRequest(const std::string& command,
                 std::function<void(const std::string&)> onSuccess,
                 std::function<void(const std::string&)> onError,
-                DWORD timeoutMs = 1000,
-                int retries = 1,
+                DWORD timeoutMs = 0,
+                int retries = -1,
                 const std::string& serviceId = "");
 
             // Getters
@@ -92,5 +102,8 @@ namespace ZemaxDDE {
             std::deque<DdeRequest> m_requestQueue;
             std::optional<DdeRequest> m_activeRequest;
             uint64_t m_nextRequestId = 1;
+
+            DWORD m_defaultTimeoutMs = 1000;
+            int   m_defaultRetries   = 1;
     };
 }

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -29,6 +29,13 @@ namespace ZemaxDDE {
 
     class ZemaxDDEClient {
         public:
+            /// Threshold for emitting a mass-error diagnostic warning when
+            /// multiple consecutive DDE requests fail with 'Zemax is not connected'
+            /// in a single dispatchNext() invocation. 50 is large enough to
+            /// avoid log spam for normal single failures but small enough to
+            /// flag server-side outages in production.
+            static constexpr size_t kMassErrorWarnThreshold = 50;
+
             ZemaxDDEClient(HWND hwndClient, Logger& logger);
             ~ZemaxDDEClient();
 

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -124,6 +124,10 @@ namespace ZemaxDDE {
         int retries,
         const std::string& serviceId) {
 
+        // Sentinel: 0 / -1 → use client defaults driven by AppSettings.dde.
+        if (timeoutMs == 0) timeoutMs = m_defaultTimeoutMs;
+        if (retries   <  0) retries   = m_defaultRetries;
+
         uint64_t id = m_nextRequestId++;
         DdeRequest req;
         req.id = id;

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -235,7 +235,6 @@ namespace ZemaxDDE {
     };
 
     LRESULT ZemaxDDEClient::handleDDEMessages(UINT iMsg, WPARAM wParam, LPARAM lParam) {
-        DDEACK DdeAck{};
         ATOM aItem;
         UINT_PTR lowWord, highWord;
         std::string buffer;
@@ -267,14 +266,47 @@ namespace ZemaxDDE {
                 return 0;
             }
             case WM_DDE_DATA: {
+                // ====== CLIENT-SIDE ACK STRUCTURE ======
+                // `clientAck` is what WE (the client) send back to the server in WM_DDE_ACK.
+                // It is NOT a server-side data structure.
+                // Field semantics (from client's perspective):
+                //   • clientAck.fAck       — "I successfully received and processed the data"
+                //   • clientAck.fBusy      — "I am NOT busy" (always 0; we don't defer)
+                //   • clientAck.fRelease   — "I do NOT request server to free anything" (always 0)
+                //   • clientAck.fAckReq    — "I do NOT request ACK for my own ACK" (always 0)
+                DDEACK clientAck{};
+
                 UnpackDDElParam(WM_DDE_DATA, lParam, &lowWord, &highWord);
                 FreeDDElParam(WM_DDE_DATA, lParam);
 
+                // ====== SERVER-SIDE DATA STRUCTURE ======
+                // `serverData` is the DDEDATA structure the SERVER (Zemax) sent us.
+                // We never modify it — we only read its flags and copy its Value[].
+                // Field semantics (from server's perspective):
+                //   • serverData->fAckReq  — "Server REQUESTS us to send WM_DDE_ACK"
+                //   • serverData->fRelease — "Server REQUESTS us to GlobalFree the handle after reading"
+                //   • serverData->fAck     — "Server is acknowledging a previous request"
+                //   • serverData->fBusy    — "Server is busy, will respond later"
                 GLOBALHANDLE ddeDataHandle = reinterpret_cast<GLOBALHANDLE>(reinterpret_cast<uintptr_t>(lowWord));
-                GlobalLockGuard ddeDataLock(ddeDataHandle);
+                GlobalLockGuard serverDataLock(ddeDataHandle);
                 aItem = static_cast<ATOM>(highWord);
 
-                if (ddeDataLock.isValid() && ddeDataLock.as<::DDEDATA>()->cfFormat == CF_TEXT) {
+                // ====== C-1 FIX: validate GlobalLock before dereferencing ======
+                // Pre-existing bug: previously, ddeDataLock was validated only at the
+                // start of the CF_TEXT block. If GlobalLock returned nullptr (invalid
+                // handle, race with server freeing the handle, memory pressure), code
+                // would dereference nullptr when reading fAckReq / fRelease below,
+                // causing a process crash. Now we validate ONCE up front and cache
+                // the pointer for safe subsequent access.
+                if (!serverDataLock.isValid()) {
+                    // Cannot read server's data — drop atom and exit.
+                    // No ACK sent (server will eventually timeout).
+                    GlobalDeleteAtom(aItem);
+                    return 0;
+                }
+                auto* serverData = serverDataLock.as<::DDEDATA>();
+
+                if (serverData->cfFormat == CF_TEXT) {
                     char item[512]; 
                     wchar_t wItem[512];
                     GlobalGetAtomNameW(aItem, wItem, sizeof(wItem));
@@ -284,7 +316,7 @@ namespace ZemaxDDE {
                     std::vector<std::string> item_tokens = ZemaxDDE::tokenize(dde_item_str);
                     std::string command_token = item_tokens.empty() ? "" : item_tokens[0];
 
-                    buffer = reinterpret_cast<char*>(ddeDataLock.as<::DDEDATA>()->Value);
+                    buffer = reinterpret_cast<char*>(serverData->Value);
 
                     #ifdef DEBUG_LOG
                     m_logger.addLog(std::format("[DDE] Received 'WM_DDE_DATA', content = {}", buffer));
@@ -298,7 +330,7 @@ namespace ZemaxDDE {
                             m_activeRequest->onSuccess(buffer);
                         }
                         finishRequest();
-                        DdeAck.fAck = true;
+                        clientAck.fAck = true;
                         matched = true;
                     }
 
@@ -314,12 +346,12 @@ namespace ZemaxDDE {
                                 m_logger.addLog("[DDE] GetName: empty lens name, using default 'unknown'");
                             }
                             m_opticalSystem.lensName = name;
-                            DdeAck.fAck = true;
+                            clientAck.fAck = true;
                         }
                         if (command_token == "GetFile") {
                             std::string fileNameStr = extractStringFromDDE(ddeDataHandle);
                             m_opticalSystem.fileName = fileNameStr;
-                            DdeAck.fAck = true;
+                            clientAck.fAck = true;
                         }
                         if (command_token == "GetSystem") {
                             const int GET_SYSTEM_PARAMS_COUNT = 9;
@@ -355,7 +387,7 @@ namespace ZemaxDDE {
                                 m_opticalSystem.pressure      = std::stod(systemParams[PRESSURE]);
                                 m_opticalSystem.globalRefSurf = std::stoi(systemParams[GLOBAL_REF_SURF]);
 
-                                DdeAck.fAck = true;
+                                clientAck.fAck = true;
                             } catch (const std::invalid_argument& e) {
                                 m_logger.addLog(std::format("[DDE] GetSystem: Invalid number format in parameter: {}", e.what()));
                                 return 0;
@@ -452,7 +484,7 @@ namespace ZemaxDDE {
                                                         ZemaxDDE::MIN_FIELDS, ZemaxDDE::MAX_FIELDS, arg));
                                 return 0;
                             }
-                            DdeAck.fAck = true;
+                            clientAck.fAck = true;
                         }
                         if (command_token == "GetWave") {
                             const int EXPECTED_COMMAND_TOKENS = 2;
@@ -533,19 +565,34 @@ namespace ZemaxDDE {
                                                         ZemaxDDE::MIN_WAVES, ZemaxDDE::MAX_FIELDS, arg));
                                 return 0;
                             }
-                            DdeAck.fAck = true;
+                            clientAck.fAck = true;
                         }
                         if (command_token == "GetSurfaceData") {
-                            DdeAck.fAck = true;
+                            clientAck.fAck = true;
                         }
                         if (command_token == "GetSag") {
-                            DdeAck.fAck = true;
+                            clientAck.fAck = true;
                         }
                     }
                 }
-                if (ddeDataLock.as<::DDEDATA>()->fAckReq == true) {
-                    WORD wStatus;
-                    memcpy(&wStatus, &DdeAck, sizeof(wStatus));
+                if (serverData->fAckReq == true) {
+                    // Server wants our ACK. Build the status word per DDE protocol:
+                    //   bit 13: fAck      (clientAck.fAck  ? 1 : 0)
+                    //   bit 12: fBusy     (clientAck.fBusy ? 1 : 0 — always 0; client never busy)
+                    //   bits 0-11, 14-15: unused/reserved (0)
+                    //
+                    // NOTE: DDEACK in MinGW's <dde.h> only has fields {unused, fBusy, fAck}.
+                    // fRelease is a SERVER-side flag (in DDEDATA), not part of the client's
+                    // outgoing DDEACK, so it is correctly omitted here. Constructed
+                    // explicitly (not via memcpy of the DDEACK struct) so the bit
+                    // positions match the wire protocol regardless of how the compiler
+                    // arranges the bitfields in DDEACK (MSVC vs MinGW/GCC differ).
+                    static_assert(sizeof(::DDEACK) == sizeof(WORD),
+                        "DDEACK must be 2 bytes; PackDDElParam requires WORD for WM_DDE_ACK");
+                    WORD wStatus = static_cast<WORD>(
+                        (clientAck.fAck  ? 0x2000 : 0) |
+                        (clientAck.fBusy ? 0x1000 : 0)
+                    );
                     if (!PostMessageW(reinterpret_cast<HWND>(wParam), WM_DDE_ACK, reinterpret_cast<WPARAM>(m_hwndZemaxClient), PackDDElParam(WM_DDE_ACK, wStatus, aItem))) {
                         GlobalDeleteAtom(aItem);
                         GlobalFree(ddeDataHandle);
@@ -554,7 +601,15 @@ namespace ZemaxDDE {
                 } else {
                     GlobalDeleteAtom(aItem);
                 }
-                if (ddeDataLock.as<::DDEDATA>()->fRelease == true || DdeAck.fAck == false) {
+
+                // Free the handle per DDE protocol in two cases:
+                //   1) Server explicitly requested release (serverData->fRelease = true).
+                //      This is the standard happy path for large data.
+                //   2) We did NOT acknowledge success (clientAck.fAck = false).
+                //      Cleanup on error to prevent handle leak. Per DDE protocol,
+                //      if the client cannot process the data, it should still free
+                //      the handle to avoid memory leak in the server's process.
+                if (serverData->fRelease == true || clientAck.fAck == false) {
                     GlobalFree(ddeDataHandle);
                 }
                 return 0;

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -147,19 +147,53 @@ namespace ZemaxDDE {
     }
 
     void ZemaxDDEClient::dispatchNext() {
-        if (m_requestQueue.empty()) return;
+        // Defensive: caller contract is that m_activeRequest is null here.
+        // If not, do nothing to avoid overwriting an in-flight request.
+        // Public callers (submitRequest) already check this, but the guard
+        // makes the function idempotent for any future internal callers.
+        if (m_activeRequest) return;
 
-        DdeRequest req = std::move(m_requestQueue.front());
-        m_requestQueue.pop_front();
+        // Track consecutive 'Zemax is not connected' errors in this call to
+        // emit a diagnostic warning when a server-side outage causes a batch
+        // of failures (avoids per-request log spam for normal cases).
+        size_t consecutiveErrors = 0;
 
-        if (!m_hwndZemaxServer) {
-            if (req.onError) req.onError("Zemax is not connected");
-            dispatchNext();
-            return;
+        // Iterative loop: avoid unbounded recursion if m_hwndZemaxServer is
+        // null and the queue holds many failed requests (audit C-5).
+        // Each iteration processes one request; the loop drains the queue
+        // until either an active request is dispatched (return) or the
+        // queue is empty.
+        while (!m_requestQueue.empty()) {
+            DdeRequest req = std::move(m_requestQueue.front());
+            m_requestQueue.pop_front();
+
+            if (!m_hwndZemaxServer) {
+                if (req.onError) req.onError("Zemax is not connected");
+                ++consecutiveErrors;
+                continue;
+            }
+
+            m_activeRequest = std::move(req);
+            sendRequest(*m_activeRequest);
+
+            if (consecutiveErrors >= kMassErrorWarnThreshold) {
+                m_logger.addLog(std::format(
+                    "[DDE] Warning: {} consecutive requests failed with "
+                    "'Zemax is not connected' before a successful dispatch. "
+                    "Server may have disconnected mid-batch.",
+                    consecutiveErrors));
+            }
+            return;  // active request set; wait for finishRequest()
         }
 
-        m_activeRequest = std::move(req);
-        sendRequest(*m_activeRequest);
+        // Queue drained without setting an active request (all errored).
+        if (consecutiveErrors >= kMassErrorWarnThreshold) {
+            m_logger.addLog(std::format(
+                "[DDE] Warning: {} consecutive requests failed with "
+                "'Zemax is not connected'. Queue is empty; server is likely "
+                "disconnected.",
+                consecutiveErrors));
+        }
     }
 
     void ZemaxDDEClient::sendRequest(DdeRequest& req) {

--- a/src/dde/dde_connection_manager.cpp
+++ b/src/dde/dde_connection_manager.cpp
@@ -53,7 +53,7 @@ DDEConnectionManager::DDEConnectionManager(Logger& logger)
 }
 
 int DDEConnectionManager::findFreeSlot() {
-    for (int i = 0; i < MAX_CONNECTIONS; ++i) {
+    for (int i = 0; i < m_maxConnections && i < MAX_CONNECTIONS; ++i) {
         if (!m_connections[i].isConnected) {
             return i;
         }
@@ -212,4 +212,50 @@ void DDEConnectionManager::processAllTimeouts() {
 
 std::vector<app::ZemaxWindowInfo> DDEConnectionManager::enumerateAvailableTargets() {
     return app::ZemaxWindowEnumerator::enumerate();
+}
+
+DWORD DDEConnectionManager::getDefaultTimeoutMs() const {
+    for (const auto& conn : m_connections) {
+        if (conn.client) return conn.client->getDefaultTimeoutMs();
+    }
+    return 1000;
+}
+
+int DDEConnectionManager::getDefaultRetries() const {
+    for (const auto& conn : m_connections) {
+        if (conn.client) return conn.client->getDefaultRetries();
+    }
+    return 1;
+}
+
+void DDEConnectionManager::setDefaultTimeoutMs(DWORD ms) {
+    propagateDefaultTimeout(ms);
+}
+
+void DDEConnectionManager::setDefaultRetries(int n) {
+    propagateDefaultRetries(n);
+}
+
+void DDEConnectionManager::setMaxConnections(int n) {
+    if (n < 1) n = 1;
+    if (n > MAX_CONNECTIONS) n = MAX_CONNECTIONS;
+    m_maxConnections = n;
+    m_logger.addLog(std::format("[DDE] Max connections set to {}", n));
+}
+
+void DDEConnectionManager::setAutoReconnect(bool enabled) {
+    m_autoReconnect = enabled;
+    m_logger.addLog(std::format("[DDE] Auto-reconnect {}", enabled ? "enabled" : "disabled"));
+}
+
+void DDEConnectionManager::propagateDefaultTimeout(DWORD ms) {
+    for (auto& conn : m_connections) {
+        if (conn.client) conn.client->setDefaultTimeoutMs(ms);
+    }
+}
+
+void DDEConnectionManager::propagateDefaultRetries(int n) {
+    for (auto& conn : m_connections) {
+        if (conn.client) conn.client->setDefaultRetries(n);
+    }
 }

--- a/src/dde/dde_connection_manager.cpp
+++ b/src/dde/dde_connection_manager.cpp
@@ -85,6 +85,17 @@ int DDEConnectionManager::connectToZemax(HWND targetHwnd, const std::wstring& ti
     SetWindowLongPtrW(conn.hwndClient, GWLP_USERDATA,
         reinterpret_cast<LONG_PTR>(conn.client.get()));
 
+    // Propagate per-request timeouts to new client.
+    conn.client->setGetNameTimeoutMs(m_getNameTimeoutMs);
+    conn.client->setGetFileTimeoutMs(m_getFileTimeoutMs);
+    conn.client->setGetSystemTimeoutMs(m_getSystemTimeoutMs);
+    conn.client->setGetFieldTimeoutMs(m_getFieldTimeoutMs);
+    conn.client->setGetWaveTimeoutMs(m_getWaveTimeoutMs);
+    conn.client->setGetSurfaceDataProfileTimeoutMs(m_getSurfaceDataProfileTimeoutMs);
+    conn.client->setGetSagProfileTimeoutMs(m_getSagProfileTimeoutMs);
+    conn.client->setGetSurfaceDataMapTimeoutMs(m_getSurfaceDataMapTimeoutMs);
+    conn.client->setGetSagMapTimeoutMs(m_getSagMapTimeoutMs);
+
     try {
         conn.client->initiateDDE(targetHwnd);
     } catch (const std::exception& e) {
@@ -248,6 +259,51 @@ void DDEConnectionManager::setAutoReconnect(bool enabled) {
     m_logger.addLog(std::format("[DDE] Auto-reconnect {}", enabled ? "enabled" : "disabled"));
 }
 
+void DDEConnectionManager::setGetNameTimeoutMs(DWORD ms) {
+    m_getNameTimeoutMs = ms;
+    propagatePerRequestTimeouts();
+}
+
+void DDEConnectionManager::setGetFileTimeoutMs(DWORD ms) {
+    m_getFileTimeoutMs = ms;
+    propagatePerRequestTimeouts();
+}
+
+void DDEConnectionManager::setGetSystemTimeoutMs(DWORD ms) {
+    m_getSystemTimeoutMs = ms;
+    propagatePerRequestTimeouts();
+}
+
+void DDEConnectionManager::setGetFieldTimeoutMs(DWORD ms) {
+    m_getFieldTimeoutMs = ms;
+    propagatePerRequestTimeouts();
+}
+
+void DDEConnectionManager::setGetWaveTimeoutMs(DWORD ms) {
+    m_getWaveTimeoutMs = ms;
+    propagatePerRequestTimeouts();
+}
+
+void DDEConnectionManager::setGetSurfaceDataProfileTimeoutMs(DWORD ms) {
+    m_getSurfaceDataProfileTimeoutMs = ms;
+    propagatePerRequestTimeouts();
+}
+
+void DDEConnectionManager::setGetSagProfileTimeoutMs(DWORD ms) {
+    m_getSagProfileTimeoutMs = ms;
+    propagatePerRequestTimeouts();
+}
+
+void DDEConnectionManager::setGetSurfaceDataMapTimeoutMs(DWORD ms) {
+    m_getSurfaceDataMapTimeoutMs = ms;
+    propagatePerRequestTimeouts();
+}
+
+void DDEConnectionManager::setGetSagMapTimeoutMs(DWORD ms) {
+    m_getSagMapTimeoutMs = ms;
+    propagatePerRequestTimeouts();
+}
+
 void DDEConnectionManager::propagateDefaultTimeout(DWORD ms) {
     for (auto& conn : m_connections) {
         if (conn.client) conn.client->setDefaultTimeoutMs(ms);
@@ -257,5 +313,20 @@ void DDEConnectionManager::propagateDefaultTimeout(DWORD ms) {
 void DDEConnectionManager::propagateDefaultRetries(int n) {
     for (auto& conn : m_connections) {
         if (conn.client) conn.client->setDefaultRetries(n);
+    }
+}
+
+void DDEConnectionManager::propagatePerRequestTimeouts() {
+    for (auto& conn : m_connections) {
+        if (!conn.client) continue;
+        conn.client->setGetNameTimeoutMs(m_getNameTimeoutMs);
+        conn.client->setGetFileTimeoutMs(m_getFileTimeoutMs);
+        conn.client->setGetSystemTimeoutMs(m_getSystemTimeoutMs);
+        conn.client->setGetFieldTimeoutMs(m_getFieldTimeoutMs);
+        conn.client->setGetWaveTimeoutMs(m_getWaveTimeoutMs);
+        conn.client->setGetSurfaceDataProfileTimeoutMs(m_getSurfaceDataProfileTimeoutMs);
+        conn.client->setGetSagProfileTimeoutMs(m_getSagProfileTimeoutMs);
+        conn.client->setGetSurfaceDataMapTimeoutMs(m_getSurfaceDataMapTimeoutMs);
+        conn.client->setGetSagMapTimeoutMs(m_getSagMapTimeoutMs);
     }
 }

--- a/src/dde/dde_connection_manager.h
+++ b/src/dde/dde_connection_manager.h
@@ -43,10 +43,30 @@ public:
     void setMaxConnections(int n);
     void setAutoReconnect(bool enabled);
 
+    void setGetNameTimeoutMs(DWORD ms);
+    void setGetFileTimeoutMs(DWORD ms);
+    void setGetSystemTimeoutMs(DWORD ms);
+    void setGetFieldTimeoutMs(DWORD ms);
+    void setGetWaveTimeoutMs(DWORD ms);
+    void setGetSurfaceDataProfileTimeoutMs(DWORD ms);
+    void setGetSagProfileTimeoutMs(DWORD ms);
+    void setGetSurfaceDataMapTimeoutMs(DWORD ms);
+    void setGetSagMapTimeoutMs(DWORD ms);
+
     [[nodiscard]] DWORD getDefaultTimeoutMs() const;
     [[nodiscard]] int   getDefaultRetries()   const;
     [[nodiscard]] int   getMaxConnections()   const { return m_maxConnections; }
     [[nodiscard]] bool  getAutoReconnect()    const { return m_autoReconnect; }
+
+    [[nodiscard]] DWORD getGetNameTimeoutMs() const { return m_getNameTimeoutMs; }
+    [[nodiscard]] DWORD getGetFileTimeoutMs() const { return m_getFileTimeoutMs; }
+    [[nodiscard]] DWORD getGetSystemTimeoutMs() const { return m_getSystemTimeoutMs; }
+    [[nodiscard]] DWORD getGetFieldTimeoutMs() const { return m_getFieldTimeoutMs; }
+    [[nodiscard]] DWORD getGetWaveTimeoutMs() const { return m_getWaveTimeoutMs; }
+    [[nodiscard]] DWORD getGetSurfaceDataProfileTimeoutMs() const { return m_getSurfaceDataProfileTimeoutMs; }
+    [[nodiscard]] DWORD getGetSagProfileTimeoutMs() const { return m_getSagProfileTimeoutMs; }
+    [[nodiscard]] DWORD getGetSurfaceDataMapTimeoutMs() const { return m_getSurfaceDataMapTimeoutMs; }
+    [[nodiscard]] DWORD getGetSagMapTimeoutMs() const { return m_getSagMapTimeoutMs; }
 
 private:
     std::array<DDEConnection, MAX_CONNECTIONS> m_connections;
@@ -55,9 +75,20 @@ private:
     int m_maxConnections = MAX_CONNECTIONS;
     bool m_autoReconnect = true;
 
+    DWORD m_getNameTimeoutMs = 2000;
+    DWORD m_getFileTimeoutMs = 2000;
+    DWORD m_getSystemTimeoutMs = 2000;
+    DWORD m_getFieldTimeoutMs = 2000;
+    DWORD m_getWaveTimeoutMs = 2000;
+    DWORD m_getSurfaceDataProfileTimeoutMs = 2000;
+    DWORD m_getSagProfileTimeoutMs = 1000;
+    DWORD m_getSurfaceDataMapTimeoutMs = 2000;
+    DWORD m_getSagMapTimeoutMs = 1000;
+
     int findFreeSlot();
     HWND createClientWindow();
 
     void propagateDefaultTimeout(DWORD ms);
     void propagateDefaultRetries(int n);
+    void propagatePerRequestTimeouts();
 };

--- a/src/dde/dde_connection_manager.h
+++ b/src/dde/dde_connection_manager.h
@@ -36,11 +36,28 @@ public:
 
     std::vector<app::ZemaxWindowInfo> enumerateAvailableTargets();
 
+    // Runtime-configurable DDE settings. Forwarded to active clients by
+    // SettingsManager::applyDDE. Clamped to safe ranges.
+    void setDefaultTimeoutMs(DWORD ms);
+    void setDefaultRetries(int n);
+    void setMaxConnections(int n);
+    void setAutoReconnect(bool enabled);
+
+    [[nodiscard]] DWORD getDefaultTimeoutMs() const;
+    [[nodiscard]] int   getDefaultRetries()   const;
+    [[nodiscard]] int   getMaxConnections()   const { return m_maxConnections; }
+    [[nodiscard]] bool  getAutoReconnect()    const { return m_autoReconnect; }
+
 private:
     std::array<DDEConnection, MAX_CONNECTIONS> m_connections;
     Logger& m_logger;
     int m_activeIndex = -1;
+    int m_maxConnections = MAX_CONNECTIONS;
+    bool m_autoReconnect = true;
 
     int findFreeSlot();
     HWND createClientWindow();
+
+    void propagateDefaultTimeout(DWORD ms);
+    void propagateDefaultRetries(int n);
 };

--- a/src/dde/initial_data_load_service.cpp
+++ b/src/dde/initial_data_load_service.cpp
@@ -102,22 +102,22 @@ namespace ZemaxDDE {
                                     [this](const std::string& err) {
                                         onError(std::format("GetField,0: {}", err));
                                     },
-                                    2000, 1, "InitialDataLoad");
+                                    m_client.getGetFieldTimeoutMs(), 1, "InitialDataLoad");
                             },
                             [this](const std::string& err) {
                                 onError(std::format("GetSystem: {}", err));
                             },
-                            2000, 1, "InitialDataLoad");
+                            m_client.getGetSystemTimeoutMs(), 1, "InitialDataLoad");
                     },
                     [this](const std::string& err) {
                         onError(std::format("GetFile: {}", err));
                     },
-                    2000, 1, "InitialDataLoad");
+                    m_client.getGetFileTimeoutMs(), 1, "InitialDataLoad");
             },
             [this](const std::string& err) {
                 onError(std::format("GetName: {}", err));
             },
-            2000, 1, "InitialDataLoad");
+            m_client.getGetNameTimeoutMs(), 1, "InitialDataLoad");
     }
 
     void InitialDataLoadService::loadNextField() {
@@ -154,7 +154,7 @@ namespace ZemaxDDE {
                 [this](const std::string& err) {
                     onError(std::format("GetWave,0: {}", err));
                 },
-                2000, 1, "InitialDataLoad");
+                m_client.getGetWaveTimeoutMs(), 1, "InitialDataLoad");
             return;
         }
 
@@ -176,7 +176,7 @@ namespace ZemaxDDE {
             [this](const std::string& err) {
                 onError(std::format("GetField,{}: {}", m_currentField, err));
             },
-            2000, 1, "InitialDataLoad");
+            m_client.getGetFieldTimeoutMs(), 1, "InitialDataLoad");
     }
 
     void InitialDataLoadService::loadNextWave() {
@@ -208,7 +208,7 @@ namespace ZemaxDDE {
             [this](const std::string& err) {
                 onError(std::format("GetWave,{}: {}", m_currentWave, err));
             },
-            2000, 1, "InitialDataLoad");
+            m_client.getGetWaveTimeoutMs(), 1, "InitialDataLoad");
     }
 
     void InitialDataLoadService::onError(const std::string& msg) {

--- a/src/dde/utils.cpp
+++ b/src/dde/utils.cpp
@@ -47,6 +47,18 @@ namespace ZemaxDDE {
         return u8str;
     }
 
+    // Convert UTF‑16 (wchar_t) string to UTF‑8
+    std::string wstring_to_utf8(const std::wstring& wstr) {
+        if (wstr.empty()) return {};
+        int len = WideCharToMultiByte(CP_UTF8, 0, wstr.data(),
+            static_cast<int>(wstr.size()), nullptr, 0, nullptr, nullptr);
+        if (len <= 0) return {};
+        std::string result(static_cast<size_t>(len), '\0');
+        WideCharToMultiByte(CP_UTF8, 0, wstr.data(),
+            static_cast<int>(wstr.size()), result.data(), len, nullptr, nullptr);
+        return result;
+    }
+
     /*
     * Splits the input string into individual "tokens" (meaningful parts).
     * Tokens are delimited by commas, spaces, newlines, or carriage returns, unless they are enclosed within double quotes.

--- a/src/dde/utils.h
+++ b/src/dde/utils.h
@@ -9,6 +9,7 @@
 namespace ZemaxDDE {
     std::vector<std::string> tokenize(std::string_view bufferStr);
     std::string cp1251_to_utf8(const char* data, size_t len);
+    std::string wstring_to_utf8(const std::wstring& wstr);
     std::string extractStringFromDDE(GLOBALHANDLE handle);
     /// Formats a duration for human-readable logging.
     /// Examples: "2.345s", "10m 30.456s", "1h 2m 3.456s"

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -60,4 +60,12 @@ namespace gui {
     // Update checker window constraints
     inline constexpr float UPDATE_WINDOW_WIDTH_MIN  = 320.0f;
     inline constexpr float UPDATE_WINDOW_HEIGHT_MIN = 200.0f;
+
+    // Preferences dialog layout
+    inline constexpr ImVec2 PREFERENCES_WINDOW_DEFAULT_SIZE = ImVec2(820.0f, 600.0f);
+    inline constexpr float  PREFERENCES_WINDOW_MIN_WIDTH    = 640.0f;
+    inline constexpr float  PREFERENCES_WINDOW_MIN_HEIGHT   = 420.0f;
+    inline constexpr float  PREFERENCES_SIDEBAR_WIDTH       = 180.0f;
+    inline constexpr float  PREFERENCES_FOOTER_HEIGHT      = 52.0f;
+    inline constexpr float  PREFERENCES_SECTION_SPACING     = 8.0f;
 }

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -49,6 +49,6 @@ namespace gui {
     inline constexpr float  PREFERENCES_WINDOW_MIN_WIDTH    = 640.0f;
     inline constexpr float  PREFERENCES_WINDOW_MIN_HEIGHT   = 420.0f;
     inline constexpr float  PREFERENCES_SIDEBAR_WIDTH       = 180.0f;
-    inline constexpr float  PREFERENCES_FOOTER_HEIGHT      = 52.0f;
+    inline constexpr float  PREFERENCES_FOOTER_HEIGHT      = 88.0f;
     inline constexpr float  PREFERENCES_SECTION_SPACING     = 8.0f;
 }

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -40,9 +40,18 @@ namespace gui {
     // Font settings
     inline constexpr float BASE_FONT_SIZE = 18.0f;
 
-    // Update checker window constraints
-    inline constexpr float UPDATE_WINDOW_WIDTH_MIN  = 320.0f;
-    inline constexpr float UPDATE_WINDOW_HEIGHT_MIN = 200.0f;
+    // Popup window names
+    inline constexpr const char* ABOUT_POPUP_NAME        = "About";
+    inline constexpr const char* UPDATE_POPUP_NAME       = "Check for Updates";
+    inline constexpr const char* PREFERENCES_POPUP_NAME  = "Preferences";
+
+    // About popup
+    inline constexpr ImVec2 ABOUT_POPUP_DEFAULT_SIZE = ImVec2(440.0f, 240.0f);
+    inline constexpr ImVec2 ABOUT_POPUP_MIN_SIZE     = ImVec2(440.0f, 240.0f);
+
+    // Check for Updates popup
+    inline constexpr ImVec2 UPDATE_POPUP_DEFAULT_SIZE = ImVec2(440.0f, 280.0f);
+    inline constexpr ImVec2 UPDATE_POPUP_MIN_SIZE     = ImVec2(440.0f, 200.0f);
 
     // Preferences dialog layout
     inline constexpr ImVec2 PREFERENCES_WINDOW_DEFAULT_SIZE = ImVec2(820.0f, 600.0f);

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -4,24 +4,17 @@
 
 namespace gui {
     // DDE status window constraints
-    inline constexpr float DDE_STATUS_WINDOW_WIDTH_MIN  = 220.0f;
-    inline constexpr float DDE_STATUS_WINDOW_HEIGHT_MIN = 130.0f;
-
-    // DDE status content constraints
-    inline constexpr float DDE_STATUS_CONTENT_WIDTH  = 0.0f;   // Automatic width
-    inline constexpr float DDE_STATUS_CONTENT_HEIGHT = 0.0f;   // Automatic height
+    inline constexpr ImVec2 DDE_STATUS_WINDOW_MIN_SIZE   = ImVec2(220.0f, 100.0f);
+    inline constexpr ImVec2 DDE_STATUS_CONTENT_SIZE      = ImVec2(0.0f, 0.0f);   // Automatic size
 
     // Debug log window constraints
-    inline constexpr float DEBUG_LOG_WINDOW_WIDTH_MIN  = 220.0f;
-    inline constexpr float DEBUG_LOG_WINDOW_HEIGHT_MIN = 160.0f;
+    inline constexpr ImVec2 DEBUG_LOG_WINDOW_MIN_SIZE    = ImVec2(236.0f, 160.0f);
 
     // System info window constraints
-    inline constexpr float SYSTEM_INFO_WINDOW_WIDTH_MIN  = 200.0f;
-    inline constexpr float SYSTEM_INFO_WINDOW_HEIGHT_MIN = 160.0f;
+    inline constexpr ImVec2 SYSTEM_INFO_WINDOW_MIN_SIZE  = ImVec2(200.0f, 160.0f);
 
     // Sag analysis window constraints
-    inline constexpr float SAG_ANALYSIS_WINDOW_WIDTH_MIN  = 200.0f;
-    inline constexpr float SAG_ANALYSIS_WINDOW_HEIGHT_MIN = 160.0f;
+    inline constexpr ImVec2 SAG_ANALYSIS_WINDOW_MIN_SIZE = ImVec2(200.0f, 160.0f);
 
     // Sag analysis sampling constraints
     // Maximum: Zemax tool "Surface Sag Cross Section" limit
@@ -31,7 +24,7 @@ namespace gui {
 
     // Connect DDE popup constraints
     inline constexpr ImVec2 CONNECT_DDE_POPUP_DEFAULT_SIZE = ImVec2(550.0f, 120.0f);
-    inline constexpr ImVec2 CONNECT_DDE_POPUP_MIN_SIZE     = ImVec2(382.0f, 100.0f);
+    inline constexpr ImVec2 CONNECT_DDE_POPUP_MIN_SIZE     = ImVec2(380.0f, 100.0f);
 
     // DPI scale constraints
     inline constexpr float MIN_DPI_SCALE = 1.0f;

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -12,18 +12,21 @@ namespace gui {
     inline constexpr float DDE_STATUS_CONTENT_HEIGHT = 0.0f;   // Automatic height
 
     // DDE status colors
-    inline constexpr ImVec4 DDE_STATUS_COLOR_CONNECTED     = ImVec4(0.0f, 1.0f, 0.0f, 1.0f);  // Green
-    inline constexpr ImVec4 DDE_STATUS_COLOR_DISCONNECTED = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);  // Red
+    inline constexpr ImVec4 DDE_STATUS_COLOR_CONNECTED     = ImVec4(0.18f, 0.64f, 0.31f, 1.0f);  // GitHub green #2da44e
+    inline constexpr ImVec4 DDE_STATUS_COLOR_DISCONNECTED = ImVec4(0.81f, 0.13f, 0.18f, 1.0f);  // GitHub red #cf222e
 
     // DDE button colors - Connect
-    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_NORMAL = ImVec4(0.0f, 0.5f, 0.0f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_HOVER   = ImVec4(0.0f, 0.7f, 0.0f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_ACTIVE  = ImVec4(0.0f, 0.3f, 0.0f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_NORMAL = ImVec4(0.04f, 0.40f, 0.08f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_HOVER  = ImVec4(0.06f, 0.50f, 0.12f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_ACTIVE = ImVec4(0.03f, 0.28f, 0.05f, 1.0f);
 
     // DDE button colors - Disconnect
-    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_NORMAL = ImVec4(0.5f, 0.0f, 0.0f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_HOVER  = ImVec4(0.7f, 0.0f, 0.0f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_ACTIVE = ImVec4(0.3f, 0.0f, 0.0f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_NORMAL = ImVec4(0.55f, 0.10f, 0.08f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_HOVER  = ImVec4(0.65f, 0.14f, 0.10f, 1.0f);
+    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_ACTIVE = ImVec4(0.40f, 0.06f, 0.04f, 1.0f);
+
+    // DDE button text
+    inline constexpr ImVec4 DDE_BUTTON_TEXT_COLOR = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);  // White
 
     // Debug log window constraints
     inline constexpr float DEBUG_LOG_WINDOW_WIDTH_MIN  = 220.0f;

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -33,6 +33,9 @@ namespace gui {
     // Font settings
     inline constexpr float BASE_FONT_SIZE = 18.0f;
 
+    // Popup button dimensions (DPI-scaled at call sites)
+    inline constexpr float BASE_POPUP_BUTTON_WIDTH = 120.0f;
+
     // Popup window names
     inline constexpr const char* ABOUT_POPUP_NAME        = "About";
     inline constexpr const char* UPDATE_POPUP_NAME       = "Check for Updates";

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -24,7 +24,7 @@ namespace gui {
 
     // Connect DDE popup constraints
     inline constexpr ImVec2 CONNECT_DDE_POPUP_DEFAULT_SIZE = ImVec2(550.0f, 120.0f);
-    inline constexpr ImVec2 CONNECT_DDE_POPUP_MIN_SIZE     = ImVec2(380.0f, 100.0f);
+    inline constexpr ImVec2 CONNECT_DDE_POPUP_MIN_SIZE     = ImVec2(550.0f, 120.0f);
 
     // DPI scale constraints
     inline constexpr float MIN_DPI_SCALE = 1.0f;
@@ -41,17 +41,15 @@ namespace gui {
 
     // About popup
     inline constexpr ImVec2 ABOUT_POPUP_DEFAULT_SIZE = ImVec2(428.0f, 242.0f);
-    inline constexpr ImVec2 ABOUT_POPUP_MIN_SIZE     = ImVec2(200.0f, 120.0f);
+    inline constexpr ImVec2 ABOUT_POPUP_MIN_SIZE     = ImVec2(428.0f, 242.0f);
 
     // Check for Updates popup
-    inline constexpr ImVec2 UPDATE_POPUP_DEFAULT_SIZE = ImVec2(440.0f, 280.0f);
-    inline constexpr ImVec2 UPDATE_POPUP_MIN_SIZE     = ImVec2(440.0f, 200.0f);
+    inline constexpr ImVec2 UPDATE_POPUP_DEFAULT_SIZE = ImVec2(340.0f, 120.0f);
+    inline constexpr ImVec2 UPDATE_POPUP_MIN_SIZE     = ImVec2(340.0f, 120.0f);
 
     // Preferences dialog layout
-    inline constexpr ImVec2 PREFERENCES_WINDOW_DEFAULT_SIZE = ImVec2(820.0f, 600.0f);
-    inline constexpr float  PREFERENCES_WINDOW_MIN_WIDTH    = 640.0f;
-    inline constexpr float  PREFERENCES_WINDOW_MIN_HEIGHT   = 420.0f;
-    inline constexpr float  PREFERENCES_SIDEBAR_WIDTH       = 180.0f;
+    inline constexpr ImVec2 PREFERENCES_WINDOW_DEFAULT_SIZE = ImVec2(500.0f, 280.0f);
+    inline constexpr ImVec2 PREFERENCES_WINDOW_MIN_SIZE     = ImVec2(500.0f, 280.0f);
     inline constexpr float  PREFERENCES_FOOTER_HEIGHT      = 88.0f;
     inline constexpr float  PREFERENCES_SECTION_SPACING     = 8.0f;
 }

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -11,23 +11,6 @@ namespace gui {
     inline constexpr float DDE_STATUS_CONTENT_WIDTH  = 0.0f;   // Automatic width
     inline constexpr float DDE_STATUS_CONTENT_HEIGHT = 0.0f;   // Automatic height
 
-    // DDE status colors
-    inline constexpr ImVec4 DDE_STATUS_COLOR_CONNECTED     = ImVec4(0.18f, 0.64f, 0.31f, 1.0f);  // GitHub green #2da44e
-    inline constexpr ImVec4 DDE_STATUS_COLOR_DISCONNECTED = ImVec4(0.81f, 0.13f, 0.18f, 1.0f);  // GitHub red #cf222e
-
-    // DDE button colors - Connect
-    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_NORMAL = ImVec4(0.04f, 0.40f, 0.08f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_HOVER  = ImVec4(0.06f, 0.50f, 0.12f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_CONNECT_COLOR_ACTIVE = ImVec4(0.03f, 0.28f, 0.05f, 1.0f);
-
-    // DDE button colors - Disconnect
-    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_NORMAL = ImVec4(0.55f, 0.10f, 0.08f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_HOVER  = ImVec4(0.65f, 0.14f, 0.10f, 1.0f);
-    inline constexpr ImVec4 DDE_BUTTON_DISCONNECT_COLOR_ACTIVE = ImVec4(0.40f, 0.06f, 0.04f, 1.0f);
-
-    // DDE button text
-    inline constexpr ImVec4 DDE_BUTTON_TEXT_COLOR = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);  // White
-
     // Debug log window constraints
     inline constexpr float DEBUG_LOG_WINDOW_WIDTH_MIN  = 220.0f;
     inline constexpr float DEBUG_LOG_WINDOW_HEIGHT_MIN = 160.0f;

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -30,8 +30,8 @@ namespace gui {
     inline constexpr int MIN_SAMPLING = 33;
 
     // Connect DDE popup constraints
-    inline constexpr float CONNECT_DDE_POPUP_WIDTH_MIN  = 260.0f;
-    inline constexpr float CONNECT_DDE_POPUP_HEIGHT_MIN = 100.0f;
+    inline constexpr ImVec2 CONNECT_DDE_POPUP_DEFAULT_SIZE = ImVec2(550.0f, 120.0f);
+    inline constexpr ImVec2 CONNECT_DDE_POPUP_MIN_SIZE     = ImVec2(382.0f, 100.0f);
 
     // DPI scale constraints
     inline constexpr float MIN_DPI_SCALE = 1.0f;
@@ -44,10 +44,11 @@ namespace gui {
     inline constexpr const char* ABOUT_POPUP_NAME        = "About";
     inline constexpr const char* UPDATE_POPUP_NAME       = "Check for Updates";
     inline constexpr const char* PREFERENCES_POPUP_NAME  = "Preferences";
+    inline constexpr const char* CONNECT_DDE_POPUP_NAME  = "Connect to Zemax \xe2\x80\x93 select a window";
 
     // About popup
-    inline constexpr ImVec2 ABOUT_POPUP_DEFAULT_SIZE = ImVec2(440.0f, 240.0f);
-    inline constexpr ImVec2 ABOUT_POPUP_MIN_SIZE     = ImVec2(440.0f, 240.0f);
+    inline constexpr ImVec2 ABOUT_POPUP_DEFAULT_SIZE = ImVec2(428.0f, 242.0f);
+    inline constexpr ImVec2 ABOUT_POPUP_MIN_SIZE     = ImVec2(200.0f, 120.0f);
 
     // Check for Updates popup
     inline constexpr ImVec2 UPDATE_POPUP_DEFAULT_SIZE = ImVec2(440.0f, 280.0f);

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -48,8 +48,6 @@ namespace gui {
     inline constexpr ImVec2 UPDATE_POPUP_MIN_SIZE     = ImVec2(340.0f, 120.0f);
 
     // Preferences dialog layout
-    inline constexpr ImVec2 PREFERENCES_WINDOW_DEFAULT_SIZE = ImVec2(500.0f, 280.0f);
-    inline constexpr ImVec2 PREFERENCES_WINDOW_MIN_SIZE     = ImVec2(500.0f, 280.0f);
-    inline constexpr float  PREFERENCES_FOOTER_HEIGHT      = 88.0f;
-    inline constexpr float  PREFERENCES_SECTION_SPACING     = 8.0f;
+    inline constexpr ImVec2 PREFERENCES_WINDOW_DEFAULT_SIZE = ImVec2(660.0f, 280.0f);
+    inline constexpr ImVec2 PREFERENCES_WINDOW_MIN_SIZE     = ImVec2(660.0f, 280.0f);
 }

--- a/src/gui/dockable_windows_manager.cpp
+++ b/src/gui/dockable_windows_manager.cpp
@@ -110,7 +110,7 @@ namespace {
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::DDEStatus);
         const char* title = mgr->GetName(WindowID::DDEStatus);
-        ImGuiUtils::SetDpiScaledWindowConstraints(gui::DDE_STATUS_WINDOW_WIDTH_MIN, gui::DDE_STATUS_WINDOW_HEIGHT_MIN);
+        ImGuiUtils::SetDpiScaledWindowConstraints(gui::DDE_STATUS_WINDOW_MIN_SIZE.x, gui::DDE_STATUS_WINDOW_MIN_SIZE.y);
         if (ImGui::Begin(title, &isVisible,
             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
             if (guiMgr->getDDEStatusRenderer()) {
@@ -128,7 +128,7 @@ namespace {
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::SystemInfo);
         const char* title = mgr->GetName(WindowID::SystemInfo);
-        ImGuiUtils::SetDpiScaledWindowConstraints(gui::SYSTEM_INFO_WINDOW_WIDTH_MIN, gui::SYSTEM_INFO_WINDOW_HEIGHT_MIN);
+        ImGuiUtils::SetDpiScaledWindowConstraints(gui::SYSTEM_INFO_WINDOW_MIN_SIZE.x, gui::SYSTEM_INFO_WINDOW_MIN_SIZE.y);
         if (ImGui::Begin(title, &isVisible)) {
             guiMgr->renderOpticalSystemInfo();
         }
@@ -143,7 +143,7 @@ namespace {
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::SurfaceProfileInspector);
         const char* title = mgr->GetName(WindowID::SurfaceProfileInspector);
-        ImGuiUtils::SetDpiScaledWindowConstraints(gui::SAG_ANALYSIS_WINDOW_WIDTH_MIN, gui::SAG_ANALYSIS_WINDOW_HEIGHT_MIN);
+        ImGuiUtils::SetDpiScaledWindowConstraints(gui::SAG_ANALYSIS_WINDOW_MIN_SIZE.x, gui::SAG_ANALYSIS_WINDOW_MIN_SIZE.y);
         if (ImGui::Begin(title, &isVisible)) {
             guiMgr->renderSurfaceProfileInspector();
         }
@@ -158,7 +158,7 @@ namespace {
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::SurfaceIrregularityMap);
         const char* title = mgr->GetName(WindowID::SurfaceIrregularityMap);
-        ImGuiUtils::SetDpiScaledWindowConstraints(gui::SAG_ANALYSIS_WINDOW_WIDTH_MIN, gui::SAG_ANALYSIS_WINDOW_HEIGHT_MIN);
+        ImGuiUtils::SetDpiScaledWindowConstraints(gui::SAG_ANALYSIS_WINDOW_MIN_SIZE.x, gui::SAG_ANALYSIS_WINDOW_MIN_SIZE.y);
         if (ImGui::Begin(title, &isVisible)) {
             guiMgr->renderSurfaceIrregularityMap();
         }
@@ -173,7 +173,7 @@ namespace {
         auto* mgr = guiMgr->getWindowManager();
         bool isVisible = mgr->IsVisible(WindowID::DebugLog);
         const char* title = mgr->GetName(WindowID::DebugLog);
-        ImGuiUtils::SetDpiScaledWindowConstraints(gui::DEBUG_LOG_WINDOW_WIDTH_MIN, gui::DEBUG_LOG_WINDOW_HEIGHT_MIN);
+        ImGuiUtils::SetDpiScaledWindowConstraints(gui::DEBUG_LOG_WINDOW_MIN_SIZE.x, gui::DEBUG_LOG_WINDOW_MIN_SIZE.y);
         if (ImGui::Begin(title, &isVisible)) {
             guiMgr->renderDebugLog();
         }

--- a/src/gui/graphics_backend.cpp
+++ b/src/gui/graphics_backend.cpp
@@ -88,9 +88,9 @@ namespace gui {
 
         // Apply initial theme
         if (isLightTheme) {
-            m_themeManager.apply("Windows 11 Light");
+            m_themeManager.apply(std::string{kThemeNameLight});
         } else {
-            m_themeManager.apply("Windows 11 Dark");
+            m_themeManager.apply(std::string{kThemeNameDark});
         }
 
         updateDpiStyle(dpiScale);

--- a/src/gui/graphics_backend.cpp
+++ b/src/gui/graphics_backend.cpp
@@ -29,13 +29,17 @@ namespace gui {
         }
     }
 
-    void GraphicsBackend::initialize(GLFWwindow* window, Logger& logger, float initialDpiScale) {
+    void GraphicsBackend::initialize(GLFWwindow* window, Logger& logger, bool isLightTheme, float initialDpiScale) {
         m_window = window;
         m_logger = &logger;
 
         if (!m_window) {
             throw std::runtime_error("Invalid GLFW window");
         }
+
+        // Register built-in themes
+        m_themeManager.registerTheme(ThemeData::CreateWin11Light());
+        m_themeManager.registerTheme(ThemeData::CreateWin11Dark());
 
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
@@ -54,33 +58,44 @@ namespace gui {
         io.ConfigDpiScaleFonts = true;
         io.ConfigDpiScaleViewports = true;
 
-        std::filesystem::path fontPath = std::filesystem::path{L"C:\\Windows\\Fonts"} / L"segoeui.ttf";
-        const std::string fontPathStr = fontPath.string();
+        // Load Segoe UI with Cyrillic support
+        {
+            std::filesystem::path fontPath = std::filesystem::path{L"C:\\Windows\\Fonts"} / L"segoeui.ttf";
+            const std::string fontPathStr = fontPath.string();
 
-        float baseFontSize = BASE_FONT_SIZE;
-        ImFont* font = io.Fonts->AddFontFromFileTTF(fontPathStr.c_str(), baseFontSize);
+            float baseFontSize = BASE_FONT_SIZE;
+            ImFontConfig fontCfg;
+            fontCfg.OversampleH = 2;
+            fontCfg.OversampleV = 1;
+            fontCfg.PixelSnapH = true;
+            ImFont* font = io.Fonts->AddFontFromFileTTF(fontPathStr.c_str(), baseFontSize, &fontCfg, io.Fonts->GetGlyphRangesCyrillic());
 
-        if (!font) {
-            logger.addLog("[GUI] Failed to load font 'segoeui.ttf'. Using default font.");
+            if (!font) {
+                font = io.Fonts->AddFontFromFileTTF(fontPathStr.c_str(), baseFontSize);
+            }
+
+            if (!font) {
+                logger.addLog("[GUI] Failed to load font 'segoeui.ttf'. Using default font.");
+            }
         }
 
         ImGuiStyle& style = ImGui::GetStyle();
         style.FontScaleDpi = dpiScale;
-        style.WindowPadding = ImVec2(8.0f, 8.0f);
-        style.FramePadding = ImVec2(4.0f, 4.0f);
-        style.ItemSpacing = ImVec2(8.0f, 4.0f);
-        style.ItemInnerSpacing = ImVec2(4.0f, 4.0f);
-        style.IndentSpacing = 25.0f;
-        style.ScrollbarSize = 15.0f;
-        style.GrabMinSize = 10.0f;
 
         ImGui_ImplGlfw_InitForOpenGL(m_window, true);
         ImGui_ImplOpenGL3_Init("#version 130");
         ImGui_ImplOpenGL3_CreateDeviceObjects();
 
+        // Apply initial theme
+        if (isLightTheme) {
+            m_themeManager.apply("Windows 11 Light");
+        } else {
+            m_themeManager.apply("Windows 11 Dark");
+        }
+
         updateDpiStyle(dpiScale);
 
-        logger.addLog("[GUI] GUI initialized");
+        logger.addLog(std::format("[GUI] GUI initialized (theme: {})", m_themeManager.currentThemeName()));
     }
 
     void GraphicsBackend::updateDpiStyle(float dpiScale) {
@@ -97,10 +112,23 @@ namespace gui {
     }
 
     void GraphicsBackend::endFrame() {
-        glClearColor(0.12f, 0.12f, 0.12f, 1.0f);
+        ImVec4 bg = m_themeManager.getClearColor();
+        glClearColor(bg.x, bg.y, bg.z, bg.w);
         glClear(GL_COLOR_BUFFER_BIT);
 
         ImGui::Render();
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+    }
+
+    void GraphicsBackend::applyTheme(bool isLight) {
+        if (isLight) {
+            m_themeManager.apply("Windows 11 Light");
+        } else {
+            m_themeManager.apply("Windows 11 Dark");
+        }
+    }
+
+    void GraphicsBackend::toggleTheme() {
+        m_themeManager.toggle();
     }
 }

--- a/src/gui/graphics_backend.cpp
+++ b/src/gui/graphics_backend.cpp
@@ -11,6 +11,10 @@
 #include "lib/imgui/backends/imgui_impl_glfw.h"
 #include "lib/imgui/backends/imgui_impl_opengl3.h"
 
+#include <GLFW/glfw3.h>
+#define GLFW_EXPOSE_NATIVE_WIN32
+#include <GLFW/glfw3native.h>
+
 #include "gui/graphics_backend.h"
 #include "gui/constants.h"
 #include "app/config_path.h"
@@ -120,15 +124,27 @@ namespace gui {
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
     }
 
-    void GraphicsBackend::applyTheme(bool isLight) {
-        if (isLight) {
-            m_themeManager.apply("Windows 11 Light");
-        } else {
-            m_themeManager.apply("Windows 11 Dark");
-        }
-    }
+    void GraphicsBackend::updateTitleBarDarkMode(bool isDark) {
+        if (!m_window) return;
 
-    void GraphicsBackend::toggleTheme() {
-        m_themeManager.toggle();
+        #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+        #define DWMWA_USE_IMMERSIVE_DARK_MODE 19
+        #endif
+
+        HMODULE dwmApi = LoadLibraryW(L"dwmapi.dll");
+        if (dwmApi) {
+            using DwmSetWindowAttributeFunc = HRESULT (WINAPI*)(HWND, DWORD, LPCVOID, DWORD);
+            auto* dwmFunc = reinterpret_cast<DwmSetWindowAttributeFunc>(
+                reinterpret_cast<void*>(GetProcAddress(dwmApi, "DwmSetWindowAttribute")));
+
+            if (dwmFunc) {
+                BOOL useDarkMode = isDark;
+                HWND hwnd = glfwGetWin32Window(m_window);
+                if (hwnd) {
+                    dwmFunc(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDarkMode, sizeof(useDarkMode));
+                }
+            }
+            FreeLibrary(dwmApi);
+        }
     }
 }

--- a/src/gui/graphics_backend.h
+++ b/src/gui/graphics_backend.h
@@ -1,30 +1,35 @@
 #pragma once
 
 #include <GLFW/glfw3.h>
+#include <imgui.h>
+
+#include "gui/theme_manager.h"
 
 class Logger;
 
 namespace gui {
-    /**
-     * @brief Manages ImGui + ImPlot + OpenGL backend lifecycle.
-     *        Handles initialization, DPI scaling, and shutdown.
-     */
     class GraphicsBackend {
         public:
             GraphicsBackend() = default;
             ~GraphicsBackend();
 
-            // Non-copyable
             GraphicsBackend(const GraphicsBackend&) = delete;
             GraphicsBackend& operator=(const GraphicsBackend&) = delete;
 
-            void initialize(GLFWwindow* window, Logger& logger, float initialDpiScale = 1.0f);
+            void initialize(GLFWwindow* window, Logger& logger, bool isLightTheme = true, float initialDpiScale = 1.0f);
             void updateDpiStyle(float dpiScale);
             void beginFrame();
             void endFrame();
 
+            void applyTheme(bool isLight);
+            void toggleTheme();
+            ThemeManager& getThemeManager() { return m_themeManager; }
+            bool isLightTheme() const { return m_themeManager.isLight(); }
+            ImVec4 getClearColor() const { return m_themeManager.getClearColor(); }
+
         private:
             GLFWwindow* m_window = nullptr;
             Logger* m_logger = nullptr;
+            ThemeManager m_themeManager;
     };
 }

--- a/src/gui/graphics_backend.h
+++ b/src/gui/graphics_backend.h
@@ -21,8 +21,10 @@ namespace gui {
             void beginFrame();
             void endFrame();
 
-            void applyTheme(bool isLight);
-            void toggleTheme();
+            /// Updates the native Win11 title bar to match the current theme.
+            /// Must be called whenever the theme changes at runtime.
+            void updateTitleBarDarkMode(bool isDark);
+
             ThemeManager& getThemeManager() { return m_themeManager; }
             bool isLightTheme() const { return m_themeManager.isLight(); }
             ImVec4 getClearColor() const { return m_themeManager.getClearColor(); }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -81,9 +81,5 @@ namespace gui {
             DockableWindowsManager* m_pWndMgr{nullptr};
 
             UiOperationMonitor m_uiOpMonitor;
-
-            // State
-            bool m_showUpdatesPopup{false};
-            bool m_showAboutPopup{false};
     };
 }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -44,6 +44,7 @@ namespace gui {
             void renderPreferencesDialog();
 
             SettingsManager& getSettingsManager() noexcept { return *m_settingsManager; }
+            UpdateChecker* getUpdateChecker() const noexcept { return m_updateChecker.get(); }
 
             MenuBarController* getMenuBarController() { return m_menuBarController.get(); }
             void setWindowManager(DockableWindowsManager* wndMgr) { m_pWndMgr = wndMgr; }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -43,6 +43,8 @@ namespace gui {
             void renderUpdatesPopup();
             void renderPreferencesDialog();
 
+            SettingsManager& getSettingsManager() noexcept { return *m_settingsManager; }
+
             MenuBarController* getMenuBarController() { return m_menuBarController.get(); }
             void setWindowManager(DockableWindowsManager* wndMgr) { m_pWndMgr = wndMgr; }
             DockableWindowsManager* getWindowManager() const { return m_pWndMgr; }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -33,9 +33,10 @@ namespace gui {
             GuiManager(GLFWwindow* glfwWindow, DDEConnectionManager* ddeConnectionManager, Logger& logger);
             ~GuiManager();
 
-            void initialize(float dpiScale = 1.0f);
+            void initialize(bool isLightTheme, float dpiScale = 1.0f);
             void render();
             void updateDpiStyle(float dpiScale);
+            void toggleTheme();
 
             void renderAboutPopup();
             void renderUpdatesPopup();

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -19,7 +19,9 @@
 #include "gui/graphics_backend.h"
 #include "windows_dockable/debug_log.h"
 #include "gui/popups/about_dialog.h"
+#include "gui/popups/preferences_dialog.h"
 #include "gui/popups/update_checker.h"
+#include "gui/settings_manager.h"
 #include "dde/client.h"
 #include "dde/dde_connection_manager.h"
 
@@ -36,10 +38,10 @@ namespace gui {
             void initialize(bool isLightTheme, float dpiScale = 1.0f);
             void render();
             void updateDpiStyle(float dpiScale);
-            void toggleTheme();
 
             void renderAboutPopup();
             void renderUpdatesPopup();
+            void renderPreferencesDialog();
 
             MenuBarController* getMenuBarController() { return m_menuBarController.get(); }
             void setWindowManager(DockableWindowsManager* wndMgr) { m_pWndMgr = wndMgr; }
@@ -71,6 +73,8 @@ namespace gui {
             std::unique_ptr<DebugLog> m_debugLogRenderer;
             std::unique_ptr<AboutDialog> m_aboutDialog;
             std::unique_ptr<UpdateChecker> m_updateChecker;
+            std::unique_ptr<SettingsManager>   m_settingsManager;
+            std::unique_ptr<PreferencesDialog> m_preferencesDialog;
             DockableWindowsManager* m_pWndMgr{nullptr};
 
             UiOperationMonitor m_uiOpMonitor;

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -27,10 +27,10 @@ namespace gui {
         if (m_glfwWindow) glfwSetWindowShouldClose(m_glfwWindow, true);
     });
     m_menuBarController->setAboutCallback([this]() {
-        m_showAboutPopup = true;
+        m_aboutDialog->open();
     });
     m_menuBarController->setUpdatesCallback([this]() {
-        m_showUpdatesPopup = true;
+        m_updateChecker->open();
     });
     m_ddeStatusRenderer = std::make_unique<DDEStatus>(m_ddeConnectionManager);
     m_debugLogRenderer = std::make_unique<DebugLog>();
@@ -218,13 +218,13 @@ void GuiManager::renderDebugLog() {
 
 void GuiManager::renderAboutPopup() {
     if (m_aboutDialog) {
-        m_aboutDialog->render(m_showAboutPopup);
+        m_aboutDialog->render();
     }
 }
 
 void GuiManager::renderUpdatesPopup() {
     if (m_updateChecker) {
-        m_updateChecker->renderPopup(m_showUpdatesPopup);
+        m_updateChecker->render();
     }
 }
 

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -39,6 +39,7 @@ namespace gui {
     m_settingsManager   = std::make_unique<SettingsManager>();
     m_preferencesDialog = std::make_unique<PreferencesDialog>(*m_settingsManager);
     m_settingsManager->setUpdateChecker(m_updateChecker.get());
+    m_settingsManager->setLogger(&m_logger);
     m_menuBarController->setPreferencesCallback([this]() {
         m_preferencesDialog->open();
     });

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -196,7 +196,6 @@ void GuiManager::render() {
         }
     }
 
-    ImGuiUtils::SetPopupWindowPosition();
     renderUpdatesPopup();
     renderAboutPopup();
     renderPreferencesDialog();

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -48,6 +48,8 @@ GuiManager::~GuiManager() = default;
 void GuiManager::initialize(bool isLightTheme, float dpiScale) {
     m_graphics.initialize(m_glfwWindow, m_logger, isLightTheme, dpiScale);
     m_settingsManager->bind(&m_graphics.getThemeManager(), m_ddeConnectionManager);
+    m_profileService->setSettingsManager(m_settingsManager.get());
+    m_irregularityMapService->setSettingsManager(m_settingsManager.get());
 }
 
 void GuiManager::render() {

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -55,6 +55,7 @@ void GuiManager::initialize(bool isLightTheme, float dpiScale) {
 
     const auto& themeManager = m_graphics.getThemeManager();
     m_ddeStatusRenderer->setThemeManager(&themeManager);
+    m_ddeStatusRenderer->setLogger(&m_logger);
     m_updateChecker->setThemeManager(&themeManager);
 }
 

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -40,8 +40,16 @@ namespace gui {
 
 GuiManager::~GuiManager() = default;
 
-void GuiManager::initialize(float dpiScale) {
-    m_graphics.initialize(m_glfwWindow, m_logger, dpiScale);
+void GuiManager::initialize(bool isLightTheme, float dpiScale) {
+    m_graphics.initialize(m_glfwWindow, m_logger, isLightTheme, dpiScale);
+    m_menuBarController->setThemeToggleCallback([this]() {
+        toggleTheme();
+    });
+}
+
+void GuiManager::toggleTheme() {
+    m_graphics.toggleTheme();
+    m_logger.addLog(std::format("[GUI] Theme switched to: {}", m_graphics.getThemeManager().currentThemeName()));
 }
 
 void GuiManager::render() {

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -36,20 +36,18 @@ namespace gui {
     m_debugLogRenderer = std::make_unique<DebugLog>();
     m_aboutDialog        = std::make_unique<AboutDialog>();
     m_updateChecker      = std::make_unique<UpdateChecker>();
+    m_settingsManager   = std::make_unique<SettingsManager>();
+    m_preferencesDialog = std::make_unique<PreferencesDialog>(*m_settingsManager);
+    m_menuBarController->setPreferencesCallback([this]() {
+        m_preferencesDialog->open();
+    });
 }
 
 GuiManager::~GuiManager() = default;
 
 void GuiManager::initialize(bool isLightTheme, float dpiScale) {
     m_graphics.initialize(m_glfwWindow, m_logger, isLightTheme, dpiScale);
-    m_menuBarController->setThemeToggleCallback([this]() {
-        toggleTheme();
-    });
-}
-
-void GuiManager::toggleTheme() {
-    m_graphics.toggleTheme();
-    m_logger.addLog(std::format("[GUI] Theme switched to: {}", m_graphics.getThemeManager().currentThemeName()));
+    m_settingsManager->bind(&m_graphics.getThemeManager(), m_ddeConnectionManager);
 }
 
 void GuiManager::render() {
@@ -193,6 +191,7 @@ void GuiManager::render() {
     ImGuiUtils::SetPopupWindowPosition();
     renderUpdatesPopup();
     renderAboutPopup();
+    renderPreferencesDialog();
 
     m_uiOpMonitor.renderGlobalStatusBar();
 
@@ -218,6 +217,12 @@ void GuiManager::renderAboutPopup() {
 void GuiManager::renderUpdatesPopup() {
     if (m_updateChecker) {
         m_updateChecker->renderPopup(m_showUpdatesPopup);
+    }
+}
+
+void GuiManager::renderPreferencesDialog() {
+    if (m_preferencesDialog) {
+        m_preferencesDialog->render();
     }
 }
 

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -50,6 +50,7 @@ GuiManager::~GuiManager() = default;
 void GuiManager::initialize(bool isLightTheme, float dpiScale) {
     m_graphics.initialize(m_glfwWindow, m_logger, isLightTheme, dpiScale);
     m_settingsManager->bind(&m_graphics.getThemeManager(), m_ddeConnectionManager);
+    m_settingsManager->setGraphicsBackend(&m_graphics);
     m_profileService->setSettingsManager(m_settingsManager.get());
     m_irregularityMapService->setSettingsManager(m_settingsManager.get());
 

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -52,6 +52,10 @@ void GuiManager::initialize(bool isLightTheme, float dpiScale) {
     m_settingsManager->bind(&m_graphics.getThemeManager(), m_ddeConnectionManager);
     m_profileService->setSettingsManager(m_settingsManager.get());
     m_irregularityMapService->setSettingsManager(m_settingsManager.get());
+
+    const auto& themeManager = m_graphics.getThemeManager();
+    m_ddeStatusRenderer->setThemeManager(&themeManager);
+    m_updateChecker->setThemeManager(&themeManager);
 }
 
 void GuiManager::render() {

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -38,6 +38,7 @@ namespace gui {
     m_updateChecker      = std::make_unique<UpdateChecker>();
     m_settingsManager   = std::make_unique<SettingsManager>();
     m_preferencesDialog = std::make_unique<PreferencesDialog>(*m_settingsManager);
+    m_settingsManager->setUpdateChecker(m_updateChecker.get());
     m_menuBarController->setPreferencesCallback([this]() {
         m_preferencesDialog->open();
     });

--- a/src/gui/imgui_utils.h
+++ b/src/gui/imgui_utils.h
@@ -166,4 +166,15 @@ namespace ImGuiUtils {
 
         return changed;
     }
+    /// Renders a section header with title, separator, and optional description.
+    inline void SectionHeader(const char* title, const char* description = nullptr) {
+        ImGui::TextUnformatted(title);
+        ImGui::Separator();
+        ImGui::Spacing();
+        if (description) {
+            ImGui::TextDisabled(description);
+            ImGui::Spacing();
+        }
+    }
+
 } // namespace ImGuiUtils

--- a/src/gui/imgui_utils.h
+++ b/src/gui/imgui_utils.h
@@ -129,4 +129,41 @@ namespace ImGuiUtils {
 
         return false;
     }
+
+    /// Horizontal splitter that resizes left/right panels.
+    /// Call between two SameLine() pairs.
+    /// @param id       Unique ID (e.g. "##splitter_1")
+    /// @param value    Current left-panel width (modified by drag)
+    /// @param height   Splitter height
+    /// @param width    Splitter bar thickness (default 4.0f)
+    /// @param minVal   Minimum value clamp
+    /// @param maxVal   Maximum value clamp
+    /// @return true if value changed
+    inline bool SplitterH(const char* id, float& value, float height,
+                           float width = 4.0f, float minVal = 0.0f, float maxVal = FLT_MAX) {
+        const ImVec2 sp = ImGui::GetCursorScreenPos();
+        ImGui::InvisibleButton(id, ImVec2(width, height));
+
+        if (ImGui::IsItemActive() || ImGui::IsItemHovered())
+            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+
+        bool changed = false;
+        if (ImGui::IsItemActive()) {
+            value += ImGui::GetIO().MouseDelta.x;
+            value = std::clamp(value, minVal, maxVal);
+            changed = true;
+        }
+
+        ImU32 col;
+        if (ImGui::IsItemActive())
+            col = ImGui::GetColorU32(ImGuiCol_SeparatorActive);
+        else if (ImGui::IsItemHovered())
+            col = ImGui::GetColorU32(ImGuiCol_Text, 0.4f);
+        else
+            col = ImGui::GetColorU32(ImGuiCol_Separator);
+
+        ImGui::GetWindowDrawList()->AddRectFilled(sp, ImVec2(sp.x + width, sp.y + height), col);
+
+        return changed;
+    }
 } // namespace ImGuiUtils

--- a/src/gui/imgui_utils.h
+++ b/src/gui/imgui_utils.h
@@ -38,8 +38,8 @@ namespace ImGuiUtils {
         }
     }
 
-    /// Centers the next popup/modal window in the viewport.
-    inline void SetPopupWindowPosition() {
+    /// Centers the next window in the viewport (call every frame; takes effect on appearing).
+    inline void CenterNextWindow() {
         ImVec2 center = ImGui::GetMainViewport()->GetCenter();
         ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
     }

--- a/src/gui/imgui_utils.h
+++ b/src/gui/imgui_utils.h
@@ -72,6 +72,17 @@ namespace ImGuiUtils {
         );
     }
 
+    /// Sets DPI-scaled window size for the next window.
+    inline void SetDpiScaledWindowSize(const ImVec2& size, ImGuiCond cond = ImGuiCond_Once) {
+        float dpi = ImGui::GetWindowDpiScale();
+        ImGui::SetNextWindowSize(ImVec2(size.x * dpi, size.y * dpi), cond);
+    }
+
+    /// Scales a value by the current window DPI factor.
+    inline float DpiScale(float value) {
+        return value * ImGui::GetWindowDpiScale();
+    }
+
     /// Disabled button with animated spinner arc (3/4 circle) inside.
     /// Shows a spinning indicator when @p isActive=true, otherwise a normal Button.
     /// @return true only when clicked in non-active state.

--- a/src/gui/menu_bar_controller.cpp
+++ b/src/gui/menu_bar_controller.cpp
@@ -44,8 +44,12 @@ namespace gui {
 
     void MenuBarController::render() {
         if (ImGui::BeginMainMenuBar()) {
-            if (ImGui::BeginMenu("Menu")) {
+            if (ImGui::BeginMenu("File")) {
                 if (ImGui::MenuItem("Open *.ZMX file in Zemax", "Ctrl+O")) App::openZmxFileInZemax(m_logger);
+                ImGui::Separator();
+                if (ImGui::MenuItem(PREFERENCES_POPUP_NAME, "Ctrl+,", false, true)) {
+                    if (m_onPreferences) m_onPreferences();
+                }
                 ImGui::Separator();
                 if (ImGui::MenuItem("Exit", "Alt+F4")) {
                     if (m_onExit) m_onExit();
@@ -73,17 +77,6 @@ namespace gui {
                 }
                 ImGui::EndMenu();
             }
-            if (ImGui::BeginMenu("Settings")) {
-                if (ImGui::MenuItem("Preferences...", "Ctrl+,", false, true)) {
-                    if (m_onPreferences) m_onPreferences();
-                }
-                ImGui::Separator();
-                ImGui::MenuItem("Performance...", "Ctrl+Shift+P", false, false);
-                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-                    ImGui::SetTooltip("Configure DDE request timeouts. (Coming soon)");
-                }
-                ImGui::EndMenu();
-            }
             if (ImGui::BeginMenu("Info")) {
                 if (m_pWndMgr) {
                     auto ids = m_pWndMgr->GetIDsByCategory(WindowCategory::Info);
@@ -99,10 +92,10 @@ namespace gui {
                         ImGui::Separator();
                     }
                 }
-                if (ImGui::MenuItem("Check for Updates")) {
+                if (ImGui::MenuItem(UPDATE_POPUP_NAME)) {
                     if (m_onUpdates) m_onUpdates();
                 }
-                if (ImGui::MenuItem("About")) {
+                if (ImGui::MenuItem(ABOUT_POPUP_NAME)) {
                     if (m_onAbout) m_onAbout();
                 }
                 ImGui::EndMenu();

--- a/src/gui/menu_bar_controller.cpp
+++ b/src/gui/menu_bar_controller.cpp
@@ -34,8 +34,12 @@ namespace gui {
         m_onSidebarToggle = std::move(cb);
     }
 
-    void MenuBarController::setThemeToggleCallback(std::function<void()> cb) {
-        m_onThemeToggle = std::move(cb);
+    void MenuBarController::setPreferencesCallback(std::function<void()> cb) {
+        m_onPreferences = std::move(cb);
+    }
+
+    void MenuBarController::openPreferences() {
+        if (m_onPreferences) m_onPreferences();
     }
 
     void MenuBarController::render() {
@@ -69,9 +73,14 @@ namespace gui {
                 }
                 ImGui::EndMenu();
             }
-            if (ImGui::BeginMenu("View")) {
-                if (ImGui::MenuItem("Switch Theme")) {
-                    if (m_onThemeToggle) m_onThemeToggle();
+            if (ImGui::BeginMenu("Settings")) {
+                if (ImGui::MenuItem("Preferences...", "Ctrl+,", false, true)) {
+                    if (m_onPreferences) m_onPreferences();
+                }
+                ImGui::Separator();
+                ImGui::MenuItem("Performance...", "Ctrl+Shift+P", false, false);
+                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                    ImGui::SetTooltip("Configure DDE request timeouts. (Coming soon)");
                 }
                 ImGui::EndMenu();
             }

--- a/src/gui/menu_bar_controller.cpp
+++ b/src/gui/menu_bar_controller.cpp
@@ -34,6 +34,10 @@ namespace gui {
         m_onSidebarToggle = std::move(cb);
     }
 
+    void MenuBarController::setThemeToggleCallback(std::function<void()> cb) {
+        m_onThemeToggle = std::move(cb);
+    }
+
     void MenuBarController::render() {
         if (ImGui::BeginMainMenuBar()) {
             if (ImGui::BeginMenu("Menu")) {
@@ -62,6 +66,12 @@ namespace gui {
                     if (ImGui::MenuItem(name, nullptr, &visible)) {
                         m_pWndMgr->SetVisible(id, visible);
                     }
+                }
+                ImGui::EndMenu();
+            }
+            if (ImGui::BeginMenu("View")) {
+                if (ImGui::MenuItem("Switch Theme")) {
+                    if (m_onThemeToggle) m_onThemeToggle();
                 }
                 ImGui::EndMenu();
             }

--- a/src/gui/menu_bar_controller.h
+++ b/src/gui/menu_bar_controller.h
@@ -19,13 +19,17 @@ namespace gui {
             void setDDEConnectionManager(DDEConnectionManager* ddeMgr);
             void setWindowManager(DockableWindowsManager* wndMgr);
             void setSidebarToggleCallback(std::function<void(bool)> cb);
-            void setThemeToggleCallback(std::function<void()> cb);
+            void setPreferencesCallback(std::function<void()> cb);
+
+            /// Invokes the registered preferences callback (if any). Used by the
+            /// application main loop to dispatch the global Ctrl+, shortcut.
+            void openPreferences();
         private:
             Logger& m_logger;
             std::function<void()> m_onExit;
             std::function<void()> m_onAbout;
             std::function<void()> m_onUpdates;
-            std::function<void()> m_onThemeToggle;
+            std::function<void()> m_onPreferences;
             ::DDEConnectionManager* m_pDDEClientMgr{nullptr};
             DockableWindowsManager* m_pWndMgr{nullptr};
             std::function<void(bool)> m_onSidebarToggle;

--- a/src/gui/menu_bar_controller.h
+++ b/src/gui/menu_bar_controller.h
@@ -19,11 +19,13 @@ namespace gui {
             void setDDEConnectionManager(DDEConnectionManager* ddeMgr);
             void setWindowManager(DockableWindowsManager* wndMgr);
             void setSidebarToggleCallback(std::function<void(bool)> cb);
+            void setThemeToggleCallback(std::function<void()> cb);
         private:
             Logger& m_logger;
             std::function<void()> m_onExit;
             std::function<void()> m_onAbout;
             std::function<void()> m_onUpdates;
+            std::function<void()> m_onThemeToggle;
             ::DDEConnectionManager* m_pDDEClientMgr{nullptr};
             DockableWindowsManager* m_pWndMgr{nullptr};
             std::function<void(bool)> m_onSidebarToggle;

--- a/src/gui/popups/about_dialog.cpp
+++ b/src/gui/popups/about_dialog.cpp
@@ -67,7 +67,7 @@ namespace gui {
 
         ImGui::EndChild();
 
-        float okBtnW = ImGuiUtils::DpiScale(120.0f);
+        float okBtnW = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
         ImGui::SetCursorPosX((ImGui::GetWindowSize().x - okBtnW) * 0.5f);
         if (ImGui::Button("OK", ImVec2(okBtnW, 0))) {
             close();

--- a/src/gui/popups/about_dialog.cpp
+++ b/src/gui/popups/about_dialog.cpp
@@ -42,13 +42,20 @@ namespace gui {
             APP_GIT_COMMIT
         );
 
-        ImGui::TextUnformatted(APP_NAME);
+        ImGui::TextWrapped(
+            "%s - Advanced analysis of optical systems using parameters "
+            "retrieved from Zemax via DDE (Dynamic Data Exchange)",
+            APP_NAME);
         ImGui::Separator();
 
         ImGui::TextUnformatted("GitHub Repository:");
         ImGui::SameLine();
         ImGui::TextLinkOpenURL("github.com/d3m37r4/ZemaxDDEClient",
                                "https://github.com/d3m37r4/ZemaxDDEClient");
+
+        ImGui::TextUnformatted("License:");
+        ImGui::SameLine();
+        ImGui::TextLinkOpenURL("MIT", "https://github.com/d3m37r4/ZemaxDDEClient/blob/main/LICENSE");
 
         ImGui::TextUnformatted("Author:");
         ImGui::SameLine();

--- a/src/gui/popups/about_dialog.cpp
+++ b/src/gui/popups/about_dialog.cpp
@@ -1,4 +1,6 @@
 #include "gui/popups/about_dialog.h"
+#include "gui/constants.h"
+#include "gui/imgui_utils.h"
 #include "lib/imgui/imgui.h"
 #include "app/app.h"
 #include "version.h"
@@ -15,13 +17,16 @@ namespace gui {
     }
 
     void AboutDialog::render() {
-        if (m_open && !ImGui::IsPopupOpen("About")) {
-            ImGui::OpenPopup("About");
+        if (m_open && !ImGui::IsPopupOpen(ABOUT_POPUP_NAME)) {
+            ImGui::OpenPopup(ABOUT_POPUP_NAME);
         }
 
-        ImGui::SetNextWindowSize(ImVec2(440.0f, 240.0f), ImGuiCond_FirstUseEver);
+        ImGuiUtils::CenterNextWindow();
 
-        if (!ImGui::BeginPopupModal("About", &m_open, ImGuiWindowFlags_NoCollapse)) {
+        ImGui::SetNextWindowSize(ABOUT_POPUP_DEFAULT_SIZE, ImGuiCond_Once);
+        ImGuiUtils::SetDpiScaledWindowConstraints(ABOUT_POPUP_MIN_SIZE.x, ABOUT_POPUP_MIN_SIZE.y);
+
+        if (!ImGui::BeginPopupModal(ABOUT_POPUP_NAME, &m_open, ImGuiWindowFlags_NoCollapse)) {
             return;
         }
 

--- a/src/gui/popups/about_dialog.cpp
+++ b/src/gui/popups/about_dialog.cpp
@@ -29,9 +29,7 @@ namespace gui {
             return;
         }
 
-        const float footerH = ImGuiUtils::DpiScale(26.0f);
-
-        ImGui::BeginChild("##about_body", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
+        ImGui::BeginChild("##about_body", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()), ImGuiChildFlags_Borders);
 
         std::string version = std::format("Version: {}", APP_FULL_VERSION);
         std::string built   = std::format("Built: {} {}", __DATE__, __TIME__);

--- a/src/gui/popups/about_dialog.cpp
+++ b/src/gui/popups/about_dialog.cpp
@@ -22,15 +22,14 @@ namespace gui {
         }
 
         ImGuiUtils::CenterNextWindow();
-
-        ImGui::SetNextWindowSize(ABOUT_POPUP_DEFAULT_SIZE, ImGuiCond_Once);
         ImGuiUtils::SetDpiScaledWindowConstraints(ABOUT_POPUP_MIN_SIZE.x, ABOUT_POPUP_MIN_SIZE.y);
+        ImGuiUtils::SetDpiScaledWindowSize(ABOUT_POPUP_DEFAULT_SIZE);
 
         if (!ImGui::BeginPopupModal(ABOUT_POPUP_NAME, &m_open, ImGuiWindowFlags_NoCollapse)) {
             return;
         }
 
-        const float footerH = 40.0f;
+        const float footerH = ImGuiUtils::DpiScale(26.0f);
 
         ImGui::BeginChild("##about_body", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
 
@@ -46,6 +45,7 @@ namespace gui {
             "%s - Advanced analysis of optical systems using parameters "
             "retrieved from Zemax via DDE (Dynamic Data Exchange)",
             APP_NAME);
+        ImGui::Spacing();    
         ImGui::Separator();
 
         ImGui::TextUnformatted("GitHub Repository:");
@@ -70,10 +70,10 @@ namespace gui {
         ImGui::EndChild();
 
         float window_width = ImGui::GetWindowSize().x;
-        float button_width = 120.0f;
+        float button_width = ImGuiUtils::DpiScale(120.0f);
         ImGui::SetCursorPosX((window_width - button_width) * 0.5f);
         if (ImGui::Button("OK", ImVec2(button_width, 0))) {
-            ImGui::CloseCurrentPopup();
+            close();
         }
         ImGui::EndPopup();
     }

--- a/src/gui/popups/about_dialog.cpp
+++ b/src/gui/popups/about_dialog.cpp
@@ -6,50 +6,63 @@
 #include <format>
 
 namespace gui {
-    void AboutDialog::render(bool& showAboutPopup) {
-        if (showAboutPopup) {
+    void AboutDialog::open() noexcept {
+        m_open = true;
+    }
+
+    void AboutDialog::close() noexcept {
+        m_open = false;
+    }
+
+    void AboutDialog::render() {
+        if (m_open && !ImGui::IsPopupOpen("About")) {
             ImGui::OpenPopup("About");
-            showAboutPopup = false;
         }
 
-        if (ImGui::BeginPopupModal("About", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-            std::string version = std::format("Version: {}", APP_FULL_VERSION);
-            std::string built   = std::format("Built: {} {}", __DATE__, __TIME__);
+        ImGui::SetNextWindowSize(ImVec2(440.0f, 240.0f), ImGuiCond_FirstUseEver);
 
-            std::string commitUrl = std::format(
-                "https://github.com/d3m37r4/ZemaxDDEClient/commit/{}",
-                APP_GIT_COMMIT
-            );
-
-            ImGui::TextUnformatted(APP_NAME);
-            ImGui::Separator();
-
-            ImGui::TextUnformatted("GitHub Repository:");
-            ImGui::SameLine();
-            ImGui::TextLinkOpenURL("github.com/d3m37r4/ZemaxDDEClient",
-                                   "https://github.com/d3m37r4/ZemaxDDEClient");
-
-            ImGui::TextUnformatted("Author:");
-            ImGui::SameLine();
-            ImGui::TextLinkOpenURL("Dmitry Isakov", "https://github.com/d3m37r4");
-
-            ImGui::TextUnformatted(version.c_str());
-            ImGui::TextUnformatted(built.c_str());
-            ImGui::TextUnformatted("Git commit:");
-            ImGui::SameLine();
-            ImGui::TextLinkOpenURL(APP_GIT_COMMIT, commitUrl.c_str());
-
-            ImGui::Spacing();
-            ImGui::Separator();
-            ImGui::Spacing();
-
-            float window_width = ImGui::GetWindowSize().x;
-            float button_width = 120.0f;
-            ImGui::SetCursorPosX((window_width - button_width) * 0.5f);
-            if (ImGui::Button("OK", ImVec2(button_width, 0))) {
-                ImGui::CloseCurrentPopup();
-            }
-            ImGui::EndPopup();
+        if (!ImGui::BeginPopupModal("About", &m_open, ImGuiWindowFlags_NoCollapse)) {
+            return;
         }
+
+        const float footerH = 40.0f;
+
+        ImGui::BeginChild("##about_body", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
+
+        std::string version = std::format("Version: {}", APP_FULL_VERSION);
+        std::string built   = std::format("Built: {} {}", __DATE__, __TIME__);
+
+        std::string commitUrl = std::format(
+            "https://github.com/d3m37r4/ZemaxDDEClient/commit/{}",
+            APP_GIT_COMMIT
+        );
+
+        ImGui::TextUnformatted(APP_NAME);
+        ImGui::Separator();
+
+        ImGui::TextUnformatted("GitHub Repository:");
+        ImGui::SameLine();
+        ImGui::TextLinkOpenURL("github.com/d3m37r4/ZemaxDDEClient",
+                               "https://github.com/d3m37r4/ZemaxDDEClient");
+
+        ImGui::TextUnformatted("Author:");
+        ImGui::SameLine();
+        ImGui::TextLinkOpenURL("Dmitry Isakov", "https://github.com/d3m37r4");
+
+        ImGui::TextUnformatted(version.c_str());
+        ImGui::TextUnformatted(built.c_str());
+        ImGui::TextUnformatted("Git commit:");
+        ImGui::SameLine();
+        ImGui::TextLinkOpenURL(APP_GIT_COMMIT, commitUrl.c_str());
+
+        ImGui::EndChild();
+
+        float window_width = ImGui::GetWindowSize().x;
+        float button_width = 120.0f;
+        ImGui::SetCursorPosX((window_width - button_width) * 0.5f);
+        if (ImGui::Button("OK", ImVec2(button_width, 0))) {
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
     }
 }

--- a/src/gui/popups/about_dialog.cpp
+++ b/src/gui/popups/about_dialog.cpp
@@ -67,10 +67,9 @@ namespace gui {
 
         ImGui::EndChild();
 
-        float window_width = ImGui::GetWindowSize().x;
-        float button_width = ImGuiUtils::DpiScale(120.0f);
-        ImGui::SetCursorPosX((window_width - button_width) * 0.5f);
-        if (ImGui::Button("OK", ImVec2(button_width, 0))) {
+        float okBtnW = ImGuiUtils::DpiScale(120.0f);
+        ImGui::SetCursorPosX((ImGui::GetWindowSize().x - okBtnW) * 0.5f);
+        if (ImGui::Button("OK", ImVec2(okBtnW, 0))) {
             close();
         }
         ImGui::EndPopup();

--- a/src/gui/popups/about_dialog.h
+++ b/src/gui/popups/about_dialog.h
@@ -3,8 +3,13 @@
 namespace gui {
     class AboutDialog {
         public:
-            void render(bool& showAboutPopup);
+            void open() noexcept;
+            void close() noexcept;
+            [[nodiscard]] bool isOpen() const noexcept { return m_open; }
+
+            void render();
 
         private:
+            bool m_open = false;
     };
 }

--- a/src/gui/popups/connect_dde.cpp
+++ b/src/gui/popups/connect_dde.cpp
@@ -21,7 +21,7 @@ namespace gui {
         if (ImGui::BeginPopupModal(CONNECT_DDE_POPUP_NAME, &showFlag, ImGuiWindowFlags_None)) {
             auto windows = app::ZemaxWindowEnumerator::enumerate();
 
-            ImGui::BeginChild("ZemaxWindowList", ImVec2(0, -ImGui::GetFrameHeightWithSpacing() - 10), ImGuiChildFlags_Borders);
+            ImGui::BeginChild("ZemaxWindowList", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()), ImGuiChildFlags_Borders);
 
             for (size_t i = 0; i < windows.size(); ++i) {
                 const auto& wnd = windows[i];

--- a/src/gui/popups/connect_dde.cpp
+++ b/src/gui/popups/connect_dde.cpp
@@ -12,15 +12,13 @@ namespace gui {
     void ConnectDDEPopup::render(bool& showFlag, Logger& logger) {
         if (!showFlag) return;
 
-        constexpr const char* POPUP_TITLE = "Connect to Zemax – select a window";
+        ImGui::OpenPopup(CONNECT_DDE_POPUP_NAME);
 
-        ImGui::OpenPopup(POPUP_TITLE);
-        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-        ImGuiUtils::SetDpiScaledWindowConstraints(CONNECT_DDE_POPUP_WIDTH_MIN, CONNECT_DDE_POPUP_HEIGHT_MIN);
-        // ImGui::SetNextWindowSize(ImVec2(920, 400), ImGuiCond_FirstUseEver);
+        ImGuiUtils::CenterNextWindow();
+        ImGuiUtils::SetDpiScaledWindowConstraints(CONNECT_DDE_POPUP_MIN_SIZE.x, CONNECT_DDE_POPUP_MIN_SIZE.y);
+        ImGuiUtils::SetDpiScaledWindowSize(CONNECT_DDE_POPUP_DEFAULT_SIZE);
 
-        if (ImGui::BeginPopupModal(POPUP_TITLE, &showFlag, ImGuiWindowFlags_None)) {
+        if (ImGui::BeginPopupModal(CONNECT_DDE_POPUP_NAME, &showFlag, ImGuiWindowFlags_None)) {
             auto windows = app::ZemaxWindowEnumerator::enumerate();
 
             ImGui::BeginChild("ZemaxWindowList", ImVec2(0, -ImGui::GetFrameHeightWithSpacing() - 10), ImGuiChildFlags_Borders);
@@ -43,11 +41,15 @@ namespace gui {
 
             bool canConnect = (m_selectedWindowIndex >= 0 && m_selectedWindowIndex < static_cast<int>(windows.size()));
 
+            float connectBtnW = ImGuiUtils::DpiScale(120.0f);
+            float cancelBtnW  = ImGuiUtils::DpiScale(120.0f);
+            float refreshBtnW = ImGuiUtils::DpiScale(120.0f);
+
             if (!canConnect) {
                 ImGui::BeginDisabled();
             }
 
-            if (ImGui::Button("Connect", ImVec2(120, 0))) {
+            if (ImGui::Button("Connect", ImVec2(connectBtnW, 0))) {
                 const auto& wnd = windows[m_selectedWindowIndex];
                 int slot = m_connectionManager->connectToZemax(wnd.hwnd, wnd.title);
                 if (slot >= 0) {
@@ -65,15 +67,15 @@ namespace gui {
 
             ImGui::SameLine();
 
-            if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+            if (ImGui::Button("Cancel", ImVec2(cancelBtnW, 0))) {
                 showFlag = false;
                 m_selectedWindowIndex = -1;
             }
 
             ImGui::SameLine();
             float remainingWidth = ImGui::GetContentRegionAvail().x;
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + remainingWidth - 120.0f);
-            if (ImGui::Button("Refresh", ImVec2(120, 0))) {
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + remainingWidth - refreshBtnW);
+            if (ImGui::Button("Refresh", ImVec2(refreshBtnW, 0))) {
                 m_selectedWindowIndex = -1;
             }
 

--- a/src/gui/popups/connect_dde.cpp
+++ b/src/gui/popups/connect_dde.cpp
@@ -55,9 +55,9 @@ namespace gui {
 
         bool canConnect = (m_selectedWindowIndex >= 0 && m_selectedWindowIndex < static_cast<int>(windows.size()));
 
-        float connectBtnW = ImGuiUtils::DpiScale(120.0f);
-        float cancelBtnW  = ImGuiUtils::DpiScale(120.0f);
-        float refreshBtnW = ImGuiUtils::DpiScale(120.0f);
+        float connectBtnW = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
+        float cancelBtnW  = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
+        float refreshBtnW = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
 
         if (!canConnect) {
             ImGui::BeginDisabled();

--- a/src/gui/popups/connect_dde.cpp
+++ b/src/gui/popups/connect_dde.cpp
@@ -9,77 +9,90 @@
 #include "logger/logger.h"
 
 namespace gui {
-    void ConnectDDEPopup::render(bool& showFlag, Logger& logger) {
-        if (!showFlag) return;
+    void ConnectDDEPopup::open() noexcept {
+        m_open = true;
+    }
 
-        ImGui::OpenPopup(CONNECT_DDE_POPUP_NAME);
+    void ConnectDDEPopup::close() noexcept {
+        m_open = false;
+    }
+
+    void ConnectDDEPopup::render() {
+        if (!m_open) return;
+        if (!m_logger) return;
+
+        if (!ImGui::IsPopupOpen(CONNECT_DDE_POPUP_NAME)) {
+            ImGui::OpenPopup(CONNECT_DDE_POPUP_NAME);
+        }
 
         ImGuiUtils::CenterNextWindow();
         ImGuiUtils::SetDpiScaledWindowConstraints(CONNECT_DDE_POPUP_MIN_SIZE.x, CONNECT_DDE_POPUP_MIN_SIZE.y);
         ImGuiUtils::SetDpiScaledWindowSize(CONNECT_DDE_POPUP_DEFAULT_SIZE);
 
-        if (ImGui::BeginPopupModal(CONNECT_DDE_POPUP_NAME, &showFlag, ImGuiWindowFlags_None)) {
-            auto windows = app::ZemaxWindowEnumerator::enumerate();
-
-            ImGui::BeginChild("ZemaxWindowList", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()), ImGuiChildFlags_Borders);
-
-            for (size_t i = 0; i < windows.size(); ++i) {
-                const auto& wnd = windows[i];
-                std::string title(wnd.title.begin(), wnd.title.end());
-                std::string label = std::format("[PID: {}] {}", wnd.pid, title);
-
-                if (ImGui::Selectable(label.c_str(), m_selectedWindowIndex == static_cast<int>(i))) {
-                    m_selectedWindowIndex = static_cast<int>(i);
-                }
-            }
-
-            if (windows.empty()) {
-                ImGui::TextDisabled("No Zemax windows found");
-            }
-
-            ImGui::EndChild();
-
-            bool canConnect = (m_selectedWindowIndex >= 0 && m_selectedWindowIndex < static_cast<int>(windows.size()));
-
-            float connectBtnW = ImGuiUtils::DpiScale(120.0f);
-            float cancelBtnW  = ImGuiUtils::DpiScale(120.0f);
-            float refreshBtnW = ImGuiUtils::DpiScale(120.0f);
-
-            if (!canConnect) {
-                ImGui::BeginDisabled();
-            }
-
-            if (ImGui::Button("Connect", ImVec2(connectBtnW, 0))) {
-                const auto& wnd = windows[m_selectedWindowIndex];
-                int slot = m_connectionManager->connectToZemax(wnd.hwnd, wnd.title);
-                if (slot >= 0) {
-                    showFlag = false;
-                    m_selectedWindowIndex = -1;
-                } else {
-                    std::string title(wnd.title.begin(), wnd.title.end());
-                    logger.addLog(std::format("[DDE] Failed to connect to: {}", title));
-                }
-            }
-
-            if (!canConnect) {
-                ImGui::EndDisabled();
-            }
-
-            ImGui::SameLine();
-
-            if (ImGui::Button("Cancel", ImVec2(cancelBtnW, 0))) {
-                showFlag = false;
-                m_selectedWindowIndex = -1;
-            }
-
-            ImGui::SameLine();
-            float remainingWidth = ImGui::GetContentRegionAvail().x;
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + remainingWidth - refreshBtnW);
-            if (ImGui::Button("Refresh", ImVec2(refreshBtnW, 0))) {
-                m_selectedWindowIndex = -1;
-            }
-
-            ImGui::EndPopup();
+        if (!ImGui::BeginPopupModal(CONNECT_DDE_POPUP_NAME, &m_open, ImGuiWindowFlags_NoCollapse)) {
+            return;
         }
+
+        auto windows = app::ZemaxWindowEnumerator::enumerate();
+
+        ImGui::BeginChild("ZemaxWindowList", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()), ImGuiChildFlags_Borders);
+
+        for (size_t i = 0; i < windows.size(); ++i) {
+            const auto& wnd = windows[i];
+            std::string title(wnd.title.begin(), wnd.title.end());
+            std::string label = std::format("[PID: {}] {}", wnd.pid, title);
+
+            if (ImGui::Selectable(label.c_str(), m_selectedWindowIndex == static_cast<int>(i))) {
+                m_selectedWindowIndex = static_cast<int>(i);
+            }
+        }
+
+        if (windows.empty()) {
+            ImGui::TextDisabled("No Zemax windows found");
+        }
+
+        ImGui::EndChild();
+
+        bool canConnect = (m_selectedWindowIndex >= 0 && m_selectedWindowIndex < static_cast<int>(windows.size()));
+
+        float connectBtnW = ImGuiUtils::DpiScale(120.0f);
+        float cancelBtnW  = ImGuiUtils::DpiScale(120.0f);
+        float refreshBtnW = ImGuiUtils::DpiScale(120.0f);
+
+        if (!canConnect) {
+            ImGui::BeginDisabled();
+        }
+
+        if (ImGui::Button("Connect", ImVec2(connectBtnW, 0))) {
+            const auto& wnd = windows[m_selectedWindowIndex];
+            int slot = m_connectionManager->connectToZemax(wnd.hwnd, wnd.title);
+            if (slot >= 0) {
+                m_open = false;
+                m_selectedWindowIndex = -1;
+            } else {
+                std::string title(wnd.title.begin(), wnd.title.end());
+                m_logger->addLog(std::format("[DDE] Failed to connect to: {}", title));
+            }
+        }
+
+        if (!canConnect) {
+            ImGui::EndDisabled();
+        }
+
+        ImGui::SameLine();
+
+        if (ImGui::Button("Cancel", ImVec2(cancelBtnW, 0))) {
+            m_open = false;
+            m_selectedWindowIndex = -1;
+        }
+
+        ImGui::SameLine();
+        float remainingWidth = ImGui::GetContentRegionAvail().x;
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + remainingWidth - refreshBtnW);
+        if (ImGui::Button("Refresh", ImVec2(refreshBtnW, 0))) {
+            m_selectedWindowIndex = -1;
+        }
+
+        ImGui::EndPopup();
     }
 }

--- a/src/gui/popups/connect_dde.cpp
+++ b/src/gui/popups/connect_dde.cpp
@@ -2,6 +2,7 @@
 
 #include "connect_dde.h"
 #include "app/zemax_window_enumerator.h"
+#include "dde/utils.h"
 #include "gui/utils.h"
 #include "gui/imgui_utils.h"
 #include "gui/constants.h"
@@ -39,7 +40,7 @@ namespace gui {
 
         for (size_t i = 0; i < windows.size(); ++i) {
             const auto& wnd = windows[i];
-            std::string title(wnd.title.begin(), wnd.title.end());
+            std::string title = ZemaxDDE::wstring_to_utf8(wnd.title);
             std::string label = std::format("[PID: {}] {}", wnd.pid, title);
 
             if (ImGui::Selectable(label.c_str(), m_selectedWindowIndex == static_cast<int>(i))) {
@@ -70,7 +71,7 @@ namespace gui {
                 m_open = false;
                 m_selectedWindowIndex = -1;
             } else {
-                std::string title(wnd.title.begin(), wnd.title.end());
+                std::string title = ZemaxDDE::wstring_to_utf8(wnd.title);
                 m_logger->addLog(std::format("[DDE] Failed to connect to: {}", title));
             }
         }

--- a/src/gui/popups/connect_dde.h
+++ b/src/gui/popups/connect_dde.h
@@ -2,16 +2,26 @@
 
 #include "dde/dde_connection_manager.h"
 
+class Logger;
+
 namespace gui {
     class ConnectDDEPopup {
     public:
         explicit ConnectDDEPopup(DDEConnectionManager* connectionManager)
             : m_connectionManager(connectionManager) {}
 
-        void render(bool& showFlag, Logger& logger);
+        void open() noexcept;
+        void close() noexcept;
+        [[nodiscard]] bool isOpen() const noexcept { return m_open; }
+
+        void setLogger(Logger* logger) noexcept { m_logger = logger; }
+
+        void render();
 
     private:
         DDEConnectionManager* m_connectionManager;
+        Logger* m_logger = nullptr;
+        bool m_open = false;
         int m_selectedWindowIndex = -1;
     };
 }

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -2,6 +2,7 @@
 
 #include "app/config_path.h"
 #include "gui/constants.h"
+#include "gui/imgui_utils.h"
 #include "gui/settings_manager.h"
 #include "lib/imgui/imgui.h"
 
@@ -24,16 +25,16 @@ namespace gui {
     }
 
     void PreferencesDialog::render() {
-        if (m_open && !ImGui::IsPopupOpen("Preferences")) {
-            ImGui::OpenPopup("Preferences");
+        if (m_open && !ImGui::IsPopupOpen(PREFERENCES_POPUP_NAME)) {
+            ImGui::OpenPopup(PREFERENCES_POPUP_NAME);
         }
 
-        ImGui::SetNextWindowSize(PREFERENCES_WINDOW_DEFAULT_SIZE, ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSizeConstraints(
-            ImVec2(PREFERENCES_WINDOW_MIN_WIDTH, PREFERENCES_WINDOW_MIN_HEIGHT),
-            ImVec2(FLT_MAX, FLT_MAX));
+        ImGuiUtils::CenterNextWindow();
 
-        if (!ImGui::BeginPopupModal("Preferences", &m_open,
+        ImGui::SetNextWindowSize(PREFERENCES_WINDOW_DEFAULT_SIZE, ImGuiCond_Once);
+        ImGuiUtils::SetDpiScaledWindowConstraints(PREFERENCES_WINDOW_MIN_WIDTH, PREFERENCES_WINDOW_MIN_HEIGHT);
+
+        if (!ImGui::BeginPopupModal(PREFERENCES_POPUP_NAME, &m_open,
                                     ImGuiWindowFlags_NoCollapse)) {
             return;
         }

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -214,7 +214,8 @@ namespace gui {
             ImGui::SetTooltip("Discard all changes and restore factory defaults.");
         }
 
-        ImGui::SameLine();
+        const float groupWidth = 2.0f * w + ImGui::GetStyle().ItemSpacing.x;
+        ImGui::SameLine(ImGui::GetContentRegionAvail().x - groupWidth);
 
         if (ImGui::Button("Cancel", ImVec2(w, 0))) {
             onCancel();

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -42,7 +42,7 @@ namespace gui {
         }
 
         static const char* sidebarLabels[] = {
-            "General", "Appearance", "DDE Connection", "Plot", "Updates", "Files"
+            "General", "Appearance", "DDE Connection", "DDE Performance", "Plot", "Updates", "Files"
         };
         if (m_sidebarWidth <= 0.0f) {
             float maxW = 0.0f;
@@ -85,6 +85,7 @@ namespace gui {
             "General",
             "Appearance",
             "DDE Connection",
+            "DDE Performance",
             "Plot",
             "Updates",
             "Files",
@@ -100,12 +101,13 @@ namespace gui {
 
     void PreferencesDialog::renderContent() {
         switch (m_section) {
-            case Section::General:    renderSectionGeneral();    break;
-            case Section::Appearance: renderSectionAppearance(); break;
-            case Section::DDE:        renderSectionDDE();        break;
-            case Section::Plot:       renderSectionPlot();       break;
-            case Section::Updates:    renderSectionUpdates();    break;
-            case Section::Files:      renderSectionFiles();      break;
+            case Section::General:       renderSectionGeneral();       break;
+            case Section::Appearance:    renderSectionAppearance();    break;
+            case Section::DDE:           renderSectionDDE();           break;
+            case Section::DDEPerformance: renderSectionDDEPerformance(); break;
+            case Section::Plot:          renderSectionPlot();          break;
+            case Section::Updates:       renderSectionUpdates();       break;
+            case Section::Files:         renderSectionFiles();         break;
             default: break;
         }
     }
@@ -153,6 +155,55 @@ namespace gui {
         if (ImGui::Checkbox("Auto-reconnect on drop", &m_working.dde.autoReconnect)) {
             applyWorkingDDE();
         }
+    }
+
+    void PreferencesDialog::renderSectionDDEPerformance() {
+        ImGuiUtils::SectionHeader("DDE Performance", "Per-request timeout overrides (ms).");
+
+        auto inputMs = [](const char* label, const char* id, int* value) {
+            ImGui::TextUnformatted(label);
+            ImGui::SameLine(200);
+            ImGui::SetNextItemWidth(120);
+            ImGui::InputInt(id, value, 0, 0);
+            ImGui::SameLine();
+            ImGui::TextUnformatted("ms");
+        };
+
+        // --- Optical System Info ---
+        if (ImGui::BeginChild("##perf_initdata", ImVec2(0, ImGui::GetFrameHeightWithSpacing() * 7), ImGuiChildFlags_Borders)) {
+            ImGui::TextUnformatted("Optical System Info");
+            ImGui::Spacing();
+            inputMs("GetName",        "##t GetName",        &m_working.dde.getNameTimeoutMs);
+            inputMs("GetFile",        "##t GetFile",        &m_working.dde.getFileTimeoutMs);
+            inputMs("GetSystem",      "##t GetSystem",      &m_working.dde.getSystemTimeoutMs);
+            inputMs("GetField",       "##t GetField",       &m_working.dde.getFieldTimeoutMs);
+            inputMs("GetWave",        "##t GetWave",        &m_working.dde.getWaveTimeoutMs);
+        }
+        ImGui::EndChild();
+
+        ImGui::Spacing();
+
+        // --- Surface Profile Inspector ---
+        if (ImGui::BeginChild("##perf_profile", ImVec2(0, ImGui::GetFrameHeightWithSpacing() * 4), ImGuiChildFlags_Borders)) {
+            ImGui::TextUnformatted("Surface Profile Inspector");
+            ImGui::Spacing();
+            inputMs("GetSurfaceData", "##t P GetSurf", &m_working.dde.getSurfaceDataProfileTimeoutMs);
+            inputMs("GetSag",         "##t P GetSag",  &m_working.dde.getSagProfileTimeoutMs);
+        }
+        ImGui::EndChild();
+
+        ImGui::Spacing();
+
+        // --- Surface Irregularity Map ---
+        if (ImGui::BeginChild("##perf_map", ImVec2(0, ImGui::GetFrameHeightWithSpacing() * 4), ImGuiChildFlags_Borders)) {
+            ImGui::TextUnformatted("Surface Irregularity Map");
+            ImGui::Spacing();
+            inputMs("GetSurfaceData", "##t M GetSurf", &m_working.dde.getSurfaceDataMapTimeoutMs);
+            inputMs("GetSag",         "##t M GetSag",  &m_working.dde.getSagMapTimeoutMs);
+        }
+        ImGui::EndChild();
+
+        applyWorkingDDE();
     }
 
     void PreferencesDialog::renderSectionPlot() {

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -63,20 +63,8 @@ namespace gui {
 
         ImGui::SameLine();
 
-        const ImVec2 sp = ImGui::GetCursorScreenPos();
-        ImGui::InvisibleButton("##prefs_splitter", ImVec2(splitterW, availH));
-        if (ImGui::IsItemActive()) {
-            m_sidebarWidth += ImGui::GetIO().MouseDelta.x;
-            m_sidebarWidth = std::clamp(m_sidebarWidth, 60.0f, availW - 100.0f - splitterW);
-        }
-        ImU32 col;
-        if (ImGui::IsItemActive())
-            col = ImGui::GetColorU32(ImGuiCol_SeparatorActive);
-        else if (ImGui::IsItemHovered())
-            col = ImGui::GetColorU32(ImGuiCol_Text, 0.4f);
-        else
-            col = ImGui::GetColorU32(ImGuiCol_Separator);
-        ImGui::GetWindowDrawList()->AddRectFilled(sp, ImVec2(sp.x + splitterW, sp.y + availH), col);
+        ImGuiUtils::SplitterH("##prefs_splitter", m_sidebarWidth, availH,
+                               splitterW, 60.0f, availW - 100.0f - splitterW);
 
         ImGui::SameLine();
 

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -24,17 +24,17 @@ namespace gui {
     }
 
     void PreferencesDialog::render() {
-        if (!m_open) return;
+        if (m_open && !ImGui::IsPopupOpen("Preferences")) {
+            ImGui::OpenPopup("Preferences");
+        }
 
         ImGui::SetNextWindowSize(PREFERENCES_WINDOW_DEFAULT_SIZE, ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSizeConstraints(
             ImVec2(PREFERENCES_WINDOW_MIN_WIDTH, PREFERENCES_WINDOW_MIN_HEIGHT),
             ImVec2(FLT_MAX, FLT_MAX));
 
-        if (!ImGui::Begin("Preferences", &m_open,
-                          ImGuiWindowFlags_NoDocking |
-                          ImGuiWindowFlags_NoCollapse)) {
-            ImGui::End();
+        if (!ImGui::BeginPopupModal("Preferences", &m_open,
+                                    ImGuiWindowFlags_NoCollapse)) {
             return;
         }
 
@@ -55,7 +55,7 @@ namespace gui {
         ImGui::Separator();
         renderFooter();
 
-        ImGui::End();
+        ImGui::EndPopup();
 
         renderResetConfirm();
     }
@@ -190,6 +190,8 @@ namespace gui {
     }
 
     void PreferencesDialog::renderFooter() {
+        ImGui::Spacing();
+
         const float w = 110.0f;
         const float h = 32.0f;
 
@@ -217,6 +219,8 @@ namespace gui {
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Persist the current values to settings.json.");
         }
+
+        ImGui::Spacing();
     }
 
     void PreferencesDialog::renderResetConfirm() {

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -205,9 +205,9 @@ namespace gui {
     }
 
     void PreferencesDialog::renderFooter() {
-        float resetBtnW   = ImGuiUtils::DpiScale(120.0f);
-        float cancelBtnW  = ImGuiUtils::DpiScale(120.0f);
-        float saveBtnW    = ImGuiUtils::DpiScale(120.0f);
+        float resetBtnW   = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
+        float cancelBtnW  = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
+        float saveBtnW    = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
 
         if (ImGui::Button("Reset", ImVec2(resetBtnW, 0))) {
             m_confirmReset = true;
@@ -252,8 +252,8 @@ namespace gui {
             ImGui::TextUnformatted("Unsaved changes will be lost.");
             ImGui::EndChild();
 
-            float cancelBtnW = ImGuiUtils::DpiScale(120.0f);
-            float resetBtnW  = ImGuiUtils::DpiScale(120.0f);
+            float cancelBtnW = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
+            float resetBtnW  = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
             const float totalW = cancelBtnW + resetBtnW + ImGui::GetStyle().ItemSpacing.x;
             ImGui::SetCursorPosX((ImGui::GetContentRegionAvail().x - totalW) * 0.5f);
             if (ImGui::Button("Cancel", ImVec2(cancelBtnW, 0))) {

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -205,12 +205,9 @@ namespace gui {
     }
 
     void PreferencesDialog::renderFooter() {
-        // ImGui::Spacing();
+        const float w = ImGuiUtils::DpiScale(120.0f);
 
-        const float w = 110.0f;
-        const float h = 32.0f;
-
-        if (ImGui::Button("Reset...", ImVec2(w, h))) {
+        if (ImGui::Button("Reset", ImVec2(w, 0))) {
             m_confirmReset = true;
         }
         if (ImGui::IsItemHovered()) {
@@ -219,7 +216,7 @@ namespace gui {
 
         ImGui::SameLine();
 
-        if (ImGui::Button("Cancel", ImVec2(w, h))) {
+        if (ImGui::Button("Cancel", ImVec2(w, 0))) {
             onCancel();
         }
         if (ImGui::IsItemHovered()) {
@@ -228,14 +225,12 @@ namespace gui {
 
         ImGui::SameLine();
 
-        if (ImGui::Button("Save", ImVec2(w, h))) {
+        if (ImGui::Button("Save", ImVec2(w, 0))) {
             onSave();
         }
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Persist the current values to settings.json.");
         }
-
-        // ImGui::Spacing();
     }
 
     void PreferencesDialog::renderResetConfirm() {
@@ -253,7 +248,7 @@ namespace gui {
             ImGui::Separator();
             ImGui::Spacing();
 
-            const float w = 110.0f;
+            const float w = ImGuiUtils::DpiScale(120.0f);
             if (ImGui::Button("Cancel", ImVec2(w, 0))) {
                 m_confirmReset = false;
             }

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -39,17 +39,17 @@ namespace gui {
             return;
         }
 
-        const float footerH = PREFERENCES_FOOTER_HEIGHT;
+        const float footerH = ImGui::GetFrameHeightWithSpacing();
 
         ImGui::BeginChild("##prefs_sidebar",
-                          ImVec2(PREFERENCES_SIDEBAR_WIDTH, -ImGuiUtils::DpiScale(footerH)),
+                          ImVec2(PREFERENCES_SIDEBAR_WIDTH, -footerH),
                           ImGuiChildFlags_Borders);
         renderSidebar();
         ImGui::EndChild();
 
         ImGui::SameLine();
 
-        ImGui::BeginChild("##prefs_content", ImVec2(0, -ImGuiUtils::DpiScale(footerH)), ImGuiChildFlags_Borders);
+        ImGui::BeginChild("##prefs_content", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
         renderContent();
         ImGui::EndChild();
 

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -1,0 +1,278 @@
+#include "gui/popups/preferences_dialog.h"
+
+#include "app/config_path.h"
+#include "gui/constants.h"
+#include "gui/settings_manager.h"
+#include "lib/imgui/imgui.h"
+
+namespace gui {
+
+    PreferencesDialog::PreferencesDialog(SettingsManager& settings) noexcept
+        : m_settings(settings) {}
+
+    void PreferencesDialog::open() noexcept {
+        m_working = m_settings.current();
+        m_loaded  = m_settings.current();
+        m_section = Section::General;
+        m_confirmReset = false;
+        m_open = true;
+    }
+
+    void PreferencesDialog::close() noexcept {
+        m_open = false;
+        m_confirmReset = false;
+    }
+
+    void PreferencesDialog::render() {
+        if (!m_open) return;
+
+        ImGui::SetNextWindowSize(PREFERENCES_WINDOW_DEFAULT_SIZE, ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowSizeConstraints(
+            ImVec2(PREFERENCES_WINDOW_MIN_WIDTH, PREFERENCES_WINDOW_MIN_HEIGHT),
+            ImVec2(FLT_MAX, FLT_MAX));
+
+        if (!ImGui::Begin("Preferences", &m_open,
+                          ImGuiWindowFlags_NoDocking |
+                          ImGuiWindowFlags_NoCollapse)) {
+            ImGui::End();
+            return;
+        }
+
+        const float footerH = PREFERENCES_FOOTER_HEIGHT;
+
+        ImGui::BeginChild("##prefs_sidebar",
+                          ImVec2(PREFERENCES_SIDEBAR_WIDTH, -footerH),
+                          ImGuiChildFlags_Borders);
+        renderSidebar();
+        ImGui::EndChild();
+
+        ImGui::SameLine();
+
+        ImGui::BeginChild("##prefs_content", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
+        renderContent();
+        ImGui::EndChild();
+
+        ImGui::Separator();
+        renderFooter();
+
+        ImGui::End();
+
+        renderResetConfirm();
+    }
+
+    void PreferencesDialog::renderSidebar() {
+        static const char* labels[static_cast<int>(Section::Count)] = {
+            "General",
+            "Appearance",
+            "DDE Connection",
+            "Plot",
+            "Updates",
+        };
+
+        ImGui::TextDisabled("Sections");
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        for (int i = 0; i < static_cast<int>(Section::Count); ++i) {
+            const bool selected = (static_cast<int>(m_section) == i);
+            if (ImGui::Selectable(labels[i], selected)) {
+                m_section = static_cast<Section>(i);
+            }
+        }
+    }
+
+    void PreferencesDialog::renderContent() {
+        switch (m_section) {
+            case Section::General:    renderSectionGeneral();    break;
+            case Section::Appearance: renderSectionAppearance(); break;
+            case Section::DDE:        renderSectionDDE();        break;
+            case Section::Plot:       renderSectionPlot();       break;
+            case Section::Updates:    renderSectionUpdates();    break;
+            default: break;
+        }
+    }
+
+    void PreferencesDialog::renderSectionGeneral() {
+        ImGui::TextUnformatted("General");
+        ImGui::Separator();
+        ImGui::Spacing();
+        ImGui::TextDisabled("These options take effect on the next application start.");
+        ImGui::Spacing();
+
+        ImGui::Checkbox("Show debug log window on startup", &m_working.general.showDebugLogOnStartup);
+        ImGui::Checkbox("Restore window layout on startup", &m_working.general.restoreWindowLayout);
+    }
+
+    void PreferencesDialog::renderSectionAppearance() {
+        ImGui::TextUnformatted("Appearance");
+        ImGui::Separator();
+        ImGui::Spacing();
+        ImGui::TextDisabled("Theme changes are applied immediately.");
+        ImGui::Spacing();
+
+        int mode = static_cast<int>(m_working.appearance.themeMode);
+        if (ImGui::RadioButton("Light",  &mode, static_cast<int>(app::ThemeMode::Light)))  { m_working.appearance.themeMode = app::ThemeMode::Light;  applyWorkingTheme(); }
+        if (ImGui::RadioButton("Dark",   &mode, static_cast<int>(app::ThemeMode::Dark)))   { m_working.appearance.themeMode = app::ThemeMode::Dark;   applyWorkingTheme(); }
+        if (ImGui::RadioButton("System", &mode, static_cast<int>(app::ThemeMode::System))) { m_working.appearance.themeMode = app::ThemeMode::System; applyWorkingTheme(); }
+    }
+
+    void PreferencesDialog::renderSectionDDE() {
+        ImGui::TextUnformatted("DDE Connection");
+        ImGui::Separator();
+        ImGui::Spacing();
+        ImGui::TextDisabled("New values apply to subsequent requests only.");
+        ImGui::Spacing();
+
+        if (ImGui::SliderInt("Connection timeout (ms)", &m_working.dde.connectionTimeoutMs, 1000, 30000, "%d", ImGuiSliderFlags_AlwaysClamp)) {
+            applyWorkingDDE();
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Maximum time to wait for a single DDE round-trip.");
+        }
+
+        if (ImGui::SliderInt("Max retry count", &m_working.dde.maxRetryCount, 0, 10, "%d", ImGuiSliderFlags_AlwaysClamp)) {
+            applyWorkingDDE();
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("How many times to retry a failed DDE exchange.");
+        }
+
+        if (ImGui::SliderInt("Max concurrent connections", &m_working.dde.maxConnections, 1, 16, "%d", ImGuiSliderFlags_AlwaysClamp)) {
+            applyWorkingDDE();
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Upper bound on parallel DDE clients kept open by the manager.");
+        }
+
+        if (ImGui::Checkbox("Auto-reconnect on drop", &m_working.dde.autoReconnect)) {
+            applyWorkingDDE();
+        }
+    }
+
+    void PreferencesDialog::renderSectionPlot() {
+        ImGui::TextUnformatted("Plot");
+        ImGui::Separator();
+        ImGui::Spacing();
+        ImGui::TextDisabled("Visual style for new plots.");
+        ImGui::Spacing();
+
+        if (ImGui::Checkbox("Show grid by default", &m_working.plot.showGridByDefault)) {
+            applyWorkingPlot();
+        }
+
+        if (ImGui::SliderFloat("Line weight (px)", &m_working.plot.lineWeight, 0.5f, 5.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp)) {
+            applyWorkingPlot();
+        }
+
+        if (ImGui::SliderFloat("Marker size (px)", &m_working.plot.markerSize, 1.0f, 20.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp)) {
+            applyWorkingPlot();
+        }
+    }
+
+    void PreferencesDialog::renderSectionUpdates() {
+        ImGui::TextUnformatted("Updates");
+        ImGui::Separator();
+        ImGui::Spacing();
+        ImGui::TextDisabled("Update checker settings. Channel changes take effect on next check.");
+        ImGui::Spacing();
+
+        ImGui::Checkbox("Check for updates on startup", &m_working.updates.autoCheckOnStartup);
+
+        ImGui::Spacing();
+        ImGui::TextUnformatted("Update channel");
+        int channel = static_cast<int>(m_working.updates.channel);
+        if (ImGui::RadioButton("Stable", &channel, static_cast<int>(app::UpdateChannel::Stable))) {
+            m_working.updates.channel = app::UpdateChannel::Stable;
+        }
+        if (ImGui::RadioButton("Beta",   &channel, static_cast<int>(app::UpdateChannel::Beta))) {
+            m_working.updates.channel = app::UpdateChannel::Beta;
+        }
+    }
+
+    void PreferencesDialog::renderFooter() {
+        const float w = 110.0f;
+        const float h = 32.0f;
+
+        if (ImGui::Button("Reset...", ImVec2(w, h))) {
+            m_confirmReset = true;
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Discard all changes and restore factory defaults.");
+        }
+
+        ImGui::SameLine();
+
+        if (ImGui::Button("Cancel", ImVec2(w, h))) {
+            onCancel();
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Discard all changes and revert to the last saved values.");
+        }
+
+        ImGui::SameLine();
+
+        if (ImGui::Button("Save", ImVec2(w, h))) {
+            onSave();
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Persist the current values to settings.json.");
+        }
+    }
+
+    void PreferencesDialog::renderResetConfirm() {
+        if (!m_confirmReset) return;
+
+        ImGui::OpenPopup("Reset Preferences?");
+        const ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+        if (ImGui::BeginPopupModal("Reset Preferences?", &m_confirmReset,
+                                   ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::TextUnformatted("This will reset all preferences to their factory defaults.");
+            ImGui::TextUnformatted("Unsaved changes will be lost.");
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+
+            const float w = 110.0f;
+            if (ImGui::Button("Cancel", ImVec2(w, 0))) {
+                m_confirmReset = false;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Reset", ImVec2(w, 0))) {
+                onReset();
+                m_confirmReset = false;
+            }
+            ImGui::EndPopup();
+        }
+    }
+
+    void PreferencesDialog::applyWorkingTheme() const {
+        m_settings.applyTheme(m_working.appearance);
+    }
+
+    void PreferencesDialog::applyWorkingDDE() const {
+        m_settings.applyDDE(m_working.dde);
+    }
+
+    void PreferencesDialog::applyWorkingPlot() const {
+        m_settings.applyPlot(m_working.plot);
+    }
+
+    void PreferencesDialog::onSave() {
+        m_settings.apply(m_working);
+        m_loaded = m_working;
+        m_settings.saveToFile();
+    }
+
+    void PreferencesDialog::onCancel() {
+        m_working = m_loaded;
+        m_settings.apply(m_working);
+    }
+
+    void PreferencesDialog::onReset() {
+        m_working = app::AppSettings::defaults();
+        m_settings.apply(m_working);
+    }
+
+} // namespace gui

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -1,6 +1,7 @@
 #include "gui/popups/preferences_dialog.h"
 
 #include <algorithm>
+#include <cstring>
 
 #include "app/config_path.h"
 #include "gui/constants.h"
@@ -41,7 +42,7 @@ namespace gui {
         }
 
         static const char* sidebarLabels[] = {
-            "General", "Appearance", "DDE Connection", "Plot", "Updates"
+            "General", "Appearance", "DDE Connection", "Plot", "Updates", "Files"
         };
         if (m_sidebarWidth <= 0.0f) {
             float maxW = 0.0f;
@@ -86,6 +87,7 @@ namespace gui {
             "DDE Connection",
             "Plot",
             "Updates",
+            "Files",
         };
 
         for (int i = 0; i < static_cast<int>(Section::Count); ++i) {
@@ -103,27 +105,20 @@ namespace gui {
             case Section::DDE:        renderSectionDDE();        break;
             case Section::Plot:       renderSectionPlot();       break;
             case Section::Updates:    renderSectionUpdates();    break;
+            case Section::Files:      renderSectionFiles();      break;
             default: break;
         }
     }
 
     void PreferencesDialog::renderSectionGeneral() {
-        ImGui::TextUnformatted("General");
-        ImGui::Separator();
-        ImGui::Spacing();
-        ImGui::TextDisabled("These options take effect on the next application start.");
-        ImGui::Spacing();
+        ImGuiUtils::SectionHeader("General", "These options take effect on the next application start.");
 
         ImGui::Checkbox("Show debug log window on startup", &m_working.general.showDebugLogOnStartup);
         ImGui::Checkbox("Restore window layout on startup", &m_working.general.restoreWindowLayout);
     }
 
     void PreferencesDialog::renderSectionAppearance() {
-        ImGui::TextUnformatted("Appearance");
-        ImGui::Separator();
-        ImGui::Spacing();
-        ImGui::TextDisabled("Theme changes are applied immediately.");
-        ImGui::Spacing();
+        ImGuiUtils::SectionHeader("Appearance", "Theme changes are applied immediately.");
 
         int mode = static_cast<int>(m_working.appearance.themeMode);
         if (ImGui::RadioButton("Light",  &mode, static_cast<int>(app::ThemeMode::Light)))  { m_working.appearance.themeMode = app::ThemeMode::Light;  applyWorkingTheme(); }
@@ -132,11 +127,7 @@ namespace gui {
     }
 
     void PreferencesDialog::renderSectionDDE() {
-        ImGui::TextUnformatted("DDE Connection");
-        ImGui::Separator();
-        ImGui::Spacing();
-        ImGui::TextDisabled("New values apply to subsequent requests only.");
-        ImGui::Spacing();
+        ImGuiUtils::SectionHeader("DDE Connection", "New values apply to subsequent requests only.");
 
         if (ImGui::SliderInt("Connection timeout (ms)", &m_working.dde.connectionTimeoutMs, 1000, 30000, "%d", ImGuiSliderFlags_AlwaysClamp)) {
             applyWorkingDDE();
@@ -165,11 +156,7 @@ namespace gui {
     }
 
     void PreferencesDialog::renderSectionPlot() {
-        ImGui::TextUnformatted("Plot");
-        ImGui::Separator();
-        ImGui::Spacing();
-        ImGui::TextDisabled("Visual style for new plots.");
-        ImGui::Spacing();
+        ImGuiUtils::SectionHeader("Plot", "Visual style for new plots.");
 
         if (ImGui::Checkbox("Show grid by default", &m_working.plot.showGridByDefault)) {
             applyWorkingPlot();
@@ -185,11 +172,7 @@ namespace gui {
     }
 
     void PreferencesDialog::renderSectionUpdates() {
-        ImGui::TextUnformatted("Updates");
-        ImGui::Separator();
-        ImGui::Spacing();
-        ImGui::TextDisabled("Update checker settings. Channel changes take effect on next check.");
-        ImGui::Spacing();
+        ImGuiUtils::SectionHeader("Updates", "Update checker settings. Channel changes take effect on next check.");
 
         ImGui::Checkbox("Check for updates on startup", &m_working.updates.autoCheckOnStartup);
 
@@ -202,6 +185,22 @@ namespace gui {
         if (ImGui::RadioButton("Beta",   &channel, static_cast<int>(app::UpdateChannel::Beta))) {
             m_working.updates.channel = app::UpdateChannel::Beta;
         }
+    }
+
+    void PreferencesDialog::renderSectionFiles() {
+        ImGuiUtils::SectionHeader("Files", "Configuration file locations (read-only).");
+
+        auto pathRow = [](const char* label, const char* id, const char* path) {
+            ImGui::TextUnformatted(label);
+            ImGui::SetNextItemWidth(-1.0f);
+            ImGui::InputText(id, const_cast<char*>(path),
+                             static_cast<int>(std::strlen(path)), ImGuiInputTextFlags_ReadOnly);
+            ImGui::Spacing();
+        };
+
+        pathRow("ImGui Layout",         "##path_imgui",    app::getImguiIniPath());
+        pathRow("Window Layout",        "##path_window",   app::getWindowStatePath());
+        pathRow("Application Settings", "##path_settings", app::getSettingsJsonPath());
     }
 
     void PreferencesDialog::renderFooter() {

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -1,5 +1,7 @@
 #include "gui/popups/preferences_dialog.h"
 
+#include <algorithm>
+
 #include "app/config_path.h"
 #include "gui/constants.h"
 #include "gui/imgui_utils.h"
@@ -31,29 +33,57 @@ namespace gui {
 
         ImGuiUtils::CenterNextWindow();
 
-        ImGuiUtils::SetDpiScaledWindowConstraints(PREFERENCES_WINDOW_MIN_WIDTH, PREFERENCES_WINDOW_MIN_HEIGHT);
+        ImGuiUtils::SetDpiScaledWindowConstraints(PREFERENCES_WINDOW_MIN_SIZE.x, PREFERENCES_WINDOW_MIN_SIZE.y);
         ImGuiUtils::SetDpiScaledWindowSize(PREFERENCES_WINDOW_DEFAULT_SIZE);
 
-        if (!ImGui::BeginPopupModal(PREFERENCES_POPUP_NAME, &m_open,
-                                    ImGuiWindowFlags_NoCollapse)) {
+        if (!ImGui::BeginPopupModal(PREFERENCES_POPUP_NAME, &m_open, ImGuiWindowFlags_NoCollapse)) {
             return;
         }
 
-        const float footerH = ImGui::GetFrameHeightWithSpacing();
+        static const char* sidebarLabels[] = {
+            "General", "Appearance", "DDE Connection", "Plot", "Updates"
+        };
+        if (m_sidebarWidth <= 0.0f) {
+            float maxW = 0.0f;
+            for (auto* l : sidebarLabels)
+                maxW = std::max(maxW, ImGui::CalcTextSize(l).x);
+            m_sidebarWidth = maxW + ImGui::GetStyle().FramePadding.x * 2.0f + 20.0f;
+        }
+
+        const float footerH    = ImGui::GetFrameHeightWithSpacing();
+        const float availH     = ImGui::GetContentRegionAvail().y - footerH;
+        const float availW     = ImGui::GetContentRegionAvail().x;
+        const float splitterW  = 4.0f;
 
         ImGui::BeginChild("##prefs_sidebar",
-                          ImVec2(PREFERENCES_SIDEBAR_WIDTH, -footerH),
+                          ImVec2(m_sidebarWidth, availH),
                           ImGuiChildFlags_Borders);
         renderSidebar();
         ImGui::EndChild();
 
         ImGui::SameLine();
 
-        ImGui::BeginChild("##prefs_content", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
+        const ImVec2 sp = ImGui::GetCursorScreenPos();
+        ImGui::InvisibleButton("##prefs_splitter", ImVec2(splitterW, availH));
+        if (ImGui::IsItemActive()) {
+            m_sidebarWidth += ImGui::GetIO().MouseDelta.x;
+            m_sidebarWidth = std::clamp(m_sidebarWidth, 60.0f, availW - 100.0f - splitterW);
+        }
+        ImU32 col;
+        if (ImGui::IsItemActive())
+            col = ImGui::GetColorU32(ImGuiCol_SeparatorActive);
+        else if (ImGui::IsItemHovered())
+            col = ImGui::GetColorU32(ImGuiCol_Text, 0.4f);
+        else
+            col = ImGui::GetColorU32(ImGuiCol_Separator);
+        ImGui::GetWindowDrawList()->AddRectFilled(sp, ImVec2(sp.x + splitterW, sp.y + availH), col);
+
+        ImGui::SameLine();
+
+        ImGui::BeginChild("##prefs_content", ImVec2(0, availH), ImGuiChildFlags_Borders);
         renderContent();
         ImGui::EndChild();
 
-        ImGui::Separator();
         renderFooter();
 
         ImGui::EndPopup();
@@ -69,10 +99,6 @@ namespace gui {
             "Plot",
             "Updates",
         };
-
-        ImGui::TextDisabled("Sections");
-        ImGui::Separator();
-        ImGui::Spacing();
 
         for (int i = 0; i < static_cast<int>(Section::Count); ++i) {
             const bool selected = (static_cast<int>(m_section) == i);
@@ -191,7 +217,7 @@ namespace gui {
     }
 
     void PreferencesDialog::renderFooter() {
-        ImGui::Spacing();
+        // ImGui::Spacing();
 
         const float w = 110.0f;
         const float h = 32.0f;
@@ -221,7 +247,7 @@ namespace gui {
             ImGui::SetTooltip("Persist the current values to settings.json.");
         }
 
-        ImGui::Spacing();
+        // ImGui::Spacing();
     }
 
     void PreferencesDialog::renderResetConfirm() {

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -31,8 +31,8 @@ namespace gui {
 
         ImGuiUtils::CenterNextWindow();
 
-        ImGui::SetNextWindowSize(PREFERENCES_WINDOW_DEFAULT_SIZE, ImGuiCond_Once);
         ImGuiUtils::SetDpiScaledWindowConstraints(PREFERENCES_WINDOW_MIN_WIDTH, PREFERENCES_WINDOW_MIN_HEIGHT);
+        ImGuiUtils::SetDpiScaledWindowSize(PREFERENCES_WINDOW_DEFAULT_SIZE);
 
         if (!ImGui::BeginPopupModal(PREFERENCES_POPUP_NAME, &m_open,
                                     ImGuiWindowFlags_NoCollapse)) {
@@ -42,14 +42,14 @@ namespace gui {
         const float footerH = PREFERENCES_FOOTER_HEIGHT;
 
         ImGui::BeginChild("##prefs_sidebar",
-                          ImVec2(PREFERENCES_SIDEBAR_WIDTH, -footerH),
+                          ImVec2(PREFERENCES_SIDEBAR_WIDTH, -ImGuiUtils::DpiScale(footerH)),
                           ImGuiChildFlags_Borders);
         renderSidebar();
         ImGui::EndChild();
 
         ImGui::SameLine();
 
-        ImGui::BeginChild("##prefs_content", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
+        ImGui::BeginChild("##prefs_content", ImVec2(0, -ImGuiUtils::DpiScale(footerH)), ImGuiChildFlags_Borders);
         renderContent();
         ImGui::EndChild();
 

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -74,9 +74,9 @@ namespace gui {
 
         renderFooter();
 
-        ImGui::EndPopup();
-
         renderResetConfirm();
+
+        ImGui::EndPopup();
     }
 
     void PreferencesDialog::renderSidebar() {
@@ -243,13 +243,16 @@ namespace gui {
 
         if (ImGui::BeginPopupModal("Reset Preferences?", &m_confirmReset,
                                    ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::BeginChild("##reset_confirm_body",
+                              ImVec2(0, -ImGui::GetFrameHeightWithSpacing()),
+                              ImGuiChildFlags_Borders);
             ImGui::TextUnformatted("This will reset all preferences to their factory defaults.");
             ImGui::TextUnformatted("Unsaved changes will be lost.");
-            ImGui::Spacing();
-            ImGui::Separator();
-            ImGui::Spacing();
+            ImGui::EndChild();
 
             const float w = ImGuiUtils::DpiScale(120.0f);
+            const float totalW = w * 2.0f + ImGui::GetStyle().ItemSpacing.x;
+            ImGui::SetCursorPosX((ImGui::GetContentRegionAvail().x - totalW) * 0.5f);
             if (ImGui::Button("Cancel", ImVec2(w, 0))) {
                 m_confirmReset = false;
             }

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -205,19 +205,21 @@ namespace gui {
     }
 
     void PreferencesDialog::renderFooter() {
-        const float w = ImGuiUtils::DpiScale(120.0f);
+        float resetBtnW   = ImGuiUtils::DpiScale(120.0f);
+        float cancelBtnW  = ImGuiUtils::DpiScale(120.0f);
+        float saveBtnW    = ImGuiUtils::DpiScale(120.0f);
 
-        if (ImGui::Button("Reset", ImVec2(w, 0))) {
+        if (ImGui::Button("Reset", ImVec2(resetBtnW, 0))) {
             m_confirmReset = true;
         }
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Discard all changes and restore factory defaults.");
         }
 
-        const float groupWidth = 2.0f * w + ImGui::GetStyle().ItemSpacing.x;
+        const float groupWidth = cancelBtnW + saveBtnW + ImGui::GetStyle().ItemSpacing.x;
         ImGui::SameLine(ImGui::GetContentRegionAvail().x - groupWidth);
 
-        if (ImGui::Button("Cancel", ImVec2(w, 0))) {
+        if (ImGui::Button("Cancel", ImVec2(cancelBtnW, 0))) {
             onCancel();
         }
         if (ImGui::IsItemHovered()) {
@@ -226,7 +228,7 @@ namespace gui {
 
         ImGui::SameLine();
 
-        if (ImGui::Button("Save", ImVec2(w, 0))) {
+        if (ImGui::Button("Save", ImVec2(saveBtnW, 0))) {
             onSave();
         }
         if (ImGui::IsItemHovered()) {
@@ -250,14 +252,15 @@ namespace gui {
             ImGui::TextUnformatted("Unsaved changes will be lost.");
             ImGui::EndChild();
 
-            const float w = ImGuiUtils::DpiScale(120.0f);
-            const float totalW = w * 2.0f + ImGui::GetStyle().ItemSpacing.x;
+            float cancelBtnW = ImGuiUtils::DpiScale(120.0f);
+            float resetBtnW  = ImGuiUtils::DpiScale(120.0f);
+            const float totalW = cancelBtnW + resetBtnW + ImGui::GetStyle().ItemSpacing.x;
             ImGui::SetCursorPosX((ImGui::GetContentRegionAvail().x - totalW) * 0.5f);
-            if (ImGui::Button("Cancel", ImVec2(w, 0))) {
+            if (ImGui::Button("Cancel", ImVec2(cancelBtnW, 0))) {
                 m_confirmReset = false;
             }
             ImGui::SameLine();
-            if (ImGui::Button("Reset", ImVec2(w, 0))) {
+            if (ImGui::Button("Reset", ImVec2(resetBtnW, 0))) {
                 onReset();
                 m_confirmReset = false;
             }

--- a/src/gui/popups/preferences_dialog.h
+++ b/src/gui/popups/preferences_dialog.h
@@ -6,7 +6,7 @@ namespace gui {
 
     class SettingsManager;
 
-    /// Resizable modal dialog with 5 sections (General, Appearance, DDE, Plot, Updates)
+    /// Resizable modal dialog with 7 sections (General, Appearance, DDE, DDE Performance, Plot, Updates, Files)
     /// plus Save/Cancel/Reset actions. Uses a "working copy" of AppSettings for live preview:
     /// per-section apply methods on SettingsManager are called as soon as the user mutates
     /// a value, and the cancel button restores the last-saved snapshot.
@@ -23,13 +23,14 @@ namespace gui {
 
         private:
             enum class Section : int {
-                General     = 0,
-                Appearance  = 1,
-                DDE         = 2,
-                Plot        = 3,
-                Updates     = 4,
-                Files       = 5,
-                Count       = 6,
+                General       = 0,
+                Appearance    = 1,
+                DDE           = 2,
+                DDEPerformance = 3,
+                Plot          = 4,
+                Updates       = 5,
+                Files         = 6,
+                Count         = 7,
             };
 
             void renderSidebar();
@@ -40,6 +41,7 @@ namespace gui {
             void renderSectionGeneral();
             void renderSectionAppearance();
             void renderSectionDDE();
+            void renderSectionDDEPerformance();
             void renderSectionPlot();
             void renderSectionUpdates();
             void renderSectionFiles();

--- a/src/gui/popups/preferences_dialog.h
+++ b/src/gui/popups/preferences_dialog.h
@@ -28,7 +28,8 @@ namespace gui {
                 DDE         = 2,
                 Plot        = 3,
                 Updates     = 4,
-                Count       = 5,
+                Files       = 5,
+                Count       = 6,
             };
 
             void renderSidebar();
@@ -41,6 +42,7 @@ namespace gui {
             void renderSectionDDE();
             void renderSectionPlot();
             void renderSectionUpdates();
+            void renderSectionFiles();
 
             void applyWorkingTheme() const;
             void applyWorkingDDE() const;

--- a/src/gui/popups/preferences_dialog.h
+++ b/src/gui/popups/preferences_dialog.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "app/settings.h"
+
+namespace gui {
+
+    class SettingsManager;
+
+    /// Resizable modal dialog with 5 sections (General, Appearance, DDE, Plot, Updates)
+    /// plus Save/Cancel/Reset actions. Uses a "working copy" of AppSettings for live preview:
+    /// per-section apply methods on SettingsManager are called as soon as the user mutates
+    /// a value, and the cancel button restores the last-saved snapshot.
+    class PreferencesDialog {
+        public:
+            explicit PreferencesDialog(SettingsManager& settings) noexcept;
+
+            void open() noexcept;
+            void close() noexcept;
+            [[nodiscard]] bool isOpen() const noexcept { return m_open; }
+
+            // Must be called every frame from the main GUI loop while the dialog is open.
+            void render();
+
+        private:
+            enum class Section : int {
+                General     = 0,
+                Appearance  = 1,
+                DDE         = 2,
+                Plot        = 3,
+                Updates     = 4,
+                Count       = 5,
+            };
+
+            void renderSidebar();
+            void renderContent();
+            void renderFooter();
+            void renderResetConfirm();
+
+            void renderSectionGeneral();
+            void renderSectionAppearance();
+            void renderSectionDDE();
+            void renderSectionPlot();
+            void renderSectionUpdates();
+
+            void applyWorkingTheme() const;
+            void applyWorkingDDE() const;
+            void applyWorkingPlot() const;
+
+            void onSave();
+            void onCancel();
+            void onReset();
+
+            SettingsManager& m_settings;
+            app::AppSettings m_working;
+            app::AppSettings m_loaded;
+            Section m_section = Section::General;
+            bool m_open = false;
+            bool m_confirmReset = false;
+    };
+
+} // namespace gui

--- a/src/gui/popups/preferences_dialog.h
+++ b/src/gui/popups/preferences_dialog.h
@@ -54,6 +54,7 @@ namespace gui {
             app::AppSettings m_working;
             app::AppSettings m_loaded;
             Section m_section = Section::General;
+            float m_sidebarWidth = 0.0f;
             bool m_open = false;
             bool m_confirmReset = false;
     };

--- a/src/gui/popups/update_checker.cpp
+++ b/src/gui/popups/update_checker.cpp
@@ -1,4 +1,6 @@
 #include "gui/popups/update_checker.h"
+#include "gui/constants.h"
+#include "gui/imgui_utils.h"
 #include "gui/theme_manager.h"
 #include "lib/imgui/imgui.h"
 #include "version.h"
@@ -141,13 +143,16 @@ namespace gui {
     }
 
     void UpdateChecker::render() {
-        if (m_open && !ImGui::IsPopupOpen("Check for Updates")) {
-            ImGui::OpenPopup("Check for Updates");
+        if (m_open && !ImGui::IsPopupOpen(UPDATE_POPUP_NAME)) {
+            ImGui::OpenPopup(UPDATE_POPUP_NAME);
         }
 
-        ImGui::SetNextWindowSize(ImVec2(440.0f, 280.0f), ImGuiCond_FirstUseEver);
+        ImGuiUtils::CenterNextWindow();
 
-        if (!ImGui::BeginPopupModal("Check for Updates", &m_open, ImGuiWindowFlags_NoCollapse)) {
+        ImGui::SetNextWindowSize(UPDATE_POPUP_DEFAULT_SIZE, ImGuiCond_Once);
+        ImGuiUtils::SetDpiScaledWindowConstraints(UPDATE_POPUP_MIN_SIZE.x, UPDATE_POPUP_MIN_SIZE.y);
+
+        if (!ImGui::BeginPopupModal(UPDATE_POPUP_NAME, &m_open, ImGuiWindowFlags_NoCollapse)) {
             return;
         }
 
@@ -194,7 +199,7 @@ namespace gui {
         } else {
             if (!m_updateInfo.hasUpdate || !m_isCheckComplete) {
                 ImGui::SetCursorPosX((windowWidth - 180.0f) * 0.5f);
-                if (ImGui::Button("Check for Updates", ImVec2(180, 0))) {
+                if (ImGui::Button(UPDATE_POPUP_NAME, ImVec2(180, 0))) {
                     checkForUpdates();
                 }
             }

--- a/src/gui/popups/update_checker.cpp
+++ b/src/gui/popups/update_checker.cpp
@@ -149,8 +149,8 @@ namespace gui {
 
         ImGuiUtils::CenterNextWindow();
 
-        ImGui::SetNextWindowSize(UPDATE_POPUP_DEFAULT_SIZE, ImGuiCond_Once);
         ImGuiUtils::SetDpiScaledWindowConstraints(UPDATE_POPUP_MIN_SIZE.x, UPDATE_POPUP_MIN_SIZE.y);
+        ImGuiUtils::SetDpiScaledWindowSize(UPDATE_POPUP_DEFAULT_SIZE);
 
         if (!ImGui::BeginPopupModal(UPDATE_POPUP_NAME, &m_open, ImGuiWindowFlags_NoCollapse)) {
             return;
@@ -163,7 +163,7 @@ namespace gui {
 
         const float footerH = 70.0f;
 
-        ImGui::BeginChild("##update_body", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
+        ImGui::BeginChild("##update_body", ImVec2(0, -ImGuiUtils::DpiScale(footerH)), ImGuiChildFlags_Borders);
 
         ImGui::TextUnformatted(APP_NAME);
         ImGui::Separator();
@@ -198,15 +198,17 @@ namespace gui {
             ImGui::TextUnformatted("Checking for updates...");
         } else {
             if (!m_updateInfo.hasUpdate || !m_isCheckComplete) {
-                ImGui::SetCursorPosX((windowWidth - 180.0f) * 0.5f);
-                if (ImGui::Button(UPDATE_POPUP_NAME, ImVec2(180, 0))) {
+                float checkBtnW = ImGuiUtils::DpiScale(180.0f);
+                ImGui::SetCursorPosX((windowWidth - checkBtnW) * 0.5f);
+                if (ImGui::Button(UPDATE_POPUP_NAME, ImVec2(checkBtnW, 0))) {
                     checkForUpdates();
                 }
             }
 
             if (m_updateInfo.hasUpdate && m_isCheckComplete) {
-                ImGui::SetCursorPosX((windowWidth - 180.0f) * 0.5f);
-                if (ImGui::Button("Download Update", ImVec2(180, 0))) {
+                float dlBtnW = ImGuiUtils::DpiScale(180.0f);
+                ImGui::SetCursorPosX((windowWidth - dlBtnW) * 0.5f);
+                if (ImGui::Button("Download Update", ImVec2(dlBtnW, 0))) {
                     if (!m_updateInfo.downloadUrl.empty()) {
                         ShellExecuteA(nullptr, "open", m_updateInfo.downloadUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
                     }
@@ -214,9 +216,10 @@ namespace gui {
             }
         }
 
-        ImGui::SetCursorPosX((windowWidth - 120.0f) * 0.5f);
-        if (ImGui::Button("OK", ImVec2(120, 0))) {
-            ImGui::CloseCurrentPopup();
+        float okBtnW = ImGuiUtils::DpiScale(120.0f);
+        ImGui::SetCursorPosX((windowWidth - okBtnW) * 0.5f);
+        if (ImGui::Button("OK", ImVec2(okBtnW, 0))) {
+            close();
             m_isCheckComplete = false;
             m_updateInfo.hasUpdate = false;
             m_errorMessage.clear();

--- a/src/gui/popups/update_checker.cpp
+++ b/src/gui/popups/update_checker.cpp
@@ -188,7 +188,7 @@ namespace gui {
 
         float windowWidth = ImGui::GetWindowSize().x;
         float spacing = ImGui::GetStyle().ItemSpacing.x;
-        float okBtnW = ImGuiUtils::DpiScale(120.0f);
+        float okBtnW = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
 
         if (!m_isChecking) {
             float actionBtnW = ImGuiUtils::DpiScale(180.0f);

--- a/src/gui/popups/update_checker.cpp
+++ b/src/gui/popups/update_checker.cpp
@@ -1,4 +1,5 @@
 #include "gui/popups/update_checker.h"
+#include "gui/theme_manager.h"
 #include "lib/imgui/imgui.h"
 #include "version.h"
 #include "app/app.h"
@@ -138,6 +139,11 @@ namespace gui {
         }
 
         if (ImGui::BeginPopupModal("Check for Updates", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            if (!m_themeManager) {
+                ImGui::EndPopup();
+                return;
+            }
+
             ImGui::TextUnformatted(APP_NAME);
             ImGui::Separator();
             ImGui::Spacing();
@@ -150,13 +156,14 @@ namespace gui {
             if (!m_isCheckComplete) {
                 ImGui::TextUnformatted("Click the button below to check for updates.");
             } else {
+                const auto& sem = m_themeManager->semantic();
                 if (!m_errorMessage.empty()) {
-                    ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "Error: %s", m_errorMessage.c_str());
+                    ImGui::TextColored(sem.danger, "Error: %s", m_errorMessage.c_str());
                 } else if (m_updateInfo.hasUpdate) {
-                    ImGui::TextColored(ImVec4(0.0f, 0.8f, 0.0f, 1.0f), "New version available: %s", m_updateInfo.version.c_str());
+                    ImGui::TextColored(sem.success, "New version available: %s", m_updateInfo.version.c_str());
                     ImGui::TextUnformatted(std::format("Released: {}", m_updateInfo.releaseDate).c_str());
                 } else {
-                    ImGui::TextColored(ImVec4(0.6f, 0.6f, 0.6f, 1.0f), "Your software is up to date!");
+                    ImGui::TextColored(sem.muted, "Your software is up to date!");
                 }
             }
 

--- a/src/gui/popups/update_checker.cpp
+++ b/src/gui/popups/update_checker.cpp
@@ -161,13 +161,9 @@ namespace gui {
             return;
         }
 
-        const float footerH = 70.0f;
+        const float footerH = ImGui::GetFrameHeightWithSpacing();
 
-        ImGui::BeginChild("##update_body", ImVec2(0, -ImGuiUtils::DpiScale(footerH)), ImGuiChildFlags_Borders);
-
-        ImGui::TextUnformatted(APP_NAME);
-        ImGui::Separator();
-        ImGui::Spacing();
+        ImGui::BeginChild("##update_body", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
 
         std::string currentVer = std::format("Current version: {}", getCurrentVersion());
         ImGui::TextUnformatted(currentVer.c_str());
@@ -190,34 +186,31 @@ namespace gui {
 
         ImGui::EndChild();
 
-        ImGui::Separator();
-
         float windowWidth = ImGui::GetWindowSize().x;
+        float spacing = ImGui::GetStyle().ItemSpacing.x;
+        float okBtnW = ImGuiUtils::DpiScale(120.0f);
 
-        if (m_isChecking) {
-            ImGui::TextUnformatted("Checking for updates...");
-        } else {
+        if (!m_isChecking) {
+            float actionBtnW = ImGuiUtils::DpiScale(180.0f);
+            float totalW = actionBtnW + spacing + okBtnW;
+            ImGui::SetCursorPosX((windowWidth - totalW) * 0.5f);
+
             if (!m_updateInfo.hasUpdate || !m_isCheckComplete) {
-                float checkBtnW = ImGuiUtils::DpiScale(180.0f);
-                ImGui::SetCursorPosX((windowWidth - checkBtnW) * 0.5f);
-                if (ImGui::Button(UPDATE_POPUP_NAME, ImVec2(checkBtnW, 0))) {
+                if (ImGuiUtils::SpinnerButton(UPDATE_POPUP_NAME, m_isChecking, ImVec2(actionBtnW, 0))) {
                     checkForUpdates();
                 }
-            }
-
-            if (m_updateInfo.hasUpdate && m_isCheckComplete) {
-                float dlBtnW = ImGuiUtils::DpiScale(180.0f);
-                ImGui::SetCursorPosX((windowWidth - dlBtnW) * 0.5f);
-                if (ImGui::Button("Download Update", ImVec2(dlBtnW, 0))) {
+            } else if (m_updateInfo.hasUpdate && m_isCheckComplete) {
+                if (ImGuiUtils::SpinnerButton("Download Update", false, ImVec2(actionBtnW, 0))) {
                     if (!m_updateInfo.downloadUrl.empty()) {
                         ShellExecuteA(nullptr, "open", m_updateInfo.downloadUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
                     }
                 }
             }
+            ImGui::SameLine();
+        } else {
+            ImGui::SetCursorPosX((windowWidth - okBtnW) * 0.5f);
         }
 
-        float okBtnW = ImGuiUtils::DpiScale(120.0f);
-        ImGui::SetCursorPosX((windowWidth - okBtnW) * 0.5f);
         if (ImGui::Button("OK", ImVec2(okBtnW, 0))) {
             close();
             m_isCheckComplete = false;

--- a/src/gui/popups/update_checker.cpp
+++ b/src/gui/popups/update_checker.cpp
@@ -47,7 +47,11 @@ namespace gui {
             return false;
         }
 
-        HINTERNET hRequest = WinHttpOpenRequest(hConnect, L"GET", L"/repos/d3m37r4/ZemaxDDEClient/releases/latest", nullptr, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
+        const wchar_t* path = (m_channel == app::UpdateChannel::Beta)
+            ? L"/repos/d3m37r4/ZemaxDDEClient/releases"
+            : L"/repos/d3m37r4/ZemaxDDEClient/releases/latest";
+
+        HINTERNET hRequest = WinHttpOpenRequest(hConnect, L"GET", path, nullptr, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
         if (!hRequest) {
             WinHttpCloseHandle(hConnect);
             WinHttpCloseHandle(hSession);
@@ -79,9 +83,32 @@ namespace gui {
 
         try {
             auto json = nlohmann::json::parse(response);
-            m_updateInfo.version = json.value("tag_name", "");
-            m_updateInfo.releaseDate = json.value("published_at", "");
-            m_updateInfo.downloadUrl = json.value("html_url", "");
+
+            if (m_channel == app::UpdateChannel::Beta) {
+                // /releases returns an array; pick the first prerelease.
+                if (!json.is_array() || json.empty()) {
+                    m_errorMessage = "No releases found on Beta channel";
+                    return false;
+                }
+                const nlohmann::json* match = nullptr;
+                for (const auto& rel : json) {
+                    if (rel.is_object() && rel.value("prerelease", false)) {
+                        match = &rel;
+                        break;
+                    }
+                }
+                if (!match) {
+                    m_errorMessage = "No prerelease found on Beta channel";
+                    return false;
+                }
+                m_updateInfo.version     = match->value("tag_name", "");
+                m_updateInfo.releaseDate = match->value("published_at", "");
+                m_updateInfo.downloadUrl = match->value("html_url", "");
+            } else {
+                m_updateInfo.version     = json.value("tag_name", "");
+                m_updateInfo.releaseDate = json.value("published_at", "");
+                m_updateInfo.downloadUrl = json.value("html_url", "");
+            }
             return true;
         } catch (...) {
             m_errorMessage = "Failed to parse GitHub response";

--- a/src/gui/popups/update_checker.cpp
+++ b/src/gui/popups/update_checker.cpp
@@ -14,6 +14,14 @@ namespace gui {
     UpdateChecker::UpdateChecker() = default;
     UpdateChecker::~UpdateChecker() = default;
 
+    void UpdateChecker::open() noexcept {
+        m_open = true;
+    }
+
+    void UpdateChecker::close() noexcept {
+        m_open = false;
+    }
+
     std::string UpdateChecker::getCurrentVersion() const {
         return APP_FULL_VERSION;
     }
@@ -132,78 +140,83 @@ namespace gui {
         m_isCheckComplete = true;
     }
 
-    void UpdateChecker::renderPopup(bool& showPopup) {
-        if (showPopup) {
+    void UpdateChecker::render() {
+        if (m_open && !ImGui::IsPopupOpen("Check for Updates")) {
             ImGui::OpenPopup("Check for Updates");
-            showPopup = false;
         }
 
-        if (ImGui::BeginPopupModal("Check for Updates", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-            if (!m_themeManager) {
-                ImGui::EndPopup();
-                return;
-            }
+        ImGui::SetNextWindowSize(ImVec2(440.0f, 280.0f), ImGuiCond_FirstUseEver);
 
-            ImGui::TextUnformatted(APP_NAME);
-            ImGui::Separator();
-            ImGui::Spacing();
+        if (!ImGui::BeginPopupModal("Check for Updates", &m_open, ImGuiWindowFlags_NoCollapse)) {
+            return;
+        }
 
-            std::string currentVer = std::format("Current version: {}", getCurrentVersion());
-            ImGui::TextUnformatted(currentVer.c_str());
-
-            ImGui::Spacing();
-
-            if (!m_isCheckComplete) {
-                ImGui::TextUnformatted("Click the button below to check for updates.");
-            } else {
-                const auto& sem = m_themeManager->semantic();
-                if (!m_errorMessage.empty()) {
-                    ImGui::TextColored(sem.danger, "Error: %s", m_errorMessage.c_str());
-                } else if (m_updateInfo.hasUpdate) {
-                    ImGui::TextColored(sem.success, "New version available: %s", m_updateInfo.version.c_str());
-                    ImGui::TextUnformatted(std::format("Released: {}", m_updateInfo.releaseDate).c_str());
-                } else {
-                    ImGui::TextColored(sem.muted, "Your software is up to date!");
-                }
-            }
-
-            ImGui::Spacing();
-            ImGui::Separator();
-            ImGui::Spacing();
-
-            float windowWidth = ImGui::GetWindowSize().x;
-
-            if (m_isChecking) {
-                ImGui::TextUnformatted("Checking for updates...");
-            } else {
-                if (!m_updateInfo.hasUpdate || !m_isCheckComplete) {
-                    ImGui::SetCursorPosX((windowWidth - 180.0f) * 0.5f);
-                    if (ImGui::Button("Check for Updates", ImVec2(180, 0))) {
-                        checkForUpdates();
-                    }
-                }
-
-                if (m_updateInfo.hasUpdate && m_isCheckComplete) {
-                    ImGui::SetCursorPosX((windowWidth - 180.0f) * 0.5f);
-                    if (ImGui::Button("Download Update", ImVec2(180, 0))) {
-                        if (!m_updateInfo.downloadUrl.empty()) {
-                            ShellExecuteA(nullptr, "open", m_updateInfo.downloadUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
-                        }
-                    }
-                }
-            }
-
-            ImGui::Spacing();
-
-            ImGui::SetCursorPosX((windowWidth - 120.0f) * 0.5f);
-            if (ImGui::Button("OK", ImVec2(120, 0))) {
-                ImGui::CloseCurrentPopup();
-                m_isCheckComplete = false;
-                m_updateInfo.hasUpdate = false;
-                m_errorMessage.clear();
-            }
-
+        if (!m_themeManager) {
             ImGui::EndPopup();
+            return;
         }
+
+        const float footerH = 70.0f;
+
+        ImGui::BeginChild("##update_body", ImVec2(0, -footerH), ImGuiChildFlags_Borders);
+
+        ImGui::TextUnformatted(APP_NAME);
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        std::string currentVer = std::format("Current version: {}", getCurrentVersion());
+        ImGui::TextUnformatted(currentVer.c_str());
+
+        ImGui::Spacing();
+
+        if (!m_isCheckComplete) {
+            ImGui::TextUnformatted("Click the button below to check for updates.");
+        } else {
+            const auto& sem = m_themeManager->semantic();
+            if (!m_errorMessage.empty()) {
+                ImGui::TextColored(sem.danger, "Error: %s", m_errorMessage.c_str());
+            } else if (m_updateInfo.hasUpdate) {
+                ImGui::TextColored(sem.success, "New version available: %s", m_updateInfo.version.c_str());
+                ImGui::TextUnformatted(std::format("Released: {}", m_updateInfo.releaseDate).c_str());
+            } else {
+                ImGui::TextColored(sem.muted, "Your software is up to date!");
+            }
+        }
+
+        ImGui::EndChild();
+
+        ImGui::Separator();
+
+        float windowWidth = ImGui::GetWindowSize().x;
+
+        if (m_isChecking) {
+            ImGui::TextUnformatted("Checking for updates...");
+        } else {
+            if (!m_updateInfo.hasUpdate || !m_isCheckComplete) {
+                ImGui::SetCursorPosX((windowWidth - 180.0f) * 0.5f);
+                if (ImGui::Button("Check for Updates", ImVec2(180, 0))) {
+                    checkForUpdates();
+                }
+            }
+
+            if (m_updateInfo.hasUpdate && m_isCheckComplete) {
+                ImGui::SetCursorPosX((windowWidth - 180.0f) * 0.5f);
+                if (ImGui::Button("Download Update", ImVec2(180, 0))) {
+                    if (!m_updateInfo.downloadUrl.empty()) {
+                        ShellExecuteA(nullptr, "open", m_updateInfo.downloadUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+                    }
+                }
+            }
+        }
+
+        ImGui::SetCursorPosX((windowWidth - 120.0f) * 0.5f);
+        if (ImGui::Button("OK", ImVec2(120, 0))) {
+            ImGui::CloseCurrentPopup();
+            m_isCheckComplete = false;
+            m_updateInfo.hasUpdate = false;
+            m_errorMessage.clear();
+        }
+
+        ImGui::EndPopup();
     }
 }

--- a/src/gui/popups/update_checker.h
+++ b/src/gui/popups/update_checker.h
@@ -6,6 +6,8 @@
 #include "app/settings.h"
 
 namespace gui {
+    class ThemeManager;
+
     struct UpdateInfo {
         std::string version;
         std::string releaseDate;
@@ -29,6 +31,9 @@ namespace gui {
             [[nodiscard]] bool isAutoCheckEnabled() const noexcept { return m_autoCheckOnStartup; }
             [[nodiscard]] bool hasChecked() const noexcept { return m_isCheckComplete; }
 
+            /// Non-owning; bound by GuiManager after graphics.initialize().
+            void setThemeManager(const ThemeManager* themeManager) noexcept { m_themeManager = themeManager; }
+
         private:
             UpdateInfo m_updateInfo;
             bool m_isChecking{false};
@@ -36,6 +41,7 @@ namespace gui {
             std::string m_errorMessage;
             app::UpdateChannel m_channel{app::UpdateChannel::Stable};
             bool m_autoCheckOnStartup{false};
+            const ThemeManager* m_themeManager = nullptr;
 
             bool fetchLatestVersion();
             int compareVersions(const std::string& v1, const std::string& v2);

--- a/src/gui/popups/update_checker.h
+++ b/src/gui/popups/update_checker.h
@@ -19,8 +19,12 @@ namespace gui {
             UpdateChecker();
             ~UpdateChecker();
 
+            void open() noexcept;
+            void close() noexcept;
+            [[nodiscard]] bool isOpen() const noexcept { return m_open; }
+
+            void render();
             void checkForUpdates();
-            void renderPopup(bool& showPopup);
             UpdateInfo getUpdateInfo() const { return m_updateInfo; }
             std::string getCurrentVersion() const;
             std::string getCurrentBuildDate() const;
@@ -34,6 +38,7 @@ namespace gui {
             void setThemeManager(const ThemeManager* themeManager) noexcept { m_themeManager = themeManager; }
 
         private:
+            bool m_open = false;
             UpdateInfo m_updateInfo;
             bool m_isChecking{false};
             bool m_isCheckComplete{false};

--- a/src/gui/popups/update_checker.h
+++ b/src/gui/popups/update_checker.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <optional>
 
+#include "app/settings.h"
+
 namespace gui {
     struct UpdateInfo {
         std::string version;
@@ -22,11 +24,18 @@ namespace gui {
             std::string getCurrentVersion() const;
             std::string getCurrentBuildDate() const;
 
+            void setChannel(app::UpdateChannel c) noexcept { m_channel = c; }
+            void setAutoCheckOnStartup(bool b) noexcept { m_autoCheckOnStartup = b; }
+            [[nodiscard]] bool isAutoCheckEnabled() const noexcept { return m_autoCheckOnStartup; }
+            [[nodiscard]] bool hasChecked() const noexcept { return m_isCheckComplete; }
+
         private:
             UpdateInfo m_updateInfo;
             bool m_isChecking{false};
             bool m_isCheckComplete{false};
             std::string m_errorMessage;
+            app::UpdateChannel m_channel{app::UpdateChannel::Stable};
+            bool m_autoCheckOnStartup{false};
 
             bool fetchLatestVersion();
             int compareVersions(const std::string& v1, const std::string& v2);

--- a/src/gui/popups/update_checker.h
+++ b/src/gui/popups/update_checker.h
@@ -4,10 +4,9 @@
 #include <optional>
 
 #include "app/settings.h"
+#include "gui/theme_manager.h"
 
 namespace gui {
-    class ThemeManager;
-
     struct UpdateInfo {
         std::string version;
         std::string releaseDate;

--- a/src/gui/settings_manager.cpp
+++ b/src/gui/settings_manager.cpp
@@ -4,6 +4,7 @@
 #include "lib/implot/implot.h"
 
 #include "dde/dde_connection_manager.h"
+#include "gui/popups/update_checker.h"
 #include "gui/theme_manager.h"
 
 namespace gui {
@@ -34,7 +35,7 @@ namespace gui {
         applyTheme(settings.appearance);
         applyDDE(settings.dde);
         applyPlot(settings.plot);
-        // Phase 7+:  applyUpdates(settings.updates);
+        applyUpdates(settings.updates);
 
         m_current = settings;
     }
@@ -61,8 +62,9 @@ namespace gui {
     }
 
     void SettingsManager::applyUpdates(const app::UpdateSettings& updates) {
-        (void)updates;
-        // Implemented in Phase 6/7
+        if (!m_updateChecker) return;
+        m_updateChecker->setChannel(updates.channel);
+        m_updateChecker->setAutoCheckOnStartup(updates.autoCheckOnStartup);
     }
 
     bool SettingsManager::loadFromFile() {

--- a/src/gui/settings_manager.cpp
+++ b/src/gui/settings_manager.cpp
@@ -54,6 +54,16 @@ namespace gui {
         m_ddeConnectionManager->setDefaultRetries(dde.maxRetryCount);
         m_ddeConnectionManager->setMaxConnections(dde.maxConnections);
         m_ddeConnectionManager->setAutoReconnect(dde.autoReconnect);
+
+        m_ddeConnectionManager->setGetNameTimeoutMs(static_cast<DWORD>(dde.getNameTimeoutMs));
+        m_ddeConnectionManager->setGetFileTimeoutMs(static_cast<DWORD>(dde.getFileTimeoutMs));
+        m_ddeConnectionManager->setGetSystemTimeoutMs(static_cast<DWORD>(dde.getSystemTimeoutMs));
+        m_ddeConnectionManager->setGetFieldTimeoutMs(static_cast<DWORD>(dde.getFieldTimeoutMs));
+        m_ddeConnectionManager->setGetWaveTimeoutMs(static_cast<DWORD>(dde.getWaveTimeoutMs));
+        m_ddeConnectionManager->setGetSurfaceDataProfileTimeoutMs(static_cast<DWORD>(dde.getSurfaceDataProfileTimeoutMs));
+        m_ddeConnectionManager->setGetSagProfileTimeoutMs(static_cast<DWORD>(dde.getSagProfileTimeoutMs));
+        m_ddeConnectionManager->setGetSurfaceDataMapTimeoutMs(static_cast<DWORD>(dde.getSurfaceDataMapTimeoutMs));
+        m_ddeConnectionManager->setGetSagMapTimeoutMs(static_cast<DWORD>(dde.getSagMapTimeoutMs));
     }
 
     void SettingsManager::applyPlot(const app::PlotSettings& plot) {

--- a/src/gui/settings_manager.cpp
+++ b/src/gui/settings_manager.cpp
@@ -1,7 +1,10 @@
 #include "gui/settings_manager.h"
 
+#include <format>
+
 #include "app/config_path.h"
 #include "lib/implot/implot.h"
+#include "logger/logger.h"
 
 #include "dde/dde_connection_manager.h"
 #include "gui/popups/update_checker.h"
@@ -72,8 +75,20 @@ namespace gui {
         if (!path || !*path) return false;
 
         app::AppSettings loaded;
-        if (!loaded.loadFromFile(path)) {
-            // Missing file or parse error: keep defaults in m_current and apply them.
+        std::string err;
+        auto result = loaded.loadFromFileWithReason(path, err);
+        if (result != app::AppSettings::LoadResult::Success) {
+            if (m_logger && result != app::AppSettings::LoadResult::FileMissing) {
+                std::string_view kind = "unknown";
+                switch (result) {
+                    case app::AppSettings::LoadResult::ParseError:     kind = "JSON parse error"; break;
+                    case app::AppSettings::LoadResult::NotAnObject:    kind = "not a JSON object"; break;
+                    case app::AppSettings::LoadResult::UnknownVersion: kind = "unknown version"; break;
+                    default: break;
+                }
+                m_logger->addLog(std::format("[SETTINGS] Failed to load {} ({}): {}",
+                                             path, kind, err));
+            }
             m_current = loaded;
             apply(m_current);
             return false;

--- a/src/gui/settings_manager.cpp
+++ b/src/gui/settings_manager.cpp
@@ -1,0 +1,61 @@
+#include "gui/settings_manager.h"
+
+#include <windows.h>
+
+#include "dde/dde_connection_manager.h"
+#include "gui/theme_manager.h"
+
+namespace gui {
+
+    bool SettingsManager::detectSystemDarkMode() {
+        HKEY hKey = nullptr;
+        LONG regResult = RegOpenKeyExW(HKEY_CURRENT_USER,
+            L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+            0, KEY_READ, &hKey);
+        if (regResult != ERROR_SUCCESS) return false;
+
+        DWORD lightTheme = 1;
+        DWORD dataSize = sizeof(DWORD);
+        LONG queryResult = RegQueryValueExW(hKey, L"AppsUseLightTheme", nullptr, nullptr,
+            (LPBYTE)&lightTheme, &dataSize);
+        RegCloseKey(hKey);
+
+        if (queryResult != ERROR_SUCCESS) return false;
+        return lightTheme == 0;
+    }
+
+    void SettingsManager::bind(ThemeManager* themeManager, DDEConnectionManager* ddeConnectionManager) {
+        m_themeManager = themeManager;
+        m_ddeConnectionManager = ddeConnectionManager;
+    }
+
+    void SettingsManager::apply(const app::AppSettings& settings) {
+        applyTheme(settings.appearance);
+        // Phase 3+: applyDDE(settings.dde);
+        // Phase 4+: applyPlot(settings.plot);
+        // Phase 7+:  applyUpdates(settings.updates);
+
+        m_current = settings;
+    }
+
+    void SettingsManager::applyTheme(const app::AppearanceSettings& appearance) {
+        if (!m_themeManager) return;
+        m_themeManager->applyByMode(appearance.themeMode, detectSystemDarkMode());
+    }
+
+    void SettingsManager::applyDDE(const app::DDESettings& dde) {
+        (void)dde;
+        // Implemented in Phase 3
+    }
+
+    void SettingsManager::applyPlot(const app::PlotSettings& plot) {
+        (void)plot;
+        // Implemented in Phase 4
+    }
+
+    void SettingsManager::applyUpdates(const app::UpdateSettings& updates) {
+        (void)updates;
+        // Implemented in Phase 6/7
+    }
+
+} // namespace gui

--- a/src/gui/settings_manager.cpp
+++ b/src/gui/settings_manager.cpp
@@ -1,7 +1,6 @@
 #include "gui/settings_manager.h"
 
-#include <windows.h>
-
+#include "app/config_path.h"
 #include "lib/implot/implot.h"
 
 #include "dde/dde_connection_manager.h"
@@ -64,6 +63,29 @@ namespace gui {
     void SettingsManager::applyUpdates(const app::UpdateSettings& updates) {
         (void)updates;
         // Implemented in Phase 6/7
+    }
+
+    bool SettingsManager::loadFromFile() {
+        const char* path = app::getSettingsJsonPath();
+        if (!path || !*path) return false;
+
+        app::AppSettings loaded;
+        if (!loaded.loadFromFile(path)) {
+            // Missing file or parse error: keep defaults in m_current and apply them.
+            m_current = loaded;
+            apply(m_current);
+            return false;
+        }
+
+        m_current = loaded;
+        apply(m_current);
+        return true;
+    }
+
+    bool SettingsManager::saveToFile() const {
+        const char* path = app::getSettingsJsonPath();
+        if (!path || !*path) return false;
+        return m_current.saveToFile(path);
     }
 
 } // namespace gui

--- a/src/gui/settings_manager.cpp
+++ b/src/gui/settings_manager.cpp
@@ -7,6 +7,7 @@
 #include "logger/logger.h"
 
 #include "dde/dde_connection_manager.h"
+#include "gui/graphics_backend.h"
 #include "gui/popups/update_checker.h"
 #include "gui/theme_manager.h"
 
@@ -46,6 +47,11 @@ namespace gui {
     void SettingsManager::applyTheme(const app::AppearanceSettings& appearance) {
         if (!m_themeManager) return;
         m_themeManager->applyByMode(appearance.themeMode, detectSystemDarkMode());
+
+        // Sync native Win11 title bar with the applied theme.
+        if (m_graphicsBackend) {
+            m_graphicsBackend->updateTitleBarDarkMode(!m_themeManager->isLight());
+        }
     }
 
     void SettingsManager::applyDDE(const app::DDESettings& dde) {

--- a/src/gui/settings_manager.cpp
+++ b/src/gui/settings_manager.cpp
@@ -2,6 +2,8 @@
 
 #include <windows.h>
 
+#include "lib/implot/implot.h"
+
 #include "dde/dde_connection_manager.h"
 #include "gui/theme_manager.h"
 
@@ -32,7 +34,7 @@ namespace gui {
     void SettingsManager::apply(const app::AppSettings& settings) {
         applyTheme(settings.appearance);
         applyDDE(settings.dde);
-        // Phase 4+: applyPlot(settings.plot);
+        applyPlot(settings.plot);
         // Phase 7+:  applyUpdates(settings.updates);
 
         m_current = settings;
@@ -53,7 +55,10 @@ namespace gui {
 
     void SettingsManager::applyPlot(const app::PlotSettings& plot) {
         (void)plot;
-        // Implemented in Phase 4
+        // ImPlot 1.x does not expose LineWeight/MarkerSize as global ImPlotStyle fields;
+        // they are per-item properties on ImPlotSpec. Surface services read them via
+        // plotLineWeight()/plotMarkerSize() and pass to each PlotLine()/PlotScatter() call.
+        // showGridByDefault is consumed by surface services via showGridByDefault().
     }
 
     void SettingsManager::applyUpdates(const app::UpdateSettings& updates) {

--- a/src/gui/settings_manager.cpp
+++ b/src/gui/settings_manager.cpp
@@ -31,7 +31,7 @@ namespace gui {
 
     void SettingsManager::apply(const app::AppSettings& settings) {
         applyTheme(settings.appearance);
-        // Phase 3+: applyDDE(settings.dde);
+        applyDDE(settings.dde);
         // Phase 4+: applyPlot(settings.plot);
         // Phase 7+:  applyUpdates(settings.updates);
 
@@ -44,8 +44,11 @@ namespace gui {
     }
 
     void SettingsManager::applyDDE(const app::DDESettings& dde) {
-        (void)dde;
-        // Implemented in Phase 3
+        if (!m_ddeConnectionManager) return;
+        m_ddeConnectionManager->setDefaultTimeoutMs(static_cast<DWORD>(dde.connectionTimeoutMs));
+        m_ddeConnectionManager->setDefaultRetries(dde.maxRetryCount);
+        m_ddeConnectionManager->setMaxConnections(dde.maxConnections);
+        m_ddeConnectionManager->setAutoReconnect(dde.autoReconnect);
     }
 
     void SettingsManager::applyPlot(const app::PlotSettings& plot) {

--- a/src/gui/settings_manager.h
+++ b/src/gui/settings_manager.h
@@ -4,6 +4,7 @@
 #include "gui/theme_manager.h"
 
 class DDEConnectionManager;
+class Logger;
 
 namespace gui {
     class UpdateChecker;
@@ -26,6 +27,7 @@ namespace gui {
             // Non-owning bindings; called once during GuiManager wiring.
             void bind(ThemeManager* themeManager, DDEConnectionManager* ddeConnectionManager);
             void setUpdateChecker(UpdateChecker* updateChecker) noexcept { m_updateChecker = updateChecker; }
+            void setLogger(Logger* logger) noexcept { m_logger = logger; }
 
             // Applies every section in @p settings. Requires bind() to have been called
             // for the consumers used by the settings being applied.
@@ -68,6 +70,7 @@ namespace gui {
             ThemeManager* m_themeManager = nullptr;
             DDEConnectionManager* m_ddeConnectionManager = nullptr;
             UpdateChecker* m_updateChecker = nullptr;
+            Logger* m_logger = nullptr;
     };
 
 } // namespace gui

--- a/src/gui/settings_manager.h
+++ b/src/gui/settings_manager.h
@@ -6,6 +6,7 @@
 class DDEConnectionManager;
 
 namespace gui {
+    class UpdateChecker;
 
     /// Centralized bridge between persistent AppSettings and runtime subsystems.
     /// apply() pushes a complete settings snapshot to all bound consumers;
@@ -24,6 +25,7 @@ namespace gui {
 
             // Non-owning bindings; called once during GuiManager wiring.
             void bind(ThemeManager* themeManager, DDEConnectionManager* ddeConnectionManager);
+            void setUpdateChecker(UpdateChecker* updateChecker) noexcept { m_updateChecker = updateChecker; }
 
             // Applies every section in @p settings. Requires bind() to have been called
             // for the consumers used by the settings being applied.
@@ -65,6 +67,7 @@ namespace gui {
             app::AppSettings m_current;
             ThemeManager* m_themeManager = nullptr;
             DDEConnectionManager* m_ddeConnectionManager = nullptr;
+            UpdateChecker* m_updateChecker = nullptr;
     };
 
 } // namespace gui

--- a/src/gui/settings_manager.h
+++ b/src/gui/settings_manager.h
@@ -34,6 +34,23 @@ namespace gui {
             void applyTheme(const app::AppearanceSettings& appearance);
             void applyDDE(const app::DDESettings& dde);
             void applyPlot(const app::PlotSettings& plot);
+
+            /// Returns the cached 'show grid by default' flag set by applyPlot().
+            /// Surface profile and surface map services read this when configuring
+            /// ImPlot::SetupAxes to honor the user's preference on new plots.
+            [[nodiscard]] bool showGridByDefault() const noexcept { return m_current.plot.showGridByDefault; }
+
+            /// Returns the cached line weight (pixels) for ImPlot plot lines.
+            /// In ImPlot 1.x LineWeight is a per-item ImPlotSpec property, not a
+            /// global style field, so surface services must pass this via ImPlotSpec
+            /// to each PlotLine()/PlotScatter() call.
+            [[nodiscard]] float plotLineWeight() const noexcept { return m_current.plot.lineWeight; }
+
+            /// Returns the cached marker size (pixels) for ImPlot plot markers.
+            /// Same caveat as plotLineWeight(): only takes effect where the plot item
+            /// uses a marker (PlotScatter/PlotLine with Marker set in ImPlotSpec).
+            [[nodiscard]] float plotMarkerSize() const noexcept { return m_current.plot.markerSize; }
+
             void applyUpdates(const app::UpdateSettings& updates);
 
             [[nodiscard]] const app::AppSettings& current() const noexcept { return m_current; }

--- a/src/gui/settings_manager.h
+++ b/src/gui/settings_manager.h
@@ -7,6 +7,7 @@ class DDEConnectionManager;
 class Logger;
 
 namespace gui {
+    class GraphicsBackend;
     class UpdateChecker;
 
     /// Centralized bridge between persistent AppSettings and runtime subsystems.
@@ -26,6 +27,7 @@ namespace gui {
 
             // Non-owning bindings; called once during GuiManager wiring.
             void bind(ThemeManager* themeManager, DDEConnectionManager* ddeConnectionManager);
+            void setGraphicsBackend(GraphicsBackend* gb) noexcept { m_graphicsBackend = gb; }
             void setUpdateChecker(UpdateChecker* updateChecker) noexcept { m_updateChecker = updateChecker; }
             void setLogger(Logger* logger) noexcept { m_logger = logger; }
 
@@ -68,6 +70,7 @@ namespace gui {
         private:
             app::AppSettings m_current;
             ThemeManager* m_themeManager = nullptr;
+            GraphicsBackend* m_graphicsBackend = nullptr;
             DDEConnectionManager* m_ddeConnectionManager = nullptr;
             UpdateChecker* m_updateChecker = nullptr;
             Logger* m_logger = nullptr;

--- a/src/gui/settings_manager.h
+++ b/src/gui/settings_manager.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "app/settings.h"
+#include "gui/theme_manager.h"
+
+class DDEConnectionManager;
+
+namespace gui {
+
+    /// Centralized bridge between persistent AppSettings and runtime subsystems.
+    /// apply() pushes a complete settings snapshot to all bound consumers;
+    /// per-section methods (applyTheme / applyDDE / applyPlot / applyUpdates) exist
+    /// for the Preferences dialog's live preview.
+    class SettingsManager {
+        public:
+            SettingsManager() = default;
+            ~SettingsManager() = default;
+
+            SettingsManager(const SettingsManager&) = delete;
+            SettingsManager& operator=(const SettingsManager&) = delete;
+
+            // Reads the system theme from the Windows registry. Used by ThemeMode::System.
+            static bool detectSystemDarkMode();
+
+            // Non-owning bindings; called once during GuiManager wiring.
+            void bind(ThemeManager* themeManager, DDEConnectionManager* ddeConnectionManager);
+
+            // Applies every section in @p settings. Requires bind() to have been called
+            // for the consumers used by the settings being applied.
+            void apply(const app::AppSettings& settings);
+
+            // Per-section apply methods. Safe to call individually for live preview.
+            // Each method uses detectSystemDarkMode() internally for theme decisions.
+            void applyTheme(const app::AppearanceSettings& appearance);
+            void applyDDE(const app::DDESettings& dde);
+            void applyPlot(const app::PlotSettings& plot);
+            void applyUpdates(const app::UpdateSettings& updates);
+
+            [[nodiscard]] const app::AppSettings& current() const noexcept { return m_current; }
+
+        private:
+            app::AppSettings m_current;
+            ThemeManager* m_themeManager = nullptr;
+            DDEConnectionManager* m_ddeConnectionManager = nullptr;
+    };
+
+} // namespace gui

--- a/src/gui/settings_manager.h
+++ b/src/gui/settings_manager.h
@@ -29,6 +29,12 @@ namespace gui {
             // for the consumers used by the settings being applied.
             void apply(const app::AppSettings& settings);
 
+            // File I/O for persistence. loadFromFile() reads settings.json, replaces
+            // m_current and pushes the values to all bound subsystems. saveToFile()
+            // writes m_current to settings.json. Both return false on I/O errors.
+            bool loadFromFile();
+            bool saveToFile() const;
+
             // Per-section apply methods. Safe to call individually for live preview.
             // Each method uses detectSystemDarkMode() internally for theme decisions.
             void applyTheme(const app::AppearanceSettings& appearance);

--- a/src/gui/surface_irregularity_map_service.cpp
+++ b/src/gui/surface_irregularity_map_service.cpp
@@ -31,6 +31,12 @@ namespace gui {
     // --- Profile calculation (via SurfaceProfileCalculator) ---
 
     void SurfaceIrregularityMapService::startCalculation(int surface, int sampling, double angle, TaskSource source) {
+        // Set per-map timeout overrides from DDEConnectionManager.
+        if (m_connectionManager) {
+            m_calculator.setSurfaceDataTimeoutMs(m_connectionManager->getGetSurfaceDataMapTimeoutMs());
+            m_calculator.setSagTimeoutMs(m_connectionManager->getGetSagMapTimeoutMs());
+        }
+
         m_calculator.onComplete = [this]() {
             m_nominalSurfaceData = m_calculator.getResult();
             if (m_nominalSurfaceData.isValid()) {
@@ -56,6 +62,12 @@ namespace gui {
         if (!client) {
             m_logger.addLog("[IrregularityMapService] No active DDE connection");
             return;
+        }
+
+        // Set per-map timeout overrides from DDEConnectionManager.
+        if (m_connectionManager) {
+            m_calculator.setSurfaceDataTimeoutMs(m_connectionManager->getGetSurfaceDataMapTimeoutMs());
+            m_calculator.setSagTimeoutMs(m_connectionManager->getGetSagMapTimeoutMs());
         }
 
         if (angleStepDeg <= 0.0 || angleStepDeg >= 180.0) {

--- a/src/gui/surface_irregularity_map_service.h
+++ b/src/gui/surface_irregularity_map_service.h
@@ -12,6 +12,7 @@
 #include "lib/imgui/imgui.h"
 
 class Logger;
+namespace gui { class SettingsManager; }
 
 namespace ZemaxDDE {
     class OperationMonitor;
@@ -41,6 +42,8 @@ namespace gui {
             SurfaceIrregularityMapService(DDEConnectionManager* connectionManager, Logger& logger);
 
             void setUiOperationMonitor(UiOperationMonitor* monitor);
+
+            void setSettingsManager(SettingsManager* mgr) noexcept { m_settingsManager = mgr; }
 
             // Profile calculation (via SurfaceProfileCalculator)
             void startCalculation(int surface, int sampling, double angle, TaskSource source);
@@ -82,6 +85,7 @@ namespace gui {
             DDEConnectionManager* m_connectionManager;
             Logger& m_logger;
             UiOperationMonitor* m_uiOpMonitor{nullptr};
+            SettingsManager* m_settingsManager = nullptr;
             SurfaceProfileCalculator m_calculator;
 
             std::vector<ZemaxDDE::SurfaceData> m_profiles;

--- a/src/gui/surface_profile_calculator.cpp
+++ b/src/gui/surface_profile_calculator.cpp
@@ -60,6 +60,9 @@ namespace gui {
         m_logger.addLog(std::format("[ProfileCalculator] Starting: surface {} ({} pts, {}°)",
             surface, sampling, angle));
 
+        DWORD surfaceDataTimeout = m_surfaceDataTimeoutMsOverride > 0
+            ? m_surfaceDataTimeoutMsOverride : client->getDefaultTimeoutMs();
+
         client->submitRequest(
             std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::TYPE_NAME),
             [this](const std::string& result) {
@@ -68,7 +71,7 @@ namespace gui {
             [this](const std::string& error) {
                 onError(std::format("GetSurfaceData(TYPE_NAME): {}", error));
             },
-            2000, 1, "ProfileCalculator");
+            surfaceDataTimeout, 1, "ProfileCalculator");
 
         client->submitRequest(
             std::format("GetSurfaceData,{},{}", surface, ZemaxDDE::SurfaceDataCode::SEMI_DIAMETER),
@@ -78,7 +81,7 @@ namespace gui {
             [this](const std::string& error) {
                 onError(std::format("GetSurfaceData(SEMI_DIAMETER): {}", error));
             },
-            2000, 1, "ProfileCalculator");
+            surfaceDataTimeout, 1, "ProfileCalculator");
     }
 
     void SurfaceProfileCalculator::cancel() {
@@ -168,6 +171,9 @@ namespace gui {
             return;
         }
 
+        DWORD sagTimeout = m_sagTimeoutMsOverride > 0
+            ? m_sagTimeoutMsOverride : client->getDefaultTimeoutMs();
+
         client->submitRequest(
             std::format("GetSag,{},{},{}", m_targetSurface, x, y),
             [this](const std::string& result) {
@@ -180,7 +186,7 @@ namespace gui {
                     onError(std::format("GetSag failed: {}", error));
                 }
             },
-            1000, 1, "ProfileCalculator");
+            sagTimeout, 1, "ProfileCalculator");
     }
 
     void SurfaceProfileCalculator::onSagDataReceived(const std::string& buffer) {

--- a/src/gui/surface_profile_calculator.h
+++ b/src/gui/surface_profile_calculator.h
@@ -17,6 +17,11 @@ namespace gui {
 
             void setMonitor(UiOperationMonitor* monitor) { m_uiOpMonitor = monitor; }
 
+            /// Per-calculator timeout overrides. When set (>0), used instead of
+            /// the global per-request timeout from ZemaxDDEClient.
+            void setSurfaceDataTimeoutMs(DWORD ms) { m_surfaceDataTimeoutMsOverride = ms; }
+            void setSagTimeoutMs(DWORD ms) { m_sagTimeoutMsOverride = ms; }
+
             void startCalculation(int surface, int sampling, double angle, TaskSource source, const std::string& label = "");
             void cancel();
             void reset() { m_state = State::Idle; m_error.clear(); m_result = {}; m_taskId = 0; m_skippedPoints = 0; }
@@ -58,5 +63,8 @@ namespace gui {
             std::chrono::steady_clock::time_point m_calcStartTime;
 
             ZemaxDDE::SurfaceData m_result;
+
+            DWORD m_surfaceDataTimeoutMsOverride = 0;
+            DWORD m_sagTimeoutMsOverride = 0;
     };
 }

--- a/src/gui/surface_profile_service.cpp
+++ b/src/gui/surface_profile_service.cpp
@@ -53,6 +53,12 @@ namespace gui {
     void SurfaceProfileService::startCalculation(int surface, int sampling, double angle, TaskSource source) {
         m_taskSource = source;
 
+        // Set per-profile timeout overrides from DDEConnectionManager.
+        if (m_connectionManager) {
+            m_calculator.setSurfaceDataTimeoutMs(m_connectionManager->getGetSurfaceDataProfileTimeoutMs());
+            m_calculator.setSagTimeoutMs(m_connectionManager->getGetSagProfileTimeoutMs());
+        }
+
         m_calculator.onComplete = [this]() { onCalculatorComplete(); };
         m_calculator.onFailed = [this]() { onCalculatorFailed(); };
 

--- a/src/gui/surface_profile_service.cpp
+++ b/src/gui/surface_profile_service.cpp
@@ -7,6 +7,7 @@
 #include "lib/imgui/imgui.h"
 #include "lib/implot/implot.h"
 
+#include "gui/settings_manager.h"
 #include "gui/surface_profile_service.h"
 #include "gui/gui.h"
 #include "logger/logger.h"
@@ -21,6 +22,17 @@ namespace gui {
 
     void SurfaceProfileService::setUiOperationMonitor(UiOperationMonitor* monitor) {
         m_calculator.setMonitor(monitor);
+    }
+
+    namespace {
+        ImPlotAxisFlags axisFlagsForGrid(bool showGrid) {
+            return showGrid ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines;
+        }
+
+        ImPlotSpec buildLineSpec(float lineWeight, float markerSize) {
+            return ImPlotSpec(ImPlotProp_LineWeight, lineWeight,
+                              ImPlotProp_MarkerSize, markerSize);
+        }
     }
 
     std::pair<std::vector<double>, std::vector<double>> extractSagCoordinates(const ZemaxDDE::SurfaceData& surface) {
@@ -105,13 +117,18 @@ namespace gui {
         if (surface.sagDataPoints.empty()) return;
 
         auto [x_vals, y_vals] = extractSagCoordinates(surface);
+        const bool showGrid = m_settingsManager ? m_settingsManager->showGridByDefault() : true;
+        const float lineWeight = m_settingsManager ? m_settingsManager->plotLineWeight() : 1.0f;
+        const float markerSize = m_settingsManager ? m_settingsManager->plotMarkerSize() : 4.0f;
 
         if (ImPlot::BeginPlot(plotLabel, size)) {
             std::string unitName = getUnitString(surface.units);
             ImPlot::SetupAxes(std::format("X ({})", unitName).c_str(),
-                              std::format("Sag ({})", unitName).c_str());
+                              std::format("Sag ({})", unitName).c_str(),
+                              axisFlagsForGrid(showGrid), axisFlagsForGrid(showGrid));
             ImPlot::SetupLegend(ImPlotLocation_NorthEast, ImPlotLegendFlags_Outside);
-            ImPlot::PlotLine("Surface", x_vals.data(), y_vals.data(), x_vals.size());
+            ImPlot::PlotLine("Surface", x_vals.data(), y_vals.data(), x_vals.size(),
+                             buildLineSpec(lineWeight, markerSize));
             ImPlot::EndPlot();
         }
     }
@@ -119,12 +136,18 @@ namespace gui {
     void SurfaceProfileService::renderProfileComparisonPlot(const char* plotLabel, const ZemaxDDE::SurfaceData& nominal, const ZemaxDDE::SurfaceData& toleranced, const ImVec2& size) {
         auto [x_nom, y_nom] = extractSagCoordinates(nominal);
         auto [x_tol, y_tol] = extractSagCoordinates(toleranced);
+        const bool showGrid = m_settingsManager ? m_settingsManager->showGridByDefault() : true;
+        const float lineWeight = m_settingsManager ? m_settingsManager->plotLineWeight() : 1.0f;
+        const float markerSize = m_settingsManager ? m_settingsManager->plotMarkerSize() : 4.0f;
 
         if (ImPlot::BeginPlot(plotLabel, size)) {
-            ImPlot::SetupAxes("X (mm)", "Sag (mm)");
+            ImPlot::SetupAxes("X (mm)", "Sag (mm)",
+                              axisFlagsForGrid(showGrid), axisFlagsForGrid(showGrid));
             ImPlot::SetupLegend(ImPlotLocation_NorthEast, ImPlotLegendFlags_Outside);
-            ImPlot::PlotLine("Nominal", x_nom.data(), y_nom.data(), x_nom.size());
-            ImPlot::PlotLine("Toleranced", x_tol.data(), y_tol.data(), x_tol.size());
+            ImPlot::PlotLine("Nominal", x_nom.data(), y_nom.data(), x_nom.size(),
+                             buildLineSpec(lineWeight, markerSize));
+            ImPlot::PlotLine("Toleranced", x_tol.data(), y_tol.data(), x_tol.size(),
+                             buildLineSpec(lineWeight, markerSize));
             ImPlot::EndPlot();
         }
     }
@@ -140,10 +163,16 @@ namespace gui {
         for (size_t i = 0; i < x_nom.size(); ++i)
             y_dev.push_back(y_tol[i] - y_nom[i]);
 
+        const bool showGrid = m_settingsManager ? m_settingsManager->showGridByDefault() : true;
+        const float lineWeight = m_settingsManager ? m_settingsManager->plotLineWeight() : 1.0f;
+        const float markerSize = m_settingsManager ? m_settingsManager->plotMarkerSize() : 4.0f;
+
         if (ImPlot::BeginPlot(plotLabel, size)) {
-            ImPlot::SetupAxes("X (mm)", "ΔSag (mm)");
+            ImPlot::SetupAxes("X (mm)", "ΔSag (mm)",
+                              axisFlagsForGrid(showGrid), axisFlagsForGrid(showGrid));
             ImPlot::SetupLegend(ImPlotLocation_NorthEast, ImPlotLegendFlags_Outside);
-            ImPlot::PlotLine("Deviation", x_nom.data(), y_dev.data(), x_nom.size());
+            ImPlot::PlotLine("Deviation", x_nom.data(), y_dev.data(), x_nom.size(),
+                             buildLineSpec(lineWeight, markerSize));
             ImPlot::EndPlot();
         }
     }

--- a/src/gui/surface_profile_service.h
+++ b/src/gui/surface_profile_service.h
@@ -11,6 +11,7 @@
 #include "gui/surface_profile_calculator.h"
 
 class Logger;
+namespace gui { class SettingsManager; }
 
 namespace gui {
 
@@ -33,6 +34,11 @@ namespace gui {
             SurfaceProfileService(DDEConnectionManager* connectionManager, Logger& logger);
 
             void setUiOperationMonitor(UiOperationMonitor* monitor);
+
+            /// Non-owning binding; called by GuiManager after SettingsManager construction.
+            /// Used to read showGridByDefault() when configuring SetupAxes.
+            void setSettingsManager(SettingsManager* mgr) noexcept { m_settingsManager = mgr; }
+
             void startCalculation(int surface, int sampling, double angle, TaskSource source = TaskSource::None);
             void saveCrossSectionToFile(const ZemaxDDE::SurfaceData& surface);
 
@@ -62,6 +68,7 @@ namespace gui {
 
             DDEConnectionManager* m_connectionManager;
             Logger& m_logger;
+            SettingsManager* m_settingsManager = nullptr;
             SurfaceProfileCalculator m_calculator;
             TaskSource m_taskSource{TaskSource::None};
     };

--- a/src/gui/theme_manager.cpp
+++ b/src/gui/theme_manager.cpp
@@ -1,0 +1,340 @@
+#include "gui/theme_manager.h"
+
+// ---------------------------------------------------------------
+//  Helper: create an ImVec4 from 0..255 RGBA bytes
+// ---------------------------------------------------------------
+static ImVec4 col(int r, int g, int b, int a = 255) {
+    return ImVec4(r / 255.0f, g / 255.0f, b / 255.0f, a / 255.0f);
+}
+
+// ===============================================================
+//  GitHub-Inspired Light
+// ===============================================================
+ThemeData ThemeData::CreateWin11Light() {
+    ThemeData t;
+    t.name    = "Windows 11 Light";
+    t.isLight = true;
+    t.clearColor = col(255, 255, 255);
+
+    ImVec4* c = t.imguiColors;
+
+    c[ImGuiCol_Text]                 = col(31,  35,  40);   // #1f2328
+    c[ImGuiCol_TextDisabled]         = col(101, 109, 118);  // #656d76
+    c[ImGuiCol_WindowBg]             = col(255, 255, 255);  // #ffffff
+    c[ImGuiCol_ChildBg]              = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_PopupBg]              = col(255, 255, 255);  // #ffffff
+    c[ImGuiCol_Border]               = col(208, 215, 222);  // #d0d7de
+    c[ImGuiCol_BorderShadow]         = ImVec4(0, 0, 0, 0);
+    c[ImGuiCol_FrameBg]              = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_FrameBgHovered]       = col(232, 236, 240);  // #e8ecf0
+    c[ImGuiCol_FrameBgActive]        = col(208, 215, 222);  // #d0d7de
+    c[ImGuiCol_TitleBg]              = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_TitleBgActive]        = col(255, 255, 255);  // #ffffff
+    c[ImGuiCol_TitleBgCollapsed]     = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_MenuBarBg]            = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_ScrollbarBg]          = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_ScrollbarGrab]        = col(175, 184, 193);  // #afb8c1
+    c[ImGuiCol_ScrollbarGrabHovered] = col(143, 154, 165);  // #8f9aa5
+    c[ImGuiCol_ScrollbarGrabActive]  = col(118, 130, 142);  // #76828e
+    c[ImGuiCol_CheckMark]            = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_SliderGrab]           = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_SliderGrabActive]     = col(8,   82,  173);  // #0852ad
+    c[ImGuiCol_Button]               = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_ButtonHovered]        = col(221, 244, 255);  // #ddf4ff
+    c[ImGuiCol_ButtonActive]         = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_Header]               = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_HeaderHovered]        = col(221, 244, 255);  // #ddf4ff
+    c[ImGuiCol_HeaderActive]         = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_Separator]            = col(208, 215, 222);  // #d0d7de
+    c[ImGuiCol_SeparatorHovered]     = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_SeparatorActive]      = col(8,   82,  173);  // #0852ad
+    c[ImGuiCol_ResizeGrip]           = col(208, 215, 222);  // #d0d7de
+    c[ImGuiCol_ResizeGripHovered]    = col(143, 154, 165);  // #8f9aa5
+    c[ImGuiCol_ResizeGripActive]     = col(118, 130, 142);  // #76828e
+    c[ImGuiCol_InputTextCursor]      = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_TabHovered]           = col(232, 236, 240);  // #e8ecf0
+    c[ImGuiCol_Tab]                  = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_TabSelected]          = col(255, 255, 255);  // #ffffff
+    c[ImGuiCol_TabSelectedOverline]  = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_TabDimmed]            = col(232, 236, 240);  // #e8ecf0
+    c[ImGuiCol_TabDimmedSelected]    = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_TabDimmedSelectedOverline] = col(101, 109, 118); // #656d76
+    c[ImGuiCol_DockingPreview]       = col(9,   105, 218, 90);
+    c[ImGuiCol_DockingEmptyBg]       = col(208, 215, 222);  // #d0d7de
+    c[ImGuiCol_PlotLines]            = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_PlotLinesHovered]     = col(8,   82,  173);  // #0852ad
+    c[ImGuiCol_PlotHistogram]        = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_PlotHistogramHovered] = col(8,   82,  173);  // #0852ad
+    c[ImGuiCol_TableHeaderBg]        = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_TableBorderStrong]    = col(208, 215, 222);  // #d0d7de
+    c[ImGuiCol_TableBorderLight]     = col(232, 236, 240);  // #e8ecf0
+    c[ImGuiCol_TableRowBg]           = col(255, 255, 255);  // #ffffff
+    c[ImGuiCol_TableRowBgAlt]        = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_TextLink]             = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_TextSelectedBg]       = col(9,   105, 218, 64);
+    c[ImGuiCol_TreeLines]            = col(208, 215, 222);  // #d0d7de
+    c[ImGuiCol_DragDropTarget]       = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_DragDropTargetBg]     = col(9,   105, 218, 32);
+    c[ImGuiCol_UnsavedMarker]        = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_NavCursor]            = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_NavWindowingHighlight]= col(255, 255, 255);  // #ffffff
+    c[ImGuiCol_NavWindowingDimBg]    = col(0,   0,   0,   89);
+    c[ImGuiCol_ModalWindowDimBg]     = col(0,   0,   0,   115);
+
+    // -- ImPlot -------------------------------------------------
+    ImVec4* pc = t.implotColors;
+    pc[ImPlotCol_FrameBg]       = t.imguiColors[ImGuiCol_FrameBg];
+    pc[ImPlotCol_PlotBg]        = col(246, 248, 250);
+    pc[ImPlotCol_PlotBorder]    = t.imguiColors[ImGuiCol_Border];
+    pc[ImPlotCol_LegendBg]      = t.imguiColors[ImGuiCol_PopupBg];
+    pc[ImPlotCol_LegendBorder]  = t.imguiColors[ImGuiCol_Border];
+    pc[ImPlotCol_LegendText]    = t.imguiColors[ImGuiCol_Text];
+    pc[ImPlotCol_TitleText]     = t.imguiColors[ImGuiCol_Text];
+    pc[ImPlotCol_InlayText]     = t.imguiColors[ImGuiCol_Text];
+    pc[ImPlotCol_AxisText]      = t.imguiColors[ImGuiCol_Text];
+    pc[ImPlotCol_AxisGrid]      = col(31, 35, 40, 51);
+    pc[ImPlotCol_AxisTick]      = pc[ImPlotCol_AxisGrid];
+    pc[ImPlotCol_AxisBg]        = ImVec4(0, 0, 0, 0);
+    pc[ImPlotCol_AxisBgHovered] = t.imguiColors[ImGuiCol_ButtonHovered];
+    pc[ImPlotCol_AxisBgActive]  = t.imguiColors[ImGuiCol_ButtonActive];
+    pc[ImPlotCol_Selection]     = col(255, 255, 0);
+    pc[ImPlotCol_Crosshairs]    = pc[ImPlotCol_PlotBorder];
+
+    // -- ImPlot3D -----------------------------------------------
+    ImVec4* p3 = t.implot3dColors;
+    p3[ImPlot3DCol_TitleText]  = t.imguiColors[ImGuiCol_Text];
+    p3[ImPlot3DCol_InlayText]  = t.imguiColors[ImGuiCol_Text];
+    p3[ImPlot3DCol_FrameBg]    = t.imguiColors[ImGuiCol_FrameBg];
+    p3[ImPlot3DCol_PlotBg]     = pc[ImPlotCol_PlotBg];
+    p3[ImPlot3DCol_PlotBorder] = t.imguiColors[ImGuiCol_Border];
+    p3[ImPlot3DCol_LegendBg]      = t.imguiColors[ImGuiCol_PopupBg];
+    p3[ImPlot3DCol_LegendBorder]  = t.imguiColors[ImGuiCol_Border];
+    p3[ImPlot3DCol_LegendText]    = t.imguiColors[ImGuiCol_Text];
+    p3[ImPlot3DCol_AxisText]      = t.imguiColors[ImGuiCol_Text];
+    p3[ImPlot3DCol_AxisGrid]      = pc[ImPlotCol_AxisGrid];
+    p3[ImPlot3DCol_AxisTick]      = pc[ImPlotCol_AxisGrid];
+    p3[ImPlot3DCol_AxisBg]        = ImVec4(0, 0, 0, 0);
+    p3[ImPlot3DCol_AxisBgHovered] = t.imguiColors[ImGuiCol_ButtonHovered];
+    p3[ImPlot3DCol_AxisBgActive]  = t.imguiColors[ImGuiCol_ButtonActive];
+
+    return t;
+}
+
+// ===============================================================
+//  GitHub Dark-Inspired
+// ===============================================================
+ThemeData ThemeData::CreateWin11Dark() {
+    ThemeData t;
+    t.name    = "Windows 11 Dark";
+    t.isLight = false;
+    t.clearColor = col(22, 27, 34);  // #161b22
+
+    ImVec4* c = t.imguiColors;
+
+    c[ImGuiCol_Text]                 = col(230, 237, 243);  // #e6edf3
+    c[ImGuiCol_TextDisabled]         = col(139, 148, 158);  // #8b949e
+    c[ImGuiCol_WindowBg]             = col(22,  27,  34);   // #161b22
+    c[ImGuiCol_ChildBg]              = col(13,  17,  23);   // #0d1117
+    c[ImGuiCol_PopupBg]              = col(22,  27,  34);   // #161b22
+    c[ImGuiCol_Border]               = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_BorderShadow]         = ImVec4(0, 0, 0, 0);
+    c[ImGuiCol_FrameBg]              = col(33,  38,  45);   // #21262d
+    c[ImGuiCol_FrameBgHovered]       = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_FrameBgActive]        = col(61,  68,  77);   // #3d444d
+    c[ImGuiCol_TitleBg]              = col(13,  17,  23);   // #0d1117
+    c[ImGuiCol_TitleBgActive]        = col(22,  27,  34);   // #161b22
+    c[ImGuiCol_TitleBgCollapsed]     = col(13,  17,  23);   // #0d1117
+    c[ImGuiCol_MenuBarBg]            = col(13,  17,  23);   // #0d1117
+    c[ImGuiCol_ScrollbarBg]          = col(22,  27,  34);   // #161b22
+    c[ImGuiCol_ScrollbarGrab]        = col(72,  79,  88);   // #484f58
+    c[ImGuiCol_ScrollbarGrabHovered] = col(89,  99,  110);  // #59636e
+    c[ImGuiCol_ScrollbarGrabActive]  = col(110, 118, 129);  // #6e7681
+    c[ImGuiCol_CheckMark]            = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_SliderGrab]           = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_SliderGrabActive]     = col(120, 184, 255);  // #78b8ff
+    c[ImGuiCol_Button]               = col(33,  38,  45);   // #21262d
+    c[ImGuiCol_ButtonHovered]        = col(31,  42,  63);   // #1f2a3f
+    c[ImGuiCol_ButtonActive]         = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_Header]               = col(33,  38,  45);   // #21262d
+    c[ImGuiCol_HeaderHovered]        = col(31,  42,  63);   // #1f2a3f
+    c[ImGuiCol_HeaderActive]         = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_Separator]            = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_SeparatorHovered]     = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_SeparatorActive]      = col(120, 184, 255);  // #78b8ff
+    c[ImGuiCol_ResizeGrip]           = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_ResizeGripHovered]    = col(89,  99,  110);  // #59636e
+    c[ImGuiCol_ResizeGripActive]     = col(110, 118, 129);  // #6e7681
+    c[ImGuiCol_InputTextCursor]      = col(230, 237, 243);  // #e6edf3
+    c[ImGuiCol_TabHovered]           = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_Tab]                  = col(33,  38,  45);   // #21262d
+    c[ImGuiCol_TabSelected]          = col(22,  27,  34);   // #161b22
+    c[ImGuiCol_TabSelectedOverline]  = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_TabDimmed]            = col(33,  38,  45);   // #21262d
+    c[ImGuiCol_TabDimmedSelected]    = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_TabDimmedSelectedOverline] = col(139, 148, 158); // #8b949e
+    c[ImGuiCol_DockingPreview]       = col(88,  166, 255, 90);
+    c[ImGuiCol_DockingEmptyBg]       = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_PlotLines]            = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_PlotLinesHovered]     = col(120, 184, 255);  // #78b8ff
+    c[ImGuiCol_PlotHistogram]        = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_PlotHistogramHovered] = col(120, 184, 255);  // #78b8ff
+    c[ImGuiCol_TableHeaderBg]        = col(33,  38,  45);   // #21262d
+    c[ImGuiCol_TableBorderStrong]    = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_TableBorderLight]     = col(33,  38,  45);   // #21262d
+    c[ImGuiCol_TableRowBg]           = col(22,  27,  34);   // #161b22
+    c[ImGuiCol_TableRowBgAlt]        = col(13,  17,  23);   // #0d1117
+    c[ImGuiCol_TextLink]             = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_TextSelectedBg]       = col(88,  166, 255, 64);
+    c[ImGuiCol_TreeLines]            = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_DragDropTarget]       = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_DragDropTargetBg]     = col(88,  166, 255, 32);
+    c[ImGuiCol_UnsavedMarker]        = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_NavCursor]            = col(88,  166, 255);  // #58a6ff
+    c[ImGuiCol_NavWindowingHighlight]= col(33,  38,  45);   // #21262d
+    c[ImGuiCol_NavWindowingDimBg]    = col(0,   0,   0,   115);
+    c[ImGuiCol_ModalWindowDimBg]     = col(0,   0,   0,   153);
+
+    // -- ImPlot -------------------------------------------------
+    ImVec4* pc = t.implotColors;
+    pc[ImPlotCol_FrameBg]       = t.imguiColors[ImGuiCol_FrameBg];
+    pc[ImPlotCol_PlotBg]        = col(13, 17, 23);
+    pc[ImPlotCol_PlotBorder]    = t.imguiColors[ImGuiCol_Border];
+    pc[ImPlotCol_LegendBg]      = t.imguiColors[ImGuiCol_PopupBg];
+    pc[ImPlotCol_LegendBorder]  = t.imguiColors[ImGuiCol_Border];
+    pc[ImPlotCol_LegendText]    = t.imguiColors[ImGuiCol_Text];
+    pc[ImPlotCol_TitleText]     = t.imguiColors[ImGuiCol_Text];
+    pc[ImPlotCol_InlayText]     = t.imguiColors[ImGuiCol_Text];
+    pc[ImPlotCol_AxisText]      = t.imguiColors[ImGuiCol_Text];
+    pc[ImPlotCol_AxisGrid]      = col(230, 237, 243, 36);
+    pc[ImPlotCol_AxisTick]      = pc[ImPlotCol_AxisGrid];
+    pc[ImPlotCol_AxisBg]        = ImVec4(0, 0, 0, 0);
+    pc[ImPlotCol_AxisBgHovered] = t.imguiColors[ImGuiCol_ButtonHovered];
+    pc[ImPlotCol_AxisBgActive]  = t.imguiColors[ImGuiCol_ButtonActive];
+    pc[ImPlotCol_Selection]     = col(255, 255, 0);
+    pc[ImPlotCol_Crosshairs]    = pc[ImPlotCol_PlotBorder];
+
+    // -- ImPlot3D -----------------------------------------------
+    ImVec4* p3 = t.implot3dColors;
+    p3[ImPlot3DCol_TitleText]  = t.imguiColors[ImGuiCol_Text];
+    p3[ImPlot3DCol_InlayText]  = t.imguiColors[ImGuiCol_Text];
+    p3[ImPlot3DCol_FrameBg]    = t.imguiColors[ImGuiCol_FrameBg];
+    p3[ImPlot3DCol_PlotBg]     = pc[ImPlotCol_PlotBg];
+    p3[ImPlot3DCol_PlotBorder] = t.imguiColors[ImGuiCol_Border];
+    p3[ImPlot3DCol_LegendBg]      = t.imguiColors[ImGuiCol_PopupBg];
+    p3[ImPlot3DCol_LegendBorder]  = t.imguiColors[ImGuiCol_Border];
+    p3[ImPlot3DCol_LegendText]    = t.imguiColors[ImGuiCol_Text];
+    p3[ImPlot3DCol_AxisText]      = t.imguiColors[ImGuiCol_Text];
+    p3[ImPlot3DCol_AxisGrid]      = pc[ImPlotCol_AxisGrid];
+    p3[ImPlot3DCol_AxisTick]      = pc[ImPlotCol_AxisGrid];
+    p3[ImPlot3DCol_AxisBg]        = ImVec4(0, 0, 0, 0);
+    p3[ImPlot3DCol_AxisBgHovered] = t.imguiColors[ImGuiCol_ButtonHovered];
+    p3[ImPlot3DCol_AxisBgActive]  = t.imguiColors[ImGuiCol_ButtonActive];
+
+    return t;
+}
+
+// ===============================================================
+//  ThemeManager
+// ===============================================================
+void ThemeManager::registerTheme(const ThemeData& theme) {
+    RegisteredTheme rt;
+    rt.data = theme;
+    m_themes.push_back(std::move(rt));
+}
+
+bool ThemeManager::apply(const std::string& name) {
+    for (size_t i = 0; i < m_themes.size(); ++i) {
+        if (m_themes[i].data.name == name) {
+            m_current = i;
+            applyThemeData(m_themes[i].data);
+            return true;
+        }
+    }
+    return false;
+}
+
+void ThemeManager::toggle() {
+    // Toggle between light/dark: find first theme with opposite isLight
+    if (m_themes.empty()) return;
+    bool currentLight = m_themes[m_current].data.isLight;
+    for (size_t i = 0; i < m_themes.size(); ++i) {
+        size_t idx = (m_current + 1 + i) % m_themes.size();
+        if (m_themes[idx].data.isLight != currentLight) {
+            m_current = idx;
+            applyThemeData(m_themes[idx].data);
+            return;
+        }
+    }
+    // fallback: just go to next
+    next();
+}
+
+void ThemeManager::next() {
+    if (m_themes.empty()) return;
+    m_current = (m_current + 1) % m_themes.size();
+    applyThemeData(m_themes[m_current].data);
+}
+
+bool ThemeManager::isLight() const {
+    if (m_themes.empty()) return true;
+    return m_themes[m_current].data.isLight;
+}
+
+ImVec4 ThemeManager::getClearColor() const {
+    if (m_themes.empty()) return ImVec4(0.12f, 0.12f, 0.12f, 1.0f);
+    return m_themes[m_current].data.clearColor;
+}
+
+const std::string& ThemeManager::currentThemeName() const {
+    static const std::string s_empty;
+    if (m_themes.empty()) return s_empty;
+    return m_themes[m_current].data.name;
+}
+
+static void applyGeometry() {
+    ImGuiStyle& style = ImGui::GetStyle();
+
+    style.WindowRounding    = 8.0f;
+    style.ChildRounding     = 8.0f;
+    style.FrameRounding     = 4.0f;
+    style.PopupRounding     = 8.0f;
+    style.ScrollbarRounding = 4.0f;
+    style.GrabRounding      = 4.0f;
+    style.TabRounding       = 4.0f;
+
+    style.WindowPadding     = ImVec2(12, 12);
+    style.FramePadding      = ImVec2(8,  4);
+    style.ItemSpacing       = ImVec2(8,  6);
+    style.ItemInnerSpacing  = ImVec2(8,  6);
+    style.CellPadding       = ImVec2(8,  4);
+    style.IndentSpacing     = 25.0f;
+    style.ScrollbarSize     = 14.0f;
+    style.GrabMinSize       = 12.0f;
+    style.WindowBorderSize  = 1.0f;
+    style.ChildBorderSize   = 1.0f;
+    style.PopupBorderSize   = 1.0f;
+    style.FrameBorderSize   = 0.0f;
+    style.TabBorderSize     = 0.0f;
+}
+
+void ThemeManager::applyThemeData(const ThemeData& data) {
+    applyGeometry();
+
+    // -- ImGui colors --
+    ImGuiStyle& style = ImGui::GetStyle();
+    for (int i = 0; i < ImGuiCol_COUNT; ++i) {
+        style.Colors[i] = data.imguiColors[i];
+    }
+
+    // -- ImPlot colors --
+    ImPlotStyle& plotStyle = ImPlot::GetStyle();
+    for (int i = 0; i < ImPlotCol_COUNT; ++i) {
+        plotStyle.Colors[i] = data.implotColors[i];
+    }
+
+    // -- ImPlot3D colors --
+    ImPlot3DStyle& plot3dStyle = ImPlot3D::GetStyle();
+    for (int i = 0; i < ImPlot3DCol_COUNT; ++i) {
+        plot3dStyle.Colors[i] = data.implot3dColors[i];
+    }
+}

--- a/src/gui/theme_manager.cpp
+++ b/src/gui/theme_manager.cpp
@@ -274,7 +274,7 @@ void ThemeManager::next() {
 }
 
 bool ThemeManager::isLight() const {
-    if (m_themes.empty()) return true;
+    if (m_themes.empty()) return false;
     return m_themes[m_current].isLight;
 }
 

--- a/src/gui/theme_manager.cpp
+++ b/src/gui/theme_manager.cpp
@@ -10,10 +10,34 @@ static ImVec4 col(int r, int g, int b, int a = 255) {
 // ===============================================================
 //  GitHub-Inspired Light
 // ===============================================================
+SemanticPalette SemanticPalette::DefaultsFor(bool isLight) {
+    SemanticPalette p;
+    p.success = ImVec4(0.18f, 0.64f, 0.31f, 1.0f);                                // #2da44e
+    p.warning = isLight ? ImVec4(0.75f, 0.55f, 0.05f, 1.0f)                       // #bf8700
+                          : ImVec4(0.82f, 0.60f, 0.13f, 1.0f);                    // #d29922
+    p.danger  = ImVec4(0.81f, 0.13f, 0.18f, 1.0f);                                // #cf222e
+    p.info    = isLight ? ImVec4(0.04f, 0.41f, 0.85f, 1.0f)                       // #0969da
+                          : ImVec4(0.35f, 0.65f, 1.00f, 1.0f);                    // #58a6ff
+    p.muted   = isLight ? ImVec4(0.40f, 0.45f, 0.50f, 1.0f)                       // #656d76
+                          : ImVec4(0.55f, 0.58f, 0.62f, 1.0f);                    // #8b949e
+
+    p.successButton       = ImVec4(0.04f, 0.40f, 0.08f, 1.0f);
+    p.successButtonHover  = ImVec4(0.06f, 0.50f, 0.12f, 1.0f);
+    p.successButtonActive = ImVec4(0.03f, 0.28f, 0.05f, 1.0f);
+
+    p.dangerButton       = ImVec4(0.55f, 0.10f, 0.08f, 1.0f);
+    p.dangerButtonHover  = ImVec4(0.65f, 0.14f, 0.10f, 1.0f);
+    p.dangerButtonActive = ImVec4(0.40f, 0.06f, 0.04f, 1.0f);
+
+    p.onAccent = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    return p;
+}
+
 ThemeData ThemeData::CreateWin11Light() {
     ThemeData t;
     t.name    = std::string{kThemeNameLight};
     t.isLight = true;
+    t.semantic = SemanticPalette::DefaultsFor(true);
     t.clearColor = col(255, 255, 255);
 
     ImVec4* c = t.imguiColors;
@@ -127,6 +151,7 @@ ThemeData ThemeData::CreateWin11Dark() {
     ThemeData t;
     t.name    = std::string{kThemeNameDark};
     t.isLight = false;
+    t.semantic = SemanticPalette::DefaultsFor(false);
     t.clearColor = col(22, 27, 34);  // #161b22
 
     ImVec4* c = t.imguiColors;
@@ -301,6 +326,12 @@ const std::string& ThemeManager::currentThemeName() const {
     static const std::string s_empty;
     if (m_themes.empty()) return s_empty;
     return m_themes[m_current].name;
+}
+
+const SemanticPalette& ThemeManager::semantic() const {
+    static const SemanticPalette s_empty;
+    if (m_themes.empty()) return s_empty;
+    return m_themes[m_current].semantic;
 }
 
 void ThemeManager::applyThemeData(const ThemeData& data) {

--- a/src/gui/theme_manager.cpp
+++ b/src/gui/theme_manager.cpp
@@ -303,34 +303,8 @@ const std::string& ThemeManager::currentThemeName() const {
     return m_themes[m_current].name;
 }
 
-static void applyGeometry() {
-    ImGuiStyle& style = ImGui::GetStyle();
-
-    style.WindowRounding    = 8.0f;
-    style.ChildRounding     = 8.0f;
-    style.FrameRounding     = 4.0f;
-    style.PopupRounding     = 8.0f;
-    style.ScrollbarRounding = 4.0f;
-    style.GrabRounding      = 4.0f;
-    style.TabRounding       = 4.0f;
-
-    style.WindowPadding     = ImVec2(12, 12);
-    style.FramePadding      = ImVec2(8,  4);
-    style.ItemSpacing       = ImVec2(8,  6);
-    style.ItemInnerSpacing  = ImVec2(8,  6);
-    style.CellPadding       = ImVec2(8,  4);
-    style.IndentSpacing     = 25.0f;
-    style.ScrollbarSize     = 14.0f;
-    style.GrabMinSize       = 12.0f;
-    style.WindowBorderSize  = 1.0f;
-    style.ChildBorderSize   = 1.0f;
-    style.PopupBorderSize   = 1.0f;
-    style.FrameBorderSize   = 0.0f;
-    style.TabBorderSize     = 0.0f;
-}
-
 void ThemeManager::applyThemeData(const ThemeData& data) {
-    applyGeometry();
+    applyGeometryData(data.geometry);
 
     // -- ImGui colors --
     ImGuiStyle& style = ImGui::GetStyle();
@@ -349,4 +323,30 @@ void ThemeManager::applyThemeData(const ThemeData& data) {
     for (int i = 0; i < ImPlot3DCol_COUNT; ++i) {
         plot3dStyle.Colors[i] = data.implot3dColors[i];
     }
+}
+
+void ThemeManager::applyGeometryData(const ThemeGeometry& g) {
+    ImGuiStyle& style = ImGui::GetStyle();
+
+    style.WindowRounding    = g.windowRounding;
+    style.ChildRounding     = g.childRounding;
+    style.FrameRounding     = g.frameRounding;
+    style.PopupRounding     = g.popupRounding;
+    style.ScrollbarRounding = g.scrollbarRounding;
+    style.GrabRounding      = g.grabRounding;
+    style.TabRounding       = g.tabRounding;
+
+    style.WindowPadding     = g.windowPadding;
+    style.FramePadding      = g.framePadding;
+    style.ItemSpacing       = g.itemSpacing;
+    style.ItemInnerSpacing  = g.itemInnerSpacing;
+    style.CellPadding       = g.cellPadding;
+    style.IndentSpacing     = g.indentSpacing;
+    style.ScrollbarSize     = g.scrollbarSize;
+    style.GrabMinSize       = g.grabMinSize;
+    style.WindowBorderSize  = g.windowBorderSize;
+    style.ChildBorderSize   = g.childBorderSize;
+    style.PopupBorderSize   = g.popupBorderSize;
+    style.FrameBorderSize   = g.frameBorderSize;
+    style.TabBorderSize     = g.tabBorderSize;
 }

--- a/src/gui/theme_manager.cpp
+++ b/src/gui/theme_manager.cpp
@@ -273,6 +273,20 @@ void ThemeManager::next() {
     applyThemeData(m_themes[m_current]);
 }
 
+void ThemeManager::applyByMode(app::ThemeMode mode, bool isSystemDark) {
+    switch (mode) {
+        case app::ThemeMode::Light:
+            apply(std::string{kThemeNameLight});
+            break;
+        case app::ThemeMode::Dark:
+            apply(std::string{kThemeNameDark});
+            break;
+        case app::ThemeMode::System:
+            apply(std::string{isSystemDark ? kThemeNameDark : kThemeNameLight});
+            break;
+    }
+}
+
 bool ThemeManager::isLight() const {
     if (m_themes.empty()) return false;
     return m_themes[m_current].isLight;

--- a/src/gui/theme_manager.cpp
+++ b/src/gui/theme_manager.cpp
@@ -8,99 +8,128 @@ static ImVec4 col(int r, int g, int b, int a = 255) {
 }
 
 // ===============================================================
-//  GitHub-Inspired Light
+//  Win11 Fluent-Inspired Semantic Palette
+// ===============================================================
+//  Accent-aligned with Win11 system blue (#0078d4). Status colors
+//  follow Win11 / WinUI 3 Fluent guidance: greens are slightly
+//  desaturated for dark mode to avoid eye-strain, danger is
+//  brightened on dark to keep AA contrast on dark surfaces.
 // ===============================================================
 SemanticPalette SemanticPalette::DefaultsFor(bool isLight) {
     SemanticPalette p;
-    p.success = ImVec4(0.18f, 0.64f, 0.31f, 1.0f);                                // #2da44e
-    p.warning = isLight ? ImVec4(0.75f, 0.55f, 0.05f, 1.0f)                       // #bf8700
-                          : ImVec4(0.82f, 0.60f, 0.13f, 1.0f);                    // #d29922
-    p.danger  = ImVec4(0.81f, 0.13f, 0.18f, 1.0f);                                // #cf222e
-    p.info    = isLight ? ImVec4(0.04f, 0.41f, 0.85f, 1.0f)                       // #0969da
-                          : ImVec4(0.35f, 0.65f, 1.00f, 1.0f);                    // #58a6ff
-    p.muted   = isLight ? ImVec4(0.40f, 0.45f, 0.50f, 1.0f)                       // #656d76
-                          : ImVec4(0.55f, 0.58f, 0.62f, 1.0f);                    // #8b949e
 
-    p.successButton       = ImVec4(0.04f, 0.40f, 0.08f, 1.0f);
-    p.successButtonHover  = ImVec4(0.06f, 0.50f, 0.12f, 1.0f);
-    p.successButtonActive = ImVec4(0.03f, 0.28f, 0.05f, 1.0f);
+    if (isLight) {
+        p.success = ImVec4(0.063f, 0.486f, 0.063f, 1.0f);  // #107c10
+        p.warning = ImVec4(0.792f, 0.314f, 0.063f, 1.0f);  // #ca5010
+        p.danger  = ImVec4(0.820f, 0.204f, 0.220f, 1.0f);  // #d13438
+        p.info    = ImVec4(0.000f, 0.471f, 0.831f, 1.0f);  // #0078d4
+        p.muted   = ImVec4(0.420f, 0.420f, 0.420f, 1.0f);  // #6b6b6b
 
-    p.dangerButton       = ImVec4(0.55f, 0.10f, 0.08f, 1.0f);
-    p.dangerButtonHover  = ImVec4(0.65f, 0.14f, 0.10f, 1.0f);
-    p.dangerButtonActive = ImVec4(0.40f, 0.06f, 0.04f, 1.0f);
+        p.successButton       = ImVec4(0.063f, 0.486f, 0.063f, 1.0f);
+        p.successButtonHover  = ImVec4(0.094f, 0.612f, 0.094f, 1.0f);
+        p.successButtonActive = ImVec4(0.039f, 0.353f, 0.039f, 1.0f);
 
-    p.onAccent = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+        p.dangerButton       = ImVec4(0.820f, 0.204f, 0.220f, 1.0f);
+        p.dangerButtonHover  = ImVec4(0.890f, 0.298f, 0.314f, 1.0f);
+        p.dangerButtonActive = ImVec4(0.671f, 0.149f, 0.165f, 1.0f);
+
+        p.onAccent = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    } else {
+        p.success = ImVec4(0.247f, 0.725f, 0.314f, 1.0f);  // #3fb950  (GitHub Dark Primer green)
+        p.warning = ImVec4(0.988f, 0.882f, 0.000f, 1.0f);  // #fce100
+        p.danger  = ImVec4(0.973f, 0.318f, 0.286f, 1.0f);  // #f85149  (GitHub Dark Primer red)
+        p.info    = ImVec4(0.376f, 0.647f, 0.980f, 1.0f);  // #60a5fa
+        p.muted   = ImVec4(0.541f, 0.541f, 0.541f, 1.0f);  // #8a8a8a
+
+        p.successButton       = ImVec4(0.137f, 0.525f, 0.212f, 1.0f);  // #238636
+        p.successButtonHover  = ImVec4(0.180f, 0.627f, 0.263f, 1.0f);  // #2ea043
+        p.successButtonActive = ImVec4(0.102f, 0.498f, 0.216f, 1.0f);  // #1a7f37
+
+        p.dangerButton       = ImVec4(0.675f, 0.180f, 0.157f, 1.0f);  // #ac2e28  (deep saturated red)
+        p.dangerButtonHover  = ImVec4(0.792f, 0.216f, 0.184f, 1.0f);  // #ca372f  (hover)
+        p.dangerButtonActive = ImVec4(0.518f, 0.141f, 0.122f, 1.0f);  // #84241f  (active)
+
+        p.onAccent = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+    }
+
     return p;
 }
 
+// ===============================================================
+//  Win11 Light (Fluent-inspired)
+// ===============================================================
+//  Soft Mica-like backgrounds, thin 1px borders, single blue
+//  accent #0078d4, no shadows. Inspired by Win11 Light + VS Code
+//  "Light Modern" themes.
+// ===============================================================
 ThemeData ThemeData::CreateWin11Light() {
     ThemeData t;
     t.name    = std::string{kThemeNameLight};
     t.isLight = true;
     t.semantic = SemanticPalette::DefaultsFor(true);
-    t.clearColor = col(255, 255, 255);
+    t.clearColor = col(243, 243, 243);  // #f3f3f3
 
     ImVec4* c = t.imguiColors;
 
-    c[ImGuiCol_Text]                 = col(31,  35,  40);   // #1f2328
-    c[ImGuiCol_TextDisabled]         = col(101, 109, 118);  // #656d76
-    c[ImGuiCol_WindowBg]             = col(255, 255, 255);  // #ffffff
-    c[ImGuiCol_ChildBg]              = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_PopupBg]              = col(255, 255, 255);  // #ffffff
-    c[ImGuiCol_Border]               = col(208, 215, 222);  // #d0d7de
+    c[ImGuiCol_Text]                 = col(31,  31,  31);   // #1f1f1f
+    c[ImGuiCol_TextDisabled]         = col(107, 107, 107);  // #6b6b6b
+    c[ImGuiCol_WindowBg]             = col(250, 250, 250);  // #fafafa
+    c[ImGuiCol_ChildBg]              = col(243, 243, 243);  // #f3f3f3
+    c[ImGuiCol_PopupBg]              = col(252, 252, 252);  // #fcfcfc
+    c[ImGuiCol_Border]               = col(229, 229, 229);  // #e5e5e5
     c[ImGuiCol_BorderShadow]         = ImVec4(0, 0, 0, 0);
-    c[ImGuiCol_FrameBg]              = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_FrameBgHovered]       = col(232, 236, 240);  // #e8ecf0
-    c[ImGuiCol_FrameBgActive]        = col(208, 215, 222);  // #d0d7de
-    c[ImGuiCol_TitleBg]              = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_TitleBgActive]        = col(255, 255, 255);  // #ffffff
-    c[ImGuiCol_TitleBgCollapsed]     = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_MenuBarBg]            = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_ScrollbarBg]          = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_ScrollbarGrab]        = col(175, 184, 193);  // #afb8c1
-    c[ImGuiCol_ScrollbarGrabHovered] = col(143, 154, 165);  // #8f9aa5
-    c[ImGuiCol_ScrollbarGrabActive]  = col(118, 130, 142);  // #76828e
-    c[ImGuiCol_CheckMark]            = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_SliderGrab]           = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_SliderGrabActive]     = col(8,   82,  173);  // #0852ad
-    c[ImGuiCol_Button]               = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_ButtonHovered]        = col(221, 244, 255);  // #ddf4ff
-    c[ImGuiCol_ButtonActive]         = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_Header]               = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_HeaderHovered]        = col(221, 244, 255);  // #ddf4ff
-    c[ImGuiCol_HeaderActive]         = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_Separator]            = col(208, 215, 222);  // #d0d7de
-    c[ImGuiCol_SeparatorHovered]     = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_SeparatorActive]      = col(8,   82,  173);  // #0852ad
-    c[ImGuiCol_ResizeGrip]           = col(208, 215, 222);  // #d0d7de
-    c[ImGuiCol_ResizeGripHovered]    = col(143, 154, 165);  // #8f9aa5
-    c[ImGuiCol_ResizeGripActive]     = col(118, 130, 142);  // #76828e
-    c[ImGuiCol_InputTextCursor]      = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_TabHovered]           = col(232, 236, 240);  // #e8ecf0
-    c[ImGuiCol_Tab]                  = col(246, 248, 250);  // #f6f8fa
+    c[ImGuiCol_FrameBg]              = col(255, 255, 255);  // #ffffff
+    c[ImGuiCol_FrameBgHovered]       = col(240, 240, 240);  // #f0f0f0
+    c[ImGuiCol_FrameBgActive]        = col(224, 224, 224);  // #e0e0e0
+    c[ImGuiCol_TitleBg]              = col(250, 250, 250);  // #fafafa
+    c[ImGuiCol_TitleBgActive]        = col(250, 250, 250);  // #fafafa
+    c[ImGuiCol_TitleBgCollapsed]     = col(243, 243, 243);  // #f3f3f3
+    c[ImGuiCol_MenuBarBg]            = col(250, 250, 250);  // #fafafa
+    c[ImGuiCol_ScrollbarBg]          = col(250, 250, 250);  // #fafafa
+    c[ImGuiCol_ScrollbarGrab]        = col(200, 200, 200);  // #c8c8c8
+    c[ImGuiCol_ScrollbarGrabHovered] = col(170, 170, 170);  // #aaaaaa
+    c[ImGuiCol_ScrollbarGrabActive]  = col(140, 140, 140);  // #8c8c8c
+    c[ImGuiCol_CheckMark]            = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_SliderGrab]           = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_SliderGrabActive]     = col(0,   90,  158);  // #005a9e
+    c[ImGuiCol_Button]               = col(255, 255, 255);  // #ffffff
+    c[ImGuiCol_ButtonHovered]        = col(240, 240, 240);  // #f0f0f0
+    c[ImGuiCol_ButtonActive]         = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_Header]               = col(243, 243, 243);  // #f3f3f3
+    c[ImGuiCol_HeaderHovered]        = col(0,   120, 212, 26); // rgba(0,120,212,0.10)
+    c[ImGuiCol_HeaderActive]         = col(0,   120, 212, 51); // rgba(0,120,212,0.20)
+    c[ImGuiCol_Separator]            = col(229, 229, 229);  // #e5e5e5
+    c[ImGuiCol_SeparatorHovered]     = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_SeparatorActive]      = col(0,   90,  158);  // #005a9e
+    c[ImGuiCol_ResizeGrip]           = col(229, 229, 229);  // #e5e5e5
+    c[ImGuiCol_ResizeGripHovered]    = col(170, 170, 170);  // #aaaaaa
+    c[ImGuiCol_ResizeGripActive]     = col(140, 140, 140);  // #8c8c8c
+    c[ImGuiCol_InputTextCursor]      = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_TabHovered]           = col(240, 240, 240);  // #f0f0f0
+    c[ImGuiCol_Tab]                  = col(243, 243, 243);  // #f3f3f3
     c[ImGuiCol_TabSelected]          = col(255, 255, 255);  // #ffffff
-    c[ImGuiCol_TabSelectedOverline]  = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_TabDimmed]            = col(232, 236, 240);  // #e8ecf0
-    c[ImGuiCol_TabDimmedSelected]    = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_TabDimmedSelectedOverline] = col(101, 109, 118); // #656d76
-    c[ImGuiCol_DockingPreview]       = col(9,   105, 218, 90);
-    c[ImGuiCol_DockingEmptyBg]       = col(208, 215, 222);  // #d0d7de
-    c[ImGuiCol_PlotLines]            = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_PlotLinesHovered]     = col(8,   82,  173);  // #0852ad
-    c[ImGuiCol_PlotHistogram]        = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_PlotHistogramHovered] = col(8,   82,  173);  // #0852ad
-    c[ImGuiCol_TableHeaderBg]        = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_TableBorderStrong]    = col(208, 215, 222);  // #d0d7de
-    c[ImGuiCol_TableBorderLight]     = col(232, 236, 240);  // #e8ecf0
+    c[ImGuiCol_TabSelectedOverline]  = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_TabDimmed]            = col(243, 243, 243);  // #f3f3f3
+    c[ImGuiCol_TabDimmedSelected]    = col(250, 250, 250);  // #fafafa
+    c[ImGuiCol_TabDimmedSelectedOverline] = col(107, 107, 107); // #6b6b6b
+    c[ImGuiCol_DockingPreview]       = col(0,   120, 212, 90);
+    c[ImGuiCol_DockingEmptyBg]       = col(229, 229, 229);  // #e5e5e5
+    c[ImGuiCol_PlotLines]            = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_PlotLinesHovered]     = col(0,   90,  158);  // #005a9e
+    c[ImGuiCol_PlotHistogram]        = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_PlotHistogramHovered] = col(0,   90,  158);  // #005a9e
+    c[ImGuiCol_TableHeaderBg]        = col(243, 243, 243);  // #f3f3f3
+    c[ImGuiCol_TableBorderStrong]    = col(229, 229, 229);  // #e5e5e5
+    c[ImGuiCol_TableBorderLight]     = col(235, 235, 235);  // #ebebeb
     c[ImGuiCol_TableRowBg]           = col(255, 255, 255);  // #ffffff
-    c[ImGuiCol_TableRowBgAlt]        = col(246, 248, 250);  // #f6f8fa
-    c[ImGuiCol_TextLink]             = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_TextSelectedBg]       = col(9,   105, 218, 64);
-    c[ImGuiCol_TreeLines]            = col(208, 215, 222);  // #d0d7de
-    c[ImGuiCol_DragDropTarget]       = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_DragDropTargetBg]     = col(9,   105, 218, 32);
-    c[ImGuiCol_UnsavedMarker]        = col(9,   105, 218);  // #0969da
-    c[ImGuiCol_NavCursor]            = col(9,   105, 218);  // #0969da
+    c[ImGuiCol_TableRowBgAlt]        = col(250, 250, 250);  // #fafafa
+    c[ImGuiCol_TextLink]             = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_TextSelectedBg]       = col(0,   120, 212, 64);
+    c[ImGuiCol_TreeLines]            = col(229, 229, 229);  // #e5e5e5
+    c[ImGuiCol_DragDropTarget]       = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_DragDropTargetBg]     = col(0,   120, 212, 32);
+    c[ImGuiCol_UnsavedMarker]        = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_NavCursor]            = col(0,   120, 212);  // #0078d4
     c[ImGuiCol_NavWindowingHighlight]= col(255, 255, 255);  // #ffffff
     c[ImGuiCol_NavWindowingDimBg]    = col(0,   0,   0,   89);
     c[ImGuiCol_ModalWindowDimBg]     = col(0,   0,   0,   115);
@@ -108,7 +137,7 @@ ThemeData ThemeData::CreateWin11Light() {
     // -- ImPlot -------------------------------------------------
     ImVec4* pc = t.implotColors;
     pc[ImPlotCol_FrameBg]       = t.imguiColors[ImGuiCol_FrameBg];
-    pc[ImPlotCol_PlotBg]        = col(246, 248, 250);
+    pc[ImPlotCol_PlotBg]        = col(252, 252, 252);
     pc[ImPlotCol_PlotBorder]    = t.imguiColors[ImGuiCol_Border];
     pc[ImPlotCol_LegendBg]      = t.imguiColors[ImGuiCol_PopupBg];
     pc[ImPlotCol_LegendBorder]  = t.imguiColors[ImGuiCol_Border];
@@ -116,12 +145,12 @@ ThemeData ThemeData::CreateWin11Light() {
     pc[ImPlotCol_TitleText]     = t.imguiColors[ImGuiCol_Text];
     pc[ImPlotCol_InlayText]     = t.imguiColors[ImGuiCol_Text];
     pc[ImPlotCol_AxisText]      = t.imguiColors[ImGuiCol_Text];
-    pc[ImPlotCol_AxisGrid]      = col(31, 35, 40, 51);
+    pc[ImPlotCol_AxisGrid]      = col(31, 31, 31, 38);
     pc[ImPlotCol_AxisTick]      = pc[ImPlotCol_AxisGrid];
     pc[ImPlotCol_AxisBg]        = ImVec4(0, 0, 0, 0);
     pc[ImPlotCol_AxisBgHovered] = t.imguiColors[ImGuiCol_ButtonHovered];
     pc[ImPlotCol_AxisBgActive]  = t.imguiColors[ImGuiCol_ButtonActive];
-    pc[ImPlotCol_Selection]     = col(255, 255, 0);
+    pc[ImPlotCol_Selection]     = col(0, 120, 212, 64);
     pc[ImPlotCol_Crosshairs]    = pc[ImPlotCol_PlotBorder];
 
     // -- ImPlot3D -----------------------------------------------
@@ -145,84 +174,95 @@ ThemeData ThemeData::CreateWin11Light() {
 }
 
 // ===============================================================
-//  GitHub Dark-Inspired
+//  Win11 Light (Fluent-inspired)
+// ===============================================================
+//  Soft Mica-like backgrounds, thin 1px borders, single blue
+//  accent #0078d4, no shadows. Inspired by Win11 Light + VS Code
+//  "Light Modern" themes.
+// ===============================================================
+//  Win11 Dark (Fluent-inspired)
+// ===============================================================
+//  Inspired by Win11 Dark + VS Code "Dark 2026" / "Dark Modern".
+//  Soft Mica-like charcoal backgrounds, lighter text (#f0f0f0),
+//  lighter semantic colors (success/danger) for AA contrast on
+//  dark surfaces. Accent #0078d4 stays consistent with light.
 // ===============================================================
 ThemeData ThemeData::CreateWin11Dark() {
     ThemeData t;
     t.name    = std::string{kThemeNameDark};
     t.isLight = false;
     t.semantic = SemanticPalette::DefaultsFor(false);
-    t.clearColor = col(22, 27, 34);  // #161b22
+    t.clearColor = col(24, 24, 24);  // #181818
 
     ImVec4* c = t.imguiColors;
 
-    c[ImGuiCol_Text]                 = col(230, 237, 243);  // #e6edf3
-    c[ImGuiCol_TextDisabled]         = col(139, 148, 158);  // #8b949e
-    c[ImGuiCol_WindowBg]             = col(22,  27,  34);   // #161b22
-    c[ImGuiCol_ChildBg]              = col(13,  17,  23);   // #0d1117
-    c[ImGuiCol_PopupBg]              = col(22,  27,  34);   // #161b22
-    c[ImGuiCol_Border]               = col(48,  54,  61);   // #30363d
+    c[ImGuiCol_Text]                 = col(240, 240, 240);  // #f0f0f0
+    c[ImGuiCol_TextDisabled]         = col(138, 138, 138);  // #8a8a8a
+    c[ImGuiCol_WindowBg]             = col(24,  24,  24);   // #181818
+    c[ImGuiCol_ChildBg]              = col(24,  24,  24);   // #181818
+    c[ImGuiCol_PopupBg]              = col(37,  37,  37);   // #252525
+    c[ImGuiCol_Border]               = col(45,  45,  45);   // #2d2d2d
     c[ImGuiCol_BorderShadow]         = ImVec4(0, 0, 0, 0);
-    c[ImGuiCol_FrameBg]              = col(33,  38,  45);   // #21262d
-    c[ImGuiCol_FrameBgHovered]       = col(48,  54,  61);   // #30363d
-    c[ImGuiCol_FrameBgActive]        = col(61,  68,  77);   // #3d444d
-    c[ImGuiCol_TitleBg]              = col(13,  17,  23);   // #0d1117
-    c[ImGuiCol_TitleBgActive]        = col(22,  27,  34);   // #161b22
-    c[ImGuiCol_TitleBgCollapsed]     = col(13,  17,  23);   // #0d1117
-    c[ImGuiCol_MenuBarBg]            = col(13,  17,  23);   // #0d1117
-    c[ImGuiCol_ScrollbarBg]          = col(22,  27,  34);   // #161b22
-    c[ImGuiCol_ScrollbarGrab]        = col(72,  79,  88);   // #484f58
-    c[ImGuiCol_ScrollbarGrabHovered] = col(89,  99,  110);  // #59636e
-    c[ImGuiCol_ScrollbarGrabActive]  = col(110, 118, 129);  // #6e7681
-    c[ImGuiCol_CheckMark]            = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_SliderGrab]           = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_SliderGrabActive]     = col(120, 184, 255);  // #78b8ff
-    c[ImGuiCol_Button]               = col(33,  38,  45);   // #21262d
-    c[ImGuiCol_ButtonHovered]        = col(31,  42,  63);   // #1f2a3f
-    c[ImGuiCol_ButtonActive]         = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_Header]               = col(33,  38,  45);   // #21262d
-    c[ImGuiCol_HeaderHovered]        = col(31,  42,  63);   // #1f2a3f
-    c[ImGuiCol_HeaderActive]         = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_Separator]            = col(48,  54,  61);   // #30363d
-    c[ImGuiCol_SeparatorHovered]     = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_SeparatorActive]      = col(120, 184, 255);  // #78b8ff
-    c[ImGuiCol_ResizeGrip]           = col(48,  54,  61);   // #30363d
-    c[ImGuiCol_ResizeGripHovered]    = col(89,  99,  110);  // #59636e
-    c[ImGuiCol_ResizeGripActive]     = col(110, 118, 129);  // #6e7681
-    c[ImGuiCol_InputTextCursor]      = col(230, 237, 243);  // #e6edf3
-    c[ImGuiCol_TabHovered]           = col(48,  54,  61);   // #30363d
-    c[ImGuiCol_Tab]                  = col(33,  38,  45);   // #21262d
-    c[ImGuiCol_TabSelected]          = col(22,  27,  34);   // #161b22
-    c[ImGuiCol_TabSelectedOverline]  = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_TabDimmed]            = col(33,  38,  45);   // #21262d
-    c[ImGuiCol_TabDimmedSelected]    = col(48,  54,  61);   // #30363d
-    c[ImGuiCol_TabDimmedSelectedOverline] = col(139, 148, 158); // #8b949e
-    c[ImGuiCol_DockingPreview]       = col(88,  166, 255, 90);
-    c[ImGuiCol_DockingEmptyBg]       = col(48,  54,  61);   // #30363d
-    c[ImGuiCol_PlotLines]            = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_PlotLinesHovered]     = col(120, 184, 255);  // #78b8ff
-    c[ImGuiCol_PlotHistogram]        = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_PlotHistogramHovered] = col(120, 184, 255);  // #78b8ff
-    c[ImGuiCol_TableHeaderBg]        = col(33,  38,  45);   // #21262d
-    c[ImGuiCol_TableBorderStrong]    = col(48,  54,  61);   // #30363d
-    c[ImGuiCol_TableBorderLight]     = col(33,  38,  45);   // #21262d
-    c[ImGuiCol_TableRowBg]           = col(22,  27,  34);   // #161b22
-    c[ImGuiCol_TableRowBgAlt]        = col(13,  17,  23);   // #0d1117
-    c[ImGuiCol_TextLink]             = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_TextSelectedBg]       = col(88,  166, 255, 64);
-    c[ImGuiCol_TreeLines]            = col(48,  54,  61);   // #30363d
-    c[ImGuiCol_DragDropTarget]       = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_DragDropTargetBg]     = col(88,  166, 255, 32);
-    c[ImGuiCol_UnsavedMarker]        = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_NavCursor]            = col(88,  166, 255);  // #58a6ff
-    c[ImGuiCol_NavWindowingHighlight]= col(33,  38,  45);   // #21262d
+    c[ImGuiCol_FrameBg]              = col(45,  45,  45);   // #2d2d2d
+    c[ImGuiCol_FrameBgHovered]       = col(56,  56,  56);   // #383838
+    c[ImGuiCol_FrameBgActive]        = col(69,  69,  69);   // #454545
+    c[ImGuiCol_TitleBg]              = col(24,  24,  24);   // #181818
+    c[ImGuiCol_TitleBgActive]        = col(24,  24,  24);   // #181818
+    c[ImGuiCol_TitleBgCollapsed]     = col(18,  18,  18);   // #121212
+    c[ImGuiCol_MenuBarBg]            = col(24,  24,  24);   // #181818
+    c[ImGuiCol_ScrollbarBg]          = col(24,  24,  24);   // #181818
+    c[ImGuiCol_ScrollbarGrab]        = col(80,  80,  80);   // #505050
+    c[ImGuiCol_ScrollbarGrabHovered] = col(110, 110, 110);  // #6e6e6e
+    c[ImGuiCol_ScrollbarGrabActive]  = col(140, 140, 140);  // #8c8c8c
+    c[ImGuiCol_CheckMark]            = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_SliderGrab]           = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_SliderGrabActive]     = col(140, 188, 255);  // #8cbcff
+    c[ImGuiCol_Button]               = col(45,  45,  45);   // #2d2d2d
+    c[ImGuiCol_ButtonHovered]        = col(56,  56,  56);   // #383838
+    c[ImGuiCol_ButtonActive]         = col(0,   120, 212);  // #0078d4
+    c[ImGuiCol_Header]               = col(45,  45,  45);   // #2d2d2d
+    c[ImGuiCol_HeaderHovered]        = col(0,   120, 212, 51);  // rgba(0,120,212,0.20)
+    c[ImGuiCol_HeaderActive]         = col(0,   120, 212, 77);  // rgba(0,120,212,0.30)
+    c[ImGuiCol_Separator]            = col(45,  45,  45);   // #2d2d2d
+    c[ImGuiCol_SeparatorHovered]     = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_SeparatorActive]      = col(140, 188, 255);  // #8cbcff
+    c[ImGuiCol_ResizeGrip]           = col(45,  45,  45);   // #2d2d2d
+    c[ImGuiCol_ResizeGripHovered]    = col(110, 110, 110);  // #6e6e6e
+    c[ImGuiCol_ResizeGripActive]     = col(140, 140, 140);  // #8c8c8c
+    c[ImGuiCol_InputTextCursor]      = col(240, 240, 240);  // #f0f0f0
+    c[ImGuiCol_TabHovered]           = col(56,  56,  56);   // #383838
+    c[ImGuiCol_Tab]                  = col(32,  32,  32);   // #202020
+    c[ImGuiCol_TabSelected]          = col(24,  24,  24);   // #181818
+    c[ImGuiCol_TabSelectedOverline]  = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_TabDimmed]            = col(32,  32,  32);   // #202020
+    c[ImGuiCol_TabDimmedSelected]    = col(45,  45,  45);   // #2d2d2d
+    c[ImGuiCol_TabDimmedSelectedOverline] = col(138, 138, 138); // #8a8a8a
+    c[ImGuiCol_DockingPreview]       = col(96,  165, 250, 90);
+    c[ImGuiCol_DockingEmptyBg]       = col(45,  45,  45);   // #2d2d2d
+    c[ImGuiCol_PlotLines]            = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_PlotLinesHovered]     = col(140, 188, 255);  // #8cbcff
+    c[ImGuiCol_PlotHistogram]        = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_PlotHistogramHovered] = col(140, 188, 255);  // #8cbcff
+    c[ImGuiCol_TableHeaderBg]        = col(32,  32,  32);   // #202020
+    c[ImGuiCol_TableBorderStrong]    = col(45,  45,  45);   // #2d2d2d
+    c[ImGuiCol_TableBorderLight]     = col(38,  38,  38);   // #262626
+    c[ImGuiCol_TableRowBg]           = col(32,  32,  32);   // #202020
+    c[ImGuiCol_TableRowBgAlt]        = col(28,  28,  28);   // #1c1c1c
+    c[ImGuiCol_TextLink]             = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_TextSelectedBg]       = col(96,  165, 250, 64);
+    c[ImGuiCol_TreeLines]            = col(45,  45,  45);   // #2d2d2d
+    c[ImGuiCol_DragDropTarget]       = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_DragDropTargetBg]     = col(96,  165, 250, 32);
+    c[ImGuiCol_UnsavedMarker]        = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_NavCursor]            = col(96,  165, 250);  // #60a5fa
+    c[ImGuiCol_NavWindowingHighlight]= col(45,  45,  45);   // #2d2d2d
     c[ImGuiCol_NavWindowingDimBg]    = col(0,   0,   0,   115);
     c[ImGuiCol_ModalWindowDimBg]     = col(0,   0,   0,   153);
 
     // -- ImPlot -------------------------------------------------
     ImVec4* pc = t.implotColors;
     pc[ImPlotCol_FrameBg]       = t.imguiColors[ImGuiCol_FrameBg];
-    pc[ImPlotCol_PlotBg]        = col(13, 17, 23);
+    pc[ImPlotCol_PlotBg]        = col(24, 24, 24);
     pc[ImPlotCol_PlotBorder]    = t.imguiColors[ImGuiCol_Border];
     pc[ImPlotCol_LegendBg]      = t.imguiColors[ImGuiCol_PopupBg];
     pc[ImPlotCol_LegendBorder]  = t.imguiColors[ImGuiCol_Border];
@@ -230,12 +270,12 @@ ThemeData ThemeData::CreateWin11Dark() {
     pc[ImPlotCol_TitleText]     = t.imguiColors[ImGuiCol_Text];
     pc[ImPlotCol_InlayText]     = t.imguiColors[ImGuiCol_Text];
     pc[ImPlotCol_AxisText]      = t.imguiColors[ImGuiCol_Text];
-    pc[ImPlotCol_AxisGrid]      = col(230, 237, 243, 36);
+    pc[ImPlotCol_AxisGrid]      = col(240, 240, 240, 36);
     pc[ImPlotCol_AxisTick]      = pc[ImPlotCol_AxisGrid];
     pc[ImPlotCol_AxisBg]        = ImVec4(0, 0, 0, 0);
     pc[ImPlotCol_AxisBgHovered] = t.imguiColors[ImGuiCol_ButtonHovered];
     pc[ImPlotCol_AxisBgActive]  = t.imguiColors[ImGuiCol_ButtonActive];
-    pc[ImPlotCol_Selection]     = col(255, 255, 0);
+    pc[ImPlotCol_Selection]     = col(96, 165, 250, 64);
     pc[ImPlotCol_Crosshairs]    = pc[ImPlotCol_PlotBorder];
 
     // -- ImPlot3D -----------------------------------------------
@@ -258,9 +298,6 @@ ThemeData ThemeData::CreateWin11Dark() {
     return t;
 }
 
-// ===============================================================
-//  ThemeManager
-// ===============================================================
 void ThemeManager::registerTheme(const ThemeData& theme) {
     m_themes.push_back(theme);
 }

--- a/src/gui/theme_manager.cpp
+++ b/src/gui/theme_manager.cpp
@@ -237,16 +237,14 @@ ThemeData ThemeData::CreateWin11Dark() {
 //  ThemeManager
 // ===============================================================
 void ThemeManager::registerTheme(const ThemeData& theme) {
-    RegisteredTheme rt;
-    rt.data = theme;
-    m_themes.push_back(std::move(rt));
+    m_themes.push_back(theme);
 }
 
 bool ThemeManager::apply(const std::string& name) {
     for (size_t i = 0; i < m_themes.size(); ++i) {
-        if (m_themes[i].data.name == name) {
+        if (m_themes[i].name == name) {
             m_current = i;
-            applyThemeData(m_themes[i].data);
+            applyThemeData(m_themes[i]);
             return true;
         }
     }
@@ -256,12 +254,12 @@ bool ThemeManager::apply(const std::string& name) {
 void ThemeManager::toggle() {
     // Toggle between light/dark: find first theme with opposite isLight
     if (m_themes.empty()) return;
-    bool currentLight = m_themes[m_current].data.isLight;
+    bool currentLight = m_themes[m_current].isLight;
     for (size_t i = 0; i < m_themes.size(); ++i) {
         size_t idx = (m_current + 1 + i) % m_themes.size();
-        if (m_themes[idx].data.isLight != currentLight) {
+        if (m_themes[idx].isLight != currentLight) {
             m_current = idx;
-            applyThemeData(m_themes[idx].data);
+            applyThemeData(m_themes[idx]);
             return;
         }
     }
@@ -272,23 +270,23 @@ void ThemeManager::toggle() {
 void ThemeManager::next() {
     if (m_themes.empty()) return;
     m_current = (m_current + 1) % m_themes.size();
-    applyThemeData(m_themes[m_current].data);
+    applyThemeData(m_themes[m_current]);
 }
 
 bool ThemeManager::isLight() const {
     if (m_themes.empty()) return true;
-    return m_themes[m_current].data.isLight;
+    return m_themes[m_current].isLight;
 }
 
 ImVec4 ThemeManager::getClearColor() const {
     if (m_themes.empty()) return ImVec4(0.12f, 0.12f, 0.12f, 1.0f);
-    return m_themes[m_current].data.clearColor;
+    return m_themes[m_current].clearColor;
 }
 
 const std::string& ThemeManager::currentThemeName() const {
     static const std::string s_empty;
     if (m_themes.empty()) return s_empty;
-    return m_themes[m_current].data.name;
+    return m_themes[m_current].name;
 }
 
 static void applyGeometry() {

--- a/src/gui/theme_manager.cpp
+++ b/src/gui/theme_manager.cpp
@@ -12,7 +12,7 @@ static ImVec4 col(int r, int g, int b, int a = 255) {
 // ===============================================================
 ThemeData ThemeData::CreateWin11Light() {
     ThemeData t;
-    t.name    = "Windows 11 Light";
+    t.name    = std::string{kThemeNameLight};
     t.isLight = true;
     t.clearColor = col(255, 255, 255);
 
@@ -125,7 +125,7 @@ ThemeData ThemeData::CreateWin11Light() {
 // ===============================================================
 ThemeData ThemeData::CreateWin11Dark() {
     ThemeData t;
-    t.name    = "Windows 11 Dark";
+    t.name    = std::string{kThemeNameDark};
     t.isLight = false;
     t.clearColor = col(22, 27, 34);  // #161b22
 

--- a/src/gui/theme_manager.h
+++ b/src/gui/theme_manager.h
@@ -38,10 +38,7 @@ public:
     size_t themeCount() const { return m_themes.size(); }
 
 private:
-    struct RegisteredTheme {
-        ThemeData data;
-    };
-    std::vector<RegisteredTheme> m_themes;
+    std::vector<ThemeData> m_themes;
     size_t m_current = 0;
 
     void applyThemeData(const ThemeData& data);

--- a/src/gui/theme_manager.h
+++ b/src/gui/theme_manager.h
@@ -8,6 +8,8 @@
 #include <implot.h>
 #include <implot3d.h>
 
+#include "app/settings.h"
+
 inline constexpr std::string_view kThemeNameLight = "Windows 11 Light";
 inline constexpr std::string_view kThemeNameDark  = "Windows 11 Dark";
 
@@ -31,6 +33,10 @@ public:
     bool apply(const std::string& name);
     void toggle();
     void next();
+
+    /// Resolves @p mode against @p isSystemDark and applies the resulting theme.
+    /// Used by SettingsManager for AppSettings.appearance.themeMode.
+    void applyByMode(app::ThemeMode mode, bool isSystemDark);
 
     bool isLight() const;
     ImVec4 getClearColor() const;

--- a/src/gui/theme_manager.h
+++ b/src/gui/theme_manager.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <imgui.h>
+#include <implot.h>
+#include <implot3d.h>
+
+struct ThemeData {
+    std::string name;
+    bool isLight;
+
+    ImVec4 clearColor;
+
+    ImVec4 imguiColors[ImGuiCol_COUNT];
+    ImVec4 implotColors[ImPlotCol_COUNT];
+    ImVec4 implot3dColors[ImPlot3DCol_COUNT];
+
+    static ThemeData CreateWin11Light();
+    static ThemeData CreateWin11Dark();
+};
+
+class ThemeManager {
+public:
+    void registerTheme(const ThemeData& theme);
+    bool apply(const std::string& name);
+    void toggle();
+    void next();
+
+    bool isLight() const;
+    ImVec4 getClearColor() const;
+    const std::string& currentThemeName() const;
+    size_t themeCount() const { return m_themes.size(); }
+
+private:
+    struct RegisteredTheme {
+        ThemeData data;
+    };
+    std::vector<RegisteredTheme> m_themes;
+    size_t m_current = 0;
+
+    void applyThemeData(const ThemeData& data);
+};

--- a/src/gui/theme_manager.h
+++ b/src/gui/theme_manager.h
@@ -42,6 +42,33 @@ struct ThemeGeometry {
     float tabBorderSize     = 0.0f;
 };
 
+/// Semantic, role-based color tokens used by widgets that need to communicate
+/// status (success/danger/info/warning/muted) or theme-aware button shades.
+/// Replaces the legacy hardcoded DDE_STATUS_COLOR_* and DDE_BUTTON_* constants
+/// from gui/constants.h so each theme can provide its own status palette.
+struct SemanticPalette {
+    ImVec4 success;          // Connected, "new version available", check marks.
+    ImVec4 warning;          // Validation warning, prerelease notice.
+    ImVec4 danger;           // Disconnected, errors, destructive actions.
+    ImVec4 info;             // Hints, links (usually matches theme accent).
+    ImVec4 muted;            // "Up to date", neutral captions.
+
+    ImVec4 successButton;
+    ImVec4 successButtonHover;
+    ImVec4 successButtonActive;
+
+    ImVec4 dangerButton;
+    ImVec4 dangerButtonHover;
+    ImVec4 dangerButtonActive;
+
+    ImVec4 onAccent;         // Text drawn on top of an accent-colored button.
+
+    /// Shared default values used by both built-in themes. The @p isLight
+    /// flag only affects the muted token (a single neutral grey is too dark
+    /// on a dark background and too light on a light background).
+    static SemanticPalette DefaultsFor(bool isLight);
+};
+
 struct ThemeData {
     std::string name;
     bool isLight;
@@ -53,6 +80,7 @@ struct ThemeData {
     ImVec4 implot3dColors[ImPlot3DCol_COUNT];
 
     ThemeGeometry geometry;
+    SemanticPalette semantic;
 
     static ThemeData CreateWin11Light();
     static ThemeData CreateWin11Dark();
@@ -73,6 +101,11 @@ public:
     ImVec4 getClearColor() const;
     const std::string& currentThemeName() const;
     size_t themeCount() const { return m_themes.size(); }
+
+    /// Returns the semantic palette of the currently active theme.
+    /// Widgets that draw status text or status-colored buttons should read
+    /// from here so colors stay consistent with the active palette.
+    const SemanticPalette& semantic() const;
 
 private:
     std::vector<ThemeData> m_themes;

--- a/src/gui/theme_manager.h
+++ b/src/gui/theme_manager.h
@@ -10,8 +10,8 @@
 
 #include "app/settings.h"
 
-inline constexpr std::string_view kThemeNameLight = "Windows 11 Light";
-inline constexpr std::string_view kThemeNameDark  = "Windows 11 Dark";
+inline constexpr std::string_view kThemeNameLight = "Light Theme";
+inline constexpr std::string_view kThemeNameDark  = "Dark Theme";
 
 /// Non-color styling (rounding, padding, spacing, border sizes).
 /// Stored per-theme so future themes can override look-and-feel without

--- a/src/gui/theme_manager.h
+++ b/src/gui/theme_manager.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <imgui.h>
 #include <implot.h>
 #include <implot3d.h>
+
+inline constexpr std::string_view kThemeNameLight = "Windows 11 Light";
+inline constexpr std::string_view kThemeNameDark  = "Windows 11 Dark";
 
 struct ThemeData {
     std::string name;

--- a/src/gui/theme_manager.h
+++ b/src/gui/theme_manager.h
@@ -13,6 +13,35 @@
 inline constexpr std::string_view kThemeNameLight = "Windows 11 Light";
 inline constexpr std::string_view kThemeNameDark  = "Windows 11 Dark";
 
+/// Non-color styling (rounding, padding, spacing, border sizes).
+/// Stored per-theme so future themes can override look-and-feel without
+/// touching color values. Defaults match the legacy hardcoded applyGeometry().
+struct ThemeGeometry {
+    float windowRounding    = 8.0f;
+    float childRounding     = 8.0f;
+    float frameRounding     = 4.0f;
+    float popupRounding     = 8.0f;
+    float scrollbarRounding = 4.0f;
+    float grabRounding      = 4.0f;
+    float tabRounding       = 4.0f;
+
+    ImVec2 windowPadding    = ImVec2(12, 12);
+    ImVec2 framePadding     = ImVec2(8,  4);
+    ImVec2 itemSpacing      = ImVec2(8,  6);
+    ImVec2 itemInnerSpacing = ImVec2(8,  6);
+    ImVec2 cellPadding      = ImVec2(8,  4);
+
+    float indentSpacing     = 25.0f;
+    float scrollbarSize     = 14.0f;
+    float grabMinSize       = 12.0f;
+
+    float windowBorderSize  = 1.0f;
+    float childBorderSize   = 1.0f;
+    float popupBorderSize   = 1.0f;
+    float frameBorderSize   = 0.0f;
+    float tabBorderSize     = 0.0f;
+};
+
 struct ThemeData {
     std::string name;
     bool isLight;
@@ -22,6 +51,8 @@ struct ThemeData {
     ImVec4 imguiColors[ImGuiCol_COUNT];
     ImVec4 implotColors[ImPlotCol_COUNT];
     ImVec4 implot3dColors[ImPlot3DCol_COUNT];
+
+    ThemeGeometry geometry;
 
     static ThemeData CreateWin11Light();
     static ThemeData CreateWin11Dark();
@@ -48,4 +79,5 @@ private:
     size_t m_current = 0;
 
     void applyThemeData(const ThemeData& data);
+    void applyGeometryData(const ThemeGeometry& geometry);
 };

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -80,7 +80,7 @@ namespace gui {
                 if (connectionCount < DDEConnectionManager::MAX_CONNECTIONS) {
                     ImGui::Separator();
                     if (ImGui::Selectable("+ Connect to another Zemax...")) {
-                        m_showConnectPopup = true;
+                        m_connectPopup->open();
                     }
                 }
 
@@ -107,7 +107,7 @@ namespace gui {
                 m_connectionManager->disconnect(activeIdx);
                 logger.addLog("[DDE] Disconnected from Zemax");
             } else {
-                m_showConnectPopup = true;
+                m_connectPopup->open();
             }
         }
 
@@ -117,8 +117,6 @@ namespace gui {
 
         ImGui::EndChild();
 
-        if (m_showConnectPopup && m_connectPopup) {
-            m_connectPopup->render(m_showConnectPopup, logger);
-        }
+        m_connectPopup->render();
     }
 }

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -12,7 +12,7 @@ namespace gui {
         if (!m_themeManager) return;
 
         ImGui::BeginChild("DDE Status Content",
-            ImVec2(gui::DDE_STATUS_CONTENT_WIDTH, gui::DDE_STATUS_CONTENT_HEIGHT),
+            ImVec2(gui::DDE_STATUS_CONTENT_SIZE.x, gui::DDE_STATUS_CONTENT_SIZE.y),
             ImGuiChildFlags_Borders,
             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse
         );

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -2,12 +2,14 @@
 
 #include "windows_dockable/dde_status.h"
 #include "gui/constants.h"
+#include "gui/theme_manager.h"
 #include "lib/imgui/imgui.h"
 #include "logger/logger.h"
 
 namespace gui {
     void DDEStatus::render(Logger& logger) {
         if (!m_connectionManager) return;
+        if (!m_themeManager) return;
 
         ImGui::BeginChild("DDE Status Content",
             ImVec2(gui::DDE_STATUS_CONTENT_WIDTH, gui::DDE_STATUS_CONTENT_HEIGHT),
@@ -37,7 +39,8 @@ namespace gui {
             ImGui::TextUnformatted(label);
             ImGui::SameLine(0.0f, 4.0f);
 
-            ImGui::PushStyleColor(ImGuiCol_Text, connected ? gui::DDE_STATUS_COLOR_CONNECTED : gui::DDE_STATUS_COLOR_DISCONNECTED);
+            const auto& sem = m_themeManager->semantic();
+            ImGui::PushStyleColor(ImGuiCol_Text, connected ? sem.success : sem.danger);
             ImGui::TextUnformatted(value);
             ImGui::PopStyleColor();
         }
@@ -89,16 +92,14 @@ namespace gui {
 
         bool connected = (activeIdx >= 0);
 
-        // Intentionally bypassing ImGui theme tokens (ImGuiCol_Button*) with hardcoded
-        // colors from gui/constants.h. This is a deliberate UX decision: DDE connect/disconnect
-        // status must remain visually unambiguous regardless of the active theme
-        // (green = connect, red = disconnect). If a future theme system exposes semantic
-        // status tokens, replace these constants with theme-aware values.
+        // Connect/disconnect button uses semantic danger/success tokens (not ImGuiCol_Button*)
+        // so the action remains visually unambiguous regardless of the active theme.
+        const auto& sem = m_themeManager->semantic();
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(-1.0f, 4.0f));
-        ImGui::PushStyleColor(ImGuiCol_Button, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_NORMAL : gui::DDE_BUTTON_CONNECT_COLOR_NORMAL);
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_HOVER : gui::DDE_BUTTON_CONNECT_COLOR_HOVER);
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_ACTIVE : gui::DDE_BUTTON_CONNECT_COLOR_ACTIVE);
-        ImGui::PushStyleColor(ImGuiCol_Text, gui::DDE_BUTTON_TEXT_COLOR);
+        ImGui::PushStyleColor(ImGuiCol_Button,        connected ? sem.dangerButton        : sem.successButton);
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, connected ? sem.dangerButtonHover   : sem.successButtonHover);
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive,  connected ? sem.dangerButtonActive  : sem.successButtonActive);
+        ImGui::PushStyleColor(ImGuiCol_Text, sem.onAccent);
         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.5f, 0.5f));
 
         if (ImGui::Button(connected ? "Disconnect from Zemax" : "Connect to Zemax", ImVec2(-1.0f, 0.0f))) {

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -89,6 +89,11 @@ namespace gui {
 
         bool connected = (activeIdx >= 0);
 
+        // Intentionally bypassing ImGui theme tokens (ImGuiCol_Button*) with hardcoded
+        // colors from gui/constants.h. This is a deliberate UX decision: DDE connect/disconnect
+        // status must remain visually unambiguous regardless of the active theme
+        // (green = connect, red = disconnect). If a future theme system exposes semantic
+        // status tokens, replace these constants with theme-aware values.
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(-1.0f, 4.0f));
         ImGui::PushStyleColor(ImGuiCol_Button, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_NORMAL : gui::DDE_BUTTON_CONNECT_COLOR_NORMAL);
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_HOVER : gui::DDE_BUTTON_CONNECT_COLOR_HOVER);

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -93,6 +93,7 @@ namespace gui {
         ImGui::PushStyleColor(ImGuiCol_Button, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_NORMAL : gui::DDE_BUTTON_CONNECT_COLOR_NORMAL);
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_HOVER : gui::DDE_BUTTON_CONNECT_COLOR_HOVER);
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, connected ? gui::DDE_BUTTON_DISCONNECT_COLOR_ACTIVE : gui::DDE_BUTTON_CONNECT_COLOR_ACTIVE);
+        ImGui::PushStyleColor(ImGuiCol_Text, gui::DDE_BUTTON_TEXT_COLOR);
         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.5f, 0.5f));
 
         if (ImGui::Button(connected ? "Disconnect from Zemax" : "Connect to Zemax", ImVec2(-1.0f, 0.0f))) {
@@ -105,7 +106,7 @@ namespace gui {
         }
 
         ImGui::PopStyleVar();
-        ImGui::PopStyleColor(3);
+        ImGui::PopStyleColor(4);
         ImGui::PopStyleVar();
 
         ImGui::EndChild();

--- a/src/gui/windows_dockable/dde_status.h
+++ b/src/gui/windows_dockable/dde_status.h
@@ -4,11 +4,10 @@
 
 #include "gui/constants.h"
 #include "gui/popups/connect_dde.h"
+#include "gui/theme_manager.h"
 #include "dde/dde_connection_manager.h"
 
 namespace gui {
-    class ThemeManager;
-
     class DDEStatus {
     public:
         explicit DDEStatus(DDEConnectionManager* connectionManager)

--- a/src/gui/windows_dockable/dde_status.h
+++ b/src/gui/windows_dockable/dde_status.h
@@ -18,11 +18,11 @@ namespace gui {
 
         /// Non-owning; bound by GuiManager after graphics.initialize().
         void setThemeManager(const ThemeManager* themeManager) noexcept { m_themeManager = themeManager; }
+        void setLogger(Logger* logger) noexcept { m_connectPopup->setLogger(logger); }
 
     private:
         DDEConnectionManager* m_connectionManager;
         const ThemeManager* m_themeManager = nullptr;
         std::unique_ptr<ConnectDDEPopup> m_connectPopup;
-        bool m_showConnectPopup = false;
     };
 }

--- a/src/gui/windows_dockable/dde_status.h
+++ b/src/gui/windows_dockable/dde_status.h
@@ -7,6 +7,8 @@
 #include "dde/dde_connection_manager.h"
 
 namespace gui {
+    class ThemeManager;
+
     class DDEStatus {
     public:
         explicit DDEStatus(DDEConnectionManager* connectionManager)
@@ -15,8 +17,12 @@ namespace gui {
 
         void render(Logger& logger);
 
+        /// Non-owning; bound by GuiManager after graphics.initialize().
+        void setThemeManager(const ThemeManager* themeManager) noexcept { m_themeManager = themeManager; }
+
     private:
         DDEConnectionManager* m_connectionManager;
+        const ThemeManager* m_themeManager = nullptr;
         std::unique_ptr<ConnectDDEPopup> m_connectPopup;
         bool m_showConnectPopup = false;
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,11 +33,12 @@ int main() {
     while (!ctx->gui->shouldClose()) {
         glfwPollEvents();
 
-        // Hotkey Ctrl+O
-        if (ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) {
-            if (ImGui::IsKeyPressed(ImGuiKey_O)) {
-                App::openZmxFileInZemax(logger);
-            }
+        // Hotkeys: Ctrl+O, Ctrl+,
+        const bool ctrlDown = ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl);
+        if (ctrlDown && ImGui::IsKeyPressed(ImGuiKey_O, false)) {
+            App::openZmxFileInZemax(logger);
+        } else if (ctrlDown && ImGui::IsKeyPressed(ImGuiKey_Comma, false)) {
+            if (menuBar) menuBar->openPreferences();
         }
 
         ctx->gui->render();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,13 @@ int main() {
 
     DockableWindowsManager wndMgr;
     wndMgr.RegisterDockableWindows(ctx->gui.get());
-    wndMgr.LoadState();
+
+    const auto& general = ctx->gui->getSettingsManager().current().general;
+    if (general.restoreWindowLayout) {
+        wndMgr.LoadState();
+    }
+    wndMgr.SetVisible(WindowID::DebugLog, general.showDebugLogOnStartup);
+
     ctx->gui->setWindowManager(&wndMgr);
 
     auto* menuBar = ctx->gui->getMenuBarController();

--- a/src/version.rc.in
+++ b/src/version.rc.in
@@ -1,0 +1,28 @@
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     @APP_VERSION_MAJOR@,@APP_VERSION_MINOR@,@APP_VERSION_PATCH@,@APP_BUILD_NUMBER@
+PRODUCTVERSION  @APP_VERSION_MAJOR@,@APP_VERSION_MINOR@,@APP_VERSION_PATCH@,@APP_BUILD_NUMBER@
+FILEFLAGSMASK   0x0000003FL
+FILEFLAGS       @APP_RC_PRERELEASE_FLAG@
+FILEOS          0x00040004L
+FILETYPE        0x00000001L
+FILESUBTYPE     0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "041904B0"
+        BEGIN
+            VALUE "CompanyName",      "d3m37r4"
+            VALUE "FileDescription",  "Advanced analysis of optical systems via DDE with Zemax"
+            VALUE "FileVersion",      "@APP_VERSION_STRING@.@APP_BUILD_NUMBER@"
+            VALUE "InternalName",     "@PROJECT_NAME@"
+            VALUE "LegalCopyright",   "Copyright (C) 2025 d3m37r4"
+            VALUE "OriginalFilename", "@PROJECT_NAME@_@APP_VERSION_STRING@_@APP_BUILD_NUMBER@.exe"
+            VALUE "ProductName",      "Zemax DDE Client"
+            VALUE "ProductVersion",   "@APP_VERSION_STRING@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x419, 1200
+    END
+END


### PR DESCRIPTION
## Summary

27 commits from dev branch:

### UI/UX
- Win11 Fluent-inspired themes (Light + Dark)
- Per-window DDE request timeout configuration (9 independent timeouts)
- Preferences: auto-size sidebar with draggable splitter, split footer (Reset / Cancel+Save)
- Files section showing config paths (imgui.ini, windows.json, settings.json)
- DPI scaling utilities (DpiScale, SetDpiScaledWindowSize)
- SectionHeader utility, BASE_POPUP_BUTTON_WIDTH constant

### Popup refactoring
- All 4 popups unified to Pattern B (m_open + open/close/isOpen + render())
- ConnectDDEPopup migrated to Pattern B
- Fix reset confirm modal (render call moved before EndPopup)

### DDE
- All hardcoded DDE timeouts (2000/1000ms) replaced with configurable per-request values
- Per-window timeouts: Optical System Info, Surface Profile Inspector, Surface Irregularity Map
- Backward-compatible settings.json migration from legacy timeout fields

### Dark theme fixes
- Remove dead code (applyTheme(bool), toggleTheme())
- Title bar now syncs with theme at runtime via DwmSetWindowAttribute

### Encoding fix
- Fix Cyrillic characters garbled in ConnectDDE window selector
- Add `wstring_to_utf8()` utility for proper UTF-16 to UTF-8 conversion (replaces naive wchar_t truncation)