### PR TITLE
feat: DDE connection health check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(SOURCES
     ${SRC_DIR}/gui/ui_operation_monitor.cpp
     ${SRC_DIR}/gui/utils.cpp
     ${SRC_DIR}/gui/popups/about_dialog.cpp
+    ${SRC_DIR}/gui/popups/connection_lost_dialog.cpp
     ${SRC_DIR}/gui/popups/preferences_dialog.cpp
     ${SRC_DIR}/gui/popups/update_checker.cpp
     ${SRC_DIR}/gui/popups/connect_dde.cpp

--- a/src/app/settings.cpp
+++ b/src/app/settings.cpp
@@ -73,7 +73,6 @@ namespace app {
 
         dde.connectionTimeoutMs = 5000;
         dde.maxRetryCount = 3;
-        dde.autoReconnect = true;
         dde.maxConnections = 4;
 
         dde.getNameTimeoutMs = 2000;
@@ -154,8 +153,6 @@ namespace app {
                 dde.maxRetryCount = clampValue(
                     d["maxRetryCount"].get<int>(), kMinRetries, kMaxRetries, 3);
             }
-            if (d.contains("autoReconnect") && d["autoReconnect"].is_boolean())
-                dde.autoReconnect = d["autoReconnect"].get<bool>();
             if (d.contains("maxConnections") && d["maxConnections"].is_number_integer()) {
                 dde.maxConnections = clampValue(
                     d["maxConnections"].get<int>(), kMinConnections, kMaxConnections, 4);
@@ -247,7 +244,6 @@ namespace app {
 
         j["dde"]["connectionTimeoutMs"] = dde.connectionTimeoutMs;
         j["dde"]["maxRetryCount"]       = dde.maxRetryCount;
-        j["dde"]["autoReconnect"]       = dde.autoReconnect;
         j["dde"]["maxConnections"]      = dde.maxConnections;
 
         j["dde"]["getNameTimeoutMs"]              = dde.getNameTimeoutMs;

--- a/src/app/settings.h
+++ b/src/app/settings.h
@@ -28,7 +28,6 @@ namespace app {
     struct DDESettings {
         int connectionTimeoutMs = 5000;
         int maxRetryCount = 3;
-        bool autoReconnect = true;
         int maxConnections = 4;
 
         // Per-request timeout overrides — Initial Data Load (startup).

--- a/src/dde/client.h
+++ b/src/dde/client.h
@@ -48,6 +48,17 @@ namespace ZemaxDDE {
             void pumpMessages();
             void processTimeouts();
 
+            /// Checks if the Zemax server window is still alive.
+            /// Call once per frame to detect connection loss.
+            void checkConnectionHealth();
+
+            using OnConnectionLostCallback = std::function<void(const std::string& reason)>;
+            void setOnConnectionLostCallback(OnConnectionLostCallback callback);
+
+            /// Sets the server PID for connection health checks.
+            void setServerPid(DWORD pid) noexcept { m_serverPid = pid; }
+            [[nodiscard]] DWORD getServerPid() const noexcept { return m_serverPid; }
+
             /// Default timeout/retries used by submitRequest when caller passes
             /// the sentinel value (0 / -1). Updated by DDEConnectionManager from
             /// AppSettings.dde at runtime.
@@ -108,11 +119,15 @@ namespace ZemaxDDE {
             /// Resets active request and advances to the next in queue.
             void finishRequest();
             void checkDDEConnection();
+            /// Handles connection loss by notifying callbacks and cleaning up.
+            void handleConnectionLost(const std::string& reason);
 
             HWND m_hwndZemaxServer = nullptr;
             HWND m_hwndZemaxClient = nullptr;
+            DWORD m_serverPid = 0;
             Logger& m_logger;
             OnDDEConnectedCallback m_onDDEConnected;
+            OnConnectionLostCallback m_onConnectionLost;
             OpticalSystemData m_opticalSystem;
             SurfaceData m_tolerancedSurface;
             SurfaceData m_nominalSurface;

--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -25,6 +25,10 @@ namespace ZemaxDDE {
         m_onDDEConnected = callback;
     }
 
+    void ZemaxDDEClient::setOnConnectionLostCallback(OnConnectionLostCallback callback) {
+        m_onConnectionLost = callback;
+    }
+
     void ZemaxDDEClient::initiateDDE() {
         if (m_hwndZemaxServer != nullptr) {
             m_logger.addLog("[DDE] DDE already connected. Skipping initiate.");
@@ -250,6 +254,59 @@ namespace ZemaxDDE {
         }
     }
 
+    void ZemaxDDEClient::checkConnectionHealth() {
+        if (!m_hwndZemaxServer) return;
+
+        if (!IsWindow(m_hwndZemaxServer)) {
+            handleConnectionLost("Zemax window handle is no longer valid");
+            return;
+        }
+
+        DWORD currentPid = 0;
+        GetWindowThreadProcessId(m_hwndZemaxServer, &currentPid);
+        if (m_serverPid != 0 && currentPid != m_serverPid) {
+            handleConnectionLost("Zemax process ID changed (process restarted?)");
+            return;
+        }
+
+        if (currentPid != 0) {
+            HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, currentPid);
+            if (hProcess) {
+                DWORD exitCode;
+                if (GetExitCodeProcess(hProcess, &exitCode) && exitCode != STILL_ACTIVE) {
+                    handleConnectionLost("Zemax process has exited");
+                    CloseHandle(hProcess);
+                    return;
+                }
+                CloseHandle(hProcess);
+            }
+        }
+    }
+
+    void ZemaxDDEClient::handleConnectionLost(const std::string& reason) {
+        m_logger.addLog(std::format("[DDE] ERROR: Connection lost — {}", reason));
+        m_hwndZemaxServer = nullptr;
+
+        if (m_activeRequest) {
+            if (m_activeRequest->onError) {
+                m_activeRequest->onError("Connection lost: " + reason);
+            }
+            m_activeRequest.reset();
+        }
+
+        while (!m_requestQueue.empty()) {
+            auto& req = m_requestQueue.front();
+            if (req.onError) {
+                req.onError("Connection lost: " + reason);
+            }
+            m_requestQueue.pop_front();
+        }
+
+        if (m_onConnectionLost) {
+            m_onConnectionLost(reason);
+        }
+    }
+
     void ZemaxDDEClient::terminateDDE() {
         if (m_hwndZemaxServer) {
             PostMessageW(m_hwndZemaxServer, WM_DDE_TERMINATE, (WPARAM)m_hwndZemaxClient, 0L);
@@ -289,6 +346,10 @@ namespace ZemaxDDE {
 
                     m_hwndZemaxServer = reinterpret_cast<HWND>(wParam);
 
+                    DWORD pid = 0;
+                    GetWindowThreadProcessId(m_hwndZemaxServer, &pid);
+                    m_serverPid = pid;
+
                     if (m_initialDataLoad) {
                         m_initialDataLoad->start();
                     }
@@ -301,6 +362,12 @@ namespace ZemaxDDE {
                     #endif
                 }
 
+                return 0;
+            }
+            case WM_DDE_TERMINATE: {
+                // Server initiated connection termination
+                m_logger.addLog("[DDE] Received WM_DDE_TERMINATE from server");
+                handleConnectionLost("Server sent WM_DDE_TERMINATE");
                 return 0;
             }
             case WM_DDE_DATA: {

--- a/src/dde/dde_connection_manager.cpp
+++ b/src/dde/dde_connection_manager.cpp
@@ -12,10 +12,10 @@ namespace {
 
     std::string ws2s(const std::wstring& wstr) {
         if (wstr.empty()) return {};
-        int len = WideCharToMultiByte(CP_ACP, 0, wstr.data(), static_cast<int>(wstr.size()),
+        int len = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), static_cast<int>(wstr.size()),
             nullptr, 0, nullptr, nullptr);
         std::string result(static_cast<size_t>(len), '\0');
-        WideCharToMultiByte(CP_ACP, 0, wstr.data(), static_cast<int>(wstr.size()),
+        WideCharToMultiByte(CP_UTF8, 0, wstr.data(), static_cast<int>(wstr.size()),
             result.data(), len, nullptr, nullptr);
         return result;
     }

--- a/src/dde/dde_connection_manager.cpp
+++ b/src/dde/dde_connection_manager.cpp
@@ -113,6 +113,16 @@ int DDEConnectionManager::connectToZemax(HWND targetHwnd, const std::wstring& ti
     DWORD pid = 0;
     GetWindowThreadProcessId(targetHwnd, &pid);
     conn.serverPid = pid;
+    conn.client->setServerPid(pid);
+
+    // Set up connection lost callback to flag for GUI popup
+    conn.client->setOnConnectionLostCallback([this, idx](const std::string& reason) {
+        if (idx >= 0 && idx < MAX_CONNECTIONS && m_connections[idx].isConnected) {
+            m_connectionLostIndex = idx;
+            m_connectionLostReason = reason;
+            m_logger.addLog(std::format("[DDE] Connection lost flagged for slot {}: {}", idx, reason));
+        }
+    });
 
     m_activeIndex = idx;
 
@@ -221,6 +231,47 @@ void DDEConnectionManager::processAllTimeouts() {
     }
 }
 
+void DDEConnectionManager::checkAllConnectionHealth() {
+    // If already flagged and not yet handled by GUI, skip re-checking
+    if (m_connectionLostIndex >= 0) return;
+
+    for (int i = 0; i < MAX_CONNECTIONS; ++i) {
+        auto& conn = m_connections[i];
+        if (!conn.isConnected || !conn.client) continue;
+
+        if (!IsWindow(conn.hwndServer)) {
+            m_connectionLostIndex = i;
+            m_connectionLostReason = "Zemax window handle is no longer valid";
+            m_logger.addLog(std::format("[DDE] Connection lost: slot {} — {}", i, m_connectionLostReason));
+            return;
+        }
+
+        DWORD currentPid = 0;
+        GetWindowThreadProcessId(conn.hwndServer, &currentPid);
+        if (conn.serverPid != 0 && currentPid != conn.serverPid) {
+            m_connectionLostIndex = i;
+            m_connectionLostReason = "Zemax process ID changed (process restarted?)";
+            m_logger.addLog(std::format("[DDE] Connection lost: slot {} — {}", i, m_connectionLostReason));
+            return;
+        }
+
+        if (currentPid != 0) {
+            HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, currentPid);
+            if (hProcess) {
+                DWORD exitCode;
+                if (GetExitCodeProcess(hProcess, &exitCode) && exitCode != STILL_ACTIVE) {
+                    m_connectionLostIndex = i;
+                    m_connectionLostReason = "Zemax process has exited";
+                    m_logger.addLog(std::format("[DDE] Connection lost: slot {} — {}", i, m_connectionLostReason));
+                    CloseHandle(hProcess);
+                    return;
+                }
+                CloseHandle(hProcess);
+            }
+        }
+    }
+}
+
 std::vector<app::ZemaxWindowInfo> DDEConnectionManager::enumerateAvailableTargets() {
     return app::ZemaxWindowEnumerator::enumerate();
 }
@@ -252,11 +303,6 @@ void DDEConnectionManager::setMaxConnections(int n) {
     if (n > MAX_CONNECTIONS) n = MAX_CONNECTIONS;
     m_maxConnections = n;
     m_logger.addLog(std::format("[DDE] Max connections set to {}", n));
-}
-
-void DDEConnectionManager::setAutoReconnect(bool enabled) {
-    m_autoReconnect = enabled;
-    m_logger.addLog(std::format("[DDE] Auto-reconnect {}", enabled ? "enabled" : "disabled"));
 }
 
 void DDEConnectionManager::setGetNameTimeoutMs(DWORD ms) {

--- a/src/dde/dde_connection_manager.h
+++ b/src/dde/dde_connection_manager.h
@@ -34,6 +34,18 @@ public:
     void pumpAllMessages();
     void processAllTimeouts();
 
+    /// Checks health of all active connections and disconnects any that are lost.
+    void checkAllConnectionHealth();
+
+    /// Returns true if a connection was lost and needs user attention.
+    [[nodiscard]] bool hasConnectionLost() const noexcept { return m_connectionLostIndex >= 0; }
+    /// Returns the index of the lost connection (-1 if none).
+    [[nodiscard]] int getConnectionLostIndex() const noexcept { return m_connectionLostIndex; }
+    /// Returns the reason for the connection loss.
+    [[nodiscard]] const std::string& getConnectionLostReason() const noexcept { return m_connectionLostReason; }
+    /// Clears the connection lost state (called after user handles it in popup).
+    void clearConnectionLost() noexcept { m_connectionLostIndex = -1; m_connectionLostReason.clear(); }
+
     std::vector<app::ZemaxWindowInfo> enumerateAvailableTargets();
 
     // Runtime-configurable DDE settings. Forwarded to active clients by
@@ -41,7 +53,6 @@ public:
     void setDefaultTimeoutMs(DWORD ms);
     void setDefaultRetries(int n);
     void setMaxConnections(int n);
-    void setAutoReconnect(bool enabled);
 
     void setGetNameTimeoutMs(DWORD ms);
     void setGetFileTimeoutMs(DWORD ms);
@@ -56,7 +67,6 @@ public:
     [[nodiscard]] DWORD getDefaultTimeoutMs() const;
     [[nodiscard]] int   getDefaultRetries()   const;
     [[nodiscard]] int   getMaxConnections()   const { return m_maxConnections; }
-    [[nodiscard]] bool  getAutoReconnect()    const { return m_autoReconnect; }
 
     [[nodiscard]] DWORD getGetNameTimeoutMs() const { return m_getNameTimeoutMs; }
     [[nodiscard]] DWORD getGetFileTimeoutMs() const { return m_getFileTimeoutMs; }
@@ -73,7 +83,6 @@ private:
     Logger& m_logger;
     int m_activeIndex = -1;
     int m_maxConnections = MAX_CONNECTIONS;
-    bool m_autoReconnect = true;
 
     DWORD m_getNameTimeoutMs = 2000;
     DWORD m_getFileTimeoutMs = 2000;
@@ -91,4 +100,7 @@ private:
     void propagateDefaultTimeout(DWORD ms);
     void propagateDefaultRetries(int n);
     void propagatePerRequestTimeouts();
+
+    int m_connectionLostIndex = -1;
+    std::string m_connectionLostReason;
 };

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -50,6 +50,10 @@ namespace gui {
     inline constexpr ImVec2 UPDATE_POPUP_DEFAULT_SIZE = ImVec2(340.0f, 120.0f);
     inline constexpr ImVec2 UPDATE_POPUP_MIN_SIZE     = ImVec2(340.0f, 120.0f);
 
+    // Connection Lost popup
+    inline constexpr ImVec2 CONNECTION_LOST_POPUP_DEFAULT_SIZE = ImVec2(380.0f, 140.0f);
+    inline constexpr ImVec2 CONNECTION_LOST_POPUP_MIN_SIZE     = ImVec2(380.0f, 140.0f);
+
     // Preferences dialog layout
     inline constexpr ImVec2 PREFERENCES_WINDOW_DEFAULT_SIZE = ImVec2(660.0f, 280.0f);
     inline constexpr ImVec2 PREFERENCES_WINDOW_MIN_SIZE     = ImVec2(660.0f, 280.0f);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -19,6 +19,7 @@
 #include "gui/graphics_backend.h"
 #include "windows_dockable/debug_log.h"
 #include "gui/popups/about_dialog.h"
+#include "gui/popups/connection_lost_dialog.h"
 #include "gui/popups/preferences_dialog.h"
 #include "gui/popups/update_checker.h"
 #include "gui/settings_manager.h"
@@ -42,6 +43,7 @@ namespace gui {
             void renderAboutPopup();
             void renderUpdatesPopup();
             void renderPreferencesDialog();
+            void renderConnectionLostPopup();
 
             SettingsManager& getSettingsManager() noexcept { return *m_settingsManager; }
             UpdateChecker* getUpdateChecker() const noexcept { return m_updateChecker.get(); }
@@ -75,6 +77,7 @@ namespace gui {
             std::unique_ptr<DDEStatus> m_ddeStatusRenderer;
             std::unique_ptr<DebugLog> m_debugLogRenderer;
             std::unique_ptr<AboutDialog> m_aboutDialog;
+            std::unique_ptr<ConnectionLostDialog> m_connectionLostDialog;
             std::unique_ptr<UpdateChecker> m_updateChecker;
             std::unique_ptr<SettingsManager>   m_settingsManager;
             std::unique_ptr<PreferencesDialog> m_preferencesDialog;

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -35,6 +35,7 @@ namespace gui {
     m_ddeStatusRenderer = std::make_unique<DDEStatus>(m_ddeConnectionManager);
     m_debugLogRenderer = std::make_unique<DebugLog>();
     m_aboutDialog        = std::make_unique<AboutDialog>();
+    m_connectionLostDialog = std::make_unique<ConnectionLostDialog>();
     m_updateChecker      = std::make_unique<UpdateChecker>();
     m_settingsManager   = std::make_unique<SettingsManager>();
     m_preferencesDialog = std::make_unique<PreferencesDialog>(*m_settingsManager);
@@ -64,6 +65,12 @@ void GuiManager::render() {
     // Refresh active DDE client in case connection changed via DDE Status UI
     m_zemaxDDEClient = m_ddeConnectionManager ? m_ddeConnectionManager->getActiveClient() : nullptr;
     m_uiOpMonitor.setMonitor(m_zemaxDDEClient ? m_zemaxDDEClient->getOperationMonitor() : nullptr);
+
+    // Process DDE timeouts and check connection health
+    if (m_ddeConnectionManager) {
+        m_ddeConnectionManager->processAllTimeouts();
+        m_ddeConnectionManager->checkAllConnectionHealth();
+    }
 
     m_graphics.beginFrame();
     if (m_menuBarController) {
@@ -201,6 +208,7 @@ void GuiManager::render() {
     renderUpdatesPopup();
     renderAboutPopup();
     renderPreferencesDialog();
+    renderConnectionLostPopup();
 
     m_uiOpMonitor.renderGlobalStatusBar();
 
@@ -232,6 +240,29 @@ void GuiManager::renderUpdatesPopup() {
 void GuiManager::renderPreferencesDialog() {
     if (m_preferencesDialog) {
         m_preferencesDialog->render();
+    }
+}
+
+void GuiManager::renderConnectionLostPopup() {
+    if (!m_ddeConnectionManager) return;
+
+    // Check if a connection was lost and the popup isn't already open
+    if (m_ddeConnectionManager->hasConnectionLost() && !m_connectionLostDialog->isOpen()) {
+        int lostIdx = m_ddeConnectionManager->getConnectionLostIndex();
+        std::string reason = m_ddeConnectionManager->getConnectionLostReason();
+
+        // Auto-disconnect the lost connection
+        if (lostIdx >= 0) {
+            m_ddeConnectionManager->disconnect(lostIdx);
+        }
+        m_ddeConnectionManager->clearConnectionLost();
+        m_logger.addLog(std::format("[DDE] Connection lost, auto-disconnected: {}", reason));
+
+        m_connectionLostDialog->open(reason);
+    }
+
+    if (m_connectionLostDialog) {
+        m_connectionLostDialog->render();
     }
 }
 

--- a/src/gui/popups/connection_lost_dialog.cpp
+++ b/src/gui/popups/connection_lost_dialog.cpp
@@ -1,0 +1,44 @@
+#include "gui/popups/connection_lost_dialog.h"
+#include "gui/constants.h"
+#include "gui/imgui_utils.h"
+#include "lib/imgui/imgui.h"
+
+namespace gui {
+    void ConnectionLostDialog::open(const std::string& reason) {
+        m_reason = reason;
+        m_open = true;
+    }
+
+    void ConnectionLostDialog::close() noexcept {
+        m_open = false;
+    }
+
+    void ConnectionLostDialog::render() {
+        if (m_open && !ImGui::IsPopupOpen("Connection Lost")) {
+            ImGui::OpenPopup("Connection Lost");
+        }
+
+        ImGuiUtils::CenterNextWindow();
+        ImGuiUtils::SetDpiScaledWindowConstraints(CONNECTION_LOST_POPUP_MIN_SIZE.x, CONNECTION_LOST_POPUP_MIN_SIZE.y);
+        ImGuiUtils::SetDpiScaledWindowSize(CONNECTION_LOST_POPUP_DEFAULT_SIZE);
+
+        if (!ImGui::BeginPopupModal("Connection Lost", &m_open, ImGuiWindowFlags_NoCollapse)) {
+            return;
+        }
+
+        ImGui::BeginChild("##connection_lost_body", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()), ImGuiChildFlags_Borders);
+
+        ImGui::TextWrapped("Connection to Zemax has been lost.");
+        ImGui::TextWrapped("%s", m_reason.c_str());
+
+        ImGui::EndChild();
+
+        float okBtnW = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
+        ImGui::SetCursorPosX((ImGui::GetWindowSize().x - okBtnW) * 0.5f);
+        if (ImGui::Button("OK", ImVec2(okBtnW, 0))) {
+            close();
+        }
+
+        ImGui::EndPopup();
+    }
+}

--- a/src/gui/popups/connection_lost_dialog.h
+++ b/src/gui/popups/connection_lost_dialog.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+namespace gui {
+    class ConnectionLostDialog {
+        public:
+            void open(const std::string& reason);
+            void close() noexcept;
+            [[nodiscard]] bool isOpen() const noexcept { return m_open; }
+
+            void render();
+
+        private:
+            bool m_open = false;
+            std::string m_reason;
+    };
+}

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -151,10 +151,6 @@ namespace gui {
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Upper bound on parallel DDE clients kept open by the manager.");
         }
-
-        if (ImGui::Checkbox("Auto-reconnect on drop", &m_working.dde.autoReconnect)) {
-            applyWorkingDDE();
-        }
     }
 
     void PreferencesDialog::renderSectionDDEPerformance() {

--- a/src/gui/settings_manager.cpp
+++ b/src/gui/settings_manager.cpp
@@ -59,7 +59,6 @@ namespace gui {
         m_ddeConnectionManager->setDefaultTimeoutMs(static_cast<DWORD>(dde.connectionTimeoutMs));
         m_ddeConnectionManager->setDefaultRetries(dde.maxRetryCount);
         m_ddeConnectionManager->setMaxConnections(dde.maxConnections);
-        m_ddeConnectionManager->setAutoReconnect(dde.autoReconnect);
 
         m_ddeConnectionManager->setGetNameTimeoutMs(static_cast<DWORD>(dde.getNameTimeoutMs));
         m_ddeConnectionManager->setGetFileTimeoutMs(static_cast<DWORD>(dde.getFileTimeoutMs));

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -3,6 +3,7 @@
 #include "windows_dockable/dde_status.h"
 #include "gui/constants.h"
 #include "gui/theme_manager.h"
+#include "dde/utils.h"
 #include "lib/imgui/imgui.h"
 #include "logger/logger.h"
 
@@ -53,7 +54,7 @@ namespace gui {
             for (int i = 0; i < DDEConnectionManager::MAX_CONNECTIONS; ++i) {
                 auto* conn = m_connectionManager->getConnection(i);
                 if (!conn || !conn->isConnected) continue;
-                std::string title(conn->serverTitle.begin(), conn->serverTitle.end());
+                std::string title = ZemaxDDE::wstring_to_utf8(conn->serverTitle);
                 std::string itemLabel = std::format("[{}] {}", i, title);
                 if (i == activeIdx) {
                     preview = itemLabel;
@@ -65,7 +66,7 @@ namespace gui {
                 for (int i = 0; i < DDEConnectionManager::MAX_CONNECTIONS; ++i) {
                     auto* conn = m_connectionManager->getConnection(i);
                     if (!conn || !conn->isConnected) continue;
-                    std::string title(conn->serverTitle.begin(), conn->serverTitle.end());
+                    std::string title = ZemaxDDE::wstring_to_utf8(conn->serverTitle);
                     std::string itemLabel = std::format("[{}] {}", i, title);
 
                     bool isSelected = (i == activeIdx);

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -24,11 +24,25 @@ namespace gui {
             if (conn && conn->isConnected) ++connectionCount;
         }
         int activeIdx = m_connectionManager->getActiveIndex();
+        bool connectionLost = m_connectionManager->hasConnectionLost();
 
         {
             const bool connected = (activeIdx >= 0);
             const char* label = "Zemax DDE Status:";
-            const char* value = connected ? "Connected" : "Disconnected";
+            const char* value;
+            ImVec4 valueColor;
+
+            const auto& sem = m_themeManager->semantic();
+            if (connectionLost) {
+                value = "Connection Lost";
+                valueColor = ImVec4(1.0f, 0.6f, 0.0f, 1.0f); // warning/orange
+            } else if (connected) {
+                value = "Connected";
+                valueColor = sem.success;
+            } else {
+                value = "Disconnected";
+                valueColor = sem.danger;
+            }
 
             float availableWidth = ImGui::GetContentRegionAvail().x;
             float labelWidth = ImGui::CalcTextSize(label).x;
@@ -40,8 +54,7 @@ namespace gui {
             ImGui::TextUnformatted(label);
             ImGui::SameLine(0.0f, 4.0f);
 
-            const auto& sem = m_themeManager->semantic();
-            ImGui::PushStyleColor(ImGuiCol_Text, connected ? sem.success : sem.danger);
+            ImGui::PushStyleColor(ImGuiCol_Text, valueColor);
             ImGui::TextUnformatted(value);
             ImGui::PopStyleColor();
         }
@@ -91,7 +104,7 @@ namespace gui {
 
         ImGui::Separator();
 
-        bool connected = (activeIdx >= 0);
+        bool connected = (activeIdx >= 0) || connectionLost;
 
         // Connect/disconnect button uses semantic danger/success tokens (not ImGuiCol_Button*)
         // so the action remains visually unambiguous regardless of the active theme.
@@ -105,7 +118,12 @@ namespace gui {
 
         if (ImGui::Button(connected ? "Disconnect from Zemax" : "Connect to Zemax", ImVec2(-1.0f, 0.0f))) {
             if (connected) {
-                m_connectionManager->disconnect(activeIdx);
+                if (connectionLost) {
+                    m_connectionManager->clearConnectionLost();
+                }
+                if (activeIdx >= 0) {
+                    m_connectionManager->disconnect(activeIdx);
+                }
                 logger.addLog("[DDE] Disconnected from Zemax");
             } else {
                 m_connectPopup->open();


### PR DESCRIPTION
## Detect Zemax process exit and prevent app crash/freeze

When the user closes Zemax (OpticStudio), the app would previously freeze or crash because the DDE connection was never properly terminated.

### What this PR does

- **Three-stage health check per frame**: `IsWindow` + PID comparison + `GetExitCodeProcess` to detect closed/restarted Zemax
- **Handle `WM_DDE_TERMINATE`** from server for graceful DDE shutdown
- **Auto-disconnect** lost connections with a "Connection Lost" popup (message + reason + OK)
- **Three-color DDE status indicator**: Connected (green) / Connection Lost (orange) / Disconnected (red)
- **Process DDE timeouts every frame** (`processAllTimeouts` + `checkAllConnectionHealth` in `GuiManager::render`)
- **Fix UTF-8 encoding** in logs and GUI dropdown (was using `CP_ACP` instead of `CP_UTF8`, and raw `wchar_t->char` truncation)
- **Remove dead `autoReconnect` code** (checkbox in Preferences did nothing)

### Affected files

| Area | Files |
|------|-------|
| DDE core | `client.h`, `client_connection.cpp`, `dde_connection_manager.{h,cpp}` |
| GUI | `gui_manager.cpp`, `gui.h`, `dde_status.cpp`, `constants.h` |
| New | `connection_lost_dialog.{h,cpp}` |
| Cleanup | `settings.{h,cpp}`, `settings_manager.cpp`, `preferences_dialog.cpp` |

### Testing

1. Connect to Zemax
2. Close Zemax window (or kill the process)
3. App should show "Connection Lost" popup and auto-disconnect
4. DDE Status should turn red (Disconnected)
5. Reconnect via "Connect to Zemax" button should work normally