### PR TITLE
fix: replace DDE Connection sliders with InputInt fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ set(SOURCES
     ${SRC_DIR}/gui/popups/about_dialog.cpp
     ${SRC_DIR}/gui/popups/connection_lost_dialog.cpp
     ${SRC_DIR}/gui/popups/preferences_dialog.cpp
+    ${SRC_DIR}/gui/popups/reset_confirm_dialog.cpp
     ${SRC_DIR}/gui/popups/update_checker.cpp
     ${SRC_DIR}/gui/popups/connect_dde.cpp
     ${SRC_DIR}/gui/dockable_windows_manager.cpp

--- a/src/app/settings.cpp
+++ b/src/app/settings.cpp
@@ -13,10 +13,10 @@ namespace app {
         constexpr int kMaxTimeoutMs = 30000;
         constexpr int kMinRequestTimeoutMs = 100;
         constexpr int kMaxRequestTimeoutMs = 30000;
-        constexpr int kMinRetries = 1;
+        constexpr int kMinRetries = 0;
         constexpr int kMaxRetries = 10;
         constexpr int kMinConnections = 1;
-        constexpr int kMaxConnections = 4;
+        constexpr int kMaxConnections = 16;
         constexpr float kMinLineWeight = 1.0f;
         constexpr float kMaxLineWeight = 3.0f;
         constexpr float kMinMarkerSize = 0.0f;

--- a/src/dde/dde_connection_manager.cpp
+++ b/src/dde/dde_connection_manager.cpp
@@ -291,61 +291,75 @@ int DDEConnectionManager::getDefaultRetries() const {
 }
 
 void DDEConnectionManager::setDefaultTimeoutMs(DWORD ms) {
+    if (ms == m_defaultTimeoutMs) return;
+    m_defaultTimeoutMs = ms;
     propagateDefaultTimeout(ms);
 }
 
 void DDEConnectionManager::setDefaultRetries(int n) {
+    if (n == m_defaultRetries) return;
+    m_defaultRetries = n;
     propagateDefaultRetries(n);
 }
 
 void DDEConnectionManager::setMaxConnections(int n) {
     if (n < 1) n = 1;
     if (n > MAX_CONNECTIONS) n = MAX_CONNECTIONS;
+    if (n == m_maxConnections) return;
     m_maxConnections = n;
     m_logger.addLog(std::format("[DDE] Max connections set to {}", n));
 }
 
 void DDEConnectionManager::setGetNameTimeoutMs(DWORD ms) {
+    if (ms == m_getNameTimeoutMs) return;
     m_getNameTimeoutMs = ms;
     propagatePerRequestTimeouts();
 }
 
 void DDEConnectionManager::setGetFileTimeoutMs(DWORD ms) {
+    if (ms == m_getFileTimeoutMs) return;
     m_getFileTimeoutMs = ms;
     propagatePerRequestTimeouts();
 }
 
 void DDEConnectionManager::setGetSystemTimeoutMs(DWORD ms) {
+    if (ms == m_getSystemTimeoutMs) return;
     m_getSystemTimeoutMs = ms;
     propagatePerRequestTimeouts();
 }
 
 void DDEConnectionManager::setGetFieldTimeoutMs(DWORD ms) {
+    if (ms == m_getFieldTimeoutMs) return;
     m_getFieldTimeoutMs = ms;
     propagatePerRequestTimeouts();
 }
 
 void DDEConnectionManager::setGetWaveTimeoutMs(DWORD ms) {
+    if (ms == m_getWaveTimeoutMs) return;
     m_getWaveTimeoutMs = ms;
     propagatePerRequestTimeouts();
 }
 
 void DDEConnectionManager::setGetSurfaceDataProfileTimeoutMs(DWORD ms) {
+    if (ms == m_getSurfaceDataProfileTimeoutMs) return;
     m_getSurfaceDataProfileTimeoutMs = ms;
     propagatePerRequestTimeouts();
 }
 
 void DDEConnectionManager::setGetSagProfileTimeoutMs(DWORD ms) {
+    if (ms == m_getSagProfileTimeoutMs) return;
     m_getSagProfileTimeoutMs = ms;
     propagatePerRequestTimeouts();
 }
 
 void DDEConnectionManager::setGetSurfaceDataMapTimeoutMs(DWORD ms) {
+    if (ms == m_getSurfaceDataMapTimeoutMs) return;
     m_getSurfaceDataMapTimeoutMs = ms;
     propagatePerRequestTimeouts();
 }
 
 void DDEConnectionManager::setGetSagMapTimeoutMs(DWORD ms) {
+    if (ms == m_getSagMapTimeoutMs) return;
     m_getSagMapTimeoutMs = ms;
     propagatePerRequestTimeouts();
 }

--- a/src/dde/dde_connection_manager.h
+++ b/src/dde/dde_connection_manager.h
@@ -83,6 +83,8 @@ private:
     Logger& m_logger;
     int m_activeIndex = -1;
     int m_maxConnections = MAX_CONNECTIONS;
+    DWORD m_defaultTimeoutMs = 5000;
+    int m_defaultRetries = 3;
 
     DWORD m_getNameTimeoutMs = 2000;
     DWORD m_getFileTimeoutMs = 2000;

--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -40,6 +40,7 @@ namespace gui {
     inline constexpr const char* ABOUT_POPUP_NAME        = "About";
     inline constexpr const char* UPDATE_POPUP_NAME       = "Check for Updates";
     inline constexpr const char* PREFERENCES_POPUP_NAME  = "Preferences";
+    inline constexpr const char* RESET_CONFIRM_POPUP_NAME = "Reset Preferences?";
     inline constexpr const char* CONNECT_DDE_POPUP_NAME  = "Connect to Zemax \xe2\x80\x93 select a window";
 
     // About popup
@@ -53,6 +54,10 @@ namespace gui {
     // Connection Lost popup
     inline constexpr ImVec2 CONNECTION_LOST_POPUP_DEFAULT_SIZE = ImVec2(380.0f, 140.0f);
     inline constexpr ImVec2 CONNECTION_LOST_POPUP_MIN_SIZE     = ImVec2(380.0f, 140.0f);
+
+    // Reset Preferences confirm popup
+    inline constexpr ImVec2 RESET_CONFIRM_DEFAULT_SIZE = ImVec2(360.0f, 120.0f);
+    inline constexpr ImVec2 RESET_CONFIRM_MIN_SIZE     = ImVec2(360.0f, 120.0f);
 
     // Preferences dialog layout
     inline constexpr ImVec2 PREFERENCES_WINDOW_DEFAULT_SIZE = ImVec2(660.0f, 280.0f);

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -6,25 +6,29 @@
 #include "app/config_path.h"
 #include "gui/constants.h"
 #include "gui/imgui_utils.h"
+#include "gui/popups/reset_confirm_dialog.h"
 #include "gui/settings_manager.h"
 #include "lib/imgui/imgui.h"
 
 namespace gui {
 
     PreferencesDialog::PreferencesDialog(SettingsManager& settings) noexcept
-        : m_settings(settings) {}
+        : m_settings(settings) {
+        m_resetConfirmDialog = std::make_unique<ResetConfirmDialog>();
+        m_resetConfirmDialog->setOnReset([this]() { onReset(); });
+    }
 
     void PreferencesDialog::open() noexcept {
         m_working = m_settings.current();
         m_loaded  = m_settings.current();
         m_section = Section::General;
-        m_confirmReset = false;
+        m_resetConfirmDialog->close();
         m_open = true;
     }
 
     void PreferencesDialog::close() noexcept {
         m_open = false;
-        m_confirmReset = false;
+        m_resetConfirmDialog->close();
     }
 
     void PreferencesDialog::render() {
@@ -33,7 +37,6 @@ namespace gui {
         }
 
         ImGuiUtils::CenterNextWindow();
-
         ImGuiUtils::SetDpiScaledWindowConstraints(PREFERENCES_WINDOW_MIN_SIZE.x, PREFERENCES_WINDOW_MIN_SIZE.y);
         ImGuiUtils::SetDpiScaledWindowSize(PREFERENCES_WINDOW_DEFAULT_SIZE);
 
@@ -75,7 +78,7 @@ namespace gui {
 
         renderFooter();
 
-        renderResetConfirm();
+        m_resetConfirmDialog->render();
 
         ImGui::EndPopup();
     }
@@ -266,7 +269,7 @@ namespace gui {
         float saveBtnW    = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
 
         if (ImGui::Button("Reset", ImVec2(resetBtnW, 0))) {
-            m_confirmReset = true;
+            m_resetConfirmDialog->open();
         }
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Discard all changes and restore factory defaults.");
@@ -289,38 +292,6 @@ namespace gui {
         }
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("Persist the current values to settings.json.");
-        }
-    }
-
-    void PreferencesDialog::renderResetConfirm() {
-        if (!m_confirmReset) return;
-
-        ImGui::OpenPopup("Reset Preferences?");
-        const ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-
-        if (ImGui::BeginPopupModal("Reset Preferences?", &m_confirmReset,
-                                   ImGuiWindowFlags_AlwaysAutoResize)) {
-            ImGui::BeginChild("##reset_confirm_body",
-                              ImVec2(0, -ImGui::GetFrameHeightWithSpacing()),
-                              ImGuiChildFlags_Borders);
-            ImGui::TextUnformatted("This will reset all preferences to their factory defaults.");
-            ImGui::TextUnformatted("Unsaved changes will be lost.");
-            ImGui::EndChild();
-
-            float cancelBtnW = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
-            float resetBtnW  = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
-            const float totalW = cancelBtnW + resetBtnW + ImGui::GetStyle().ItemSpacing.x;
-            ImGui::SetCursorPosX((ImGui::GetContentRegionAvail().x - totalW) * 0.5f);
-            if (ImGui::Button("Cancel", ImVec2(cancelBtnW, 0))) {
-                m_confirmReset = false;
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Reset", ImVec2(resetBtnW, 0))) {
-                onReset();
-                m_confirmReset = false;
-            }
-            ImGui::EndPopup();
         }
     }
 

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -131,26 +131,32 @@ namespace gui {
     void PreferencesDialog::renderSectionDDE() {
         ImGuiUtils::SectionHeader("DDE Connection", "New values apply to subsequent requests only.");
 
-        if (ImGui::SliderInt("Connection timeout (ms)", &m_working.dde.connectionTimeoutMs, 1000, 30000, "%d", ImGuiSliderFlags_AlwaysClamp)) {
-            applyWorkingDDE();
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("Maximum time to wait for a single DDE round-trip.");
-        }
+        auto inputMs = [](const char* label, const char* id, int* value) {
+            ImGui::TextUnformatted(label);
+            ImGui::SameLine(ImGuiUtils::DpiScale(250.0f));
+            ImGui::SetNextItemWidth(ImGuiUtils::DpiScale(120.0f));
+            ImGui::InputInt(id, value, 0, 0);
+            ImGui::SameLine();
+            ImGui::TextUnformatted("ms");
+        };
 
-        if (ImGui::SliderInt("Max retry count", &m_working.dde.maxRetryCount, 0, 10, "%d", ImGuiSliderFlags_AlwaysClamp)) {
-            applyWorkingDDE();
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("How many times to retry a failed DDE exchange.");
-        }
+        auto inputInt = [](const char* label, const char* id, int* value) {
+            ImGui::TextUnformatted(label);
+            ImGui::SameLine(ImGuiUtils::DpiScale(250.0f));
+            ImGui::SetNextItemWidth(ImGuiUtils::DpiScale(120.0f));
+            ImGui::InputInt(id, value, 0, 0);
+        };
 
-        if (ImGui::SliderInt("Max concurrent connections", &m_working.dde.maxConnections, 1, 16, "%d", ImGuiSliderFlags_AlwaysClamp)) {
-            applyWorkingDDE();
+        if (ImGui::BeginChild("##dde_conn", ImVec2(0, 0), ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY)) {
+            ImGui::TextUnformatted("Connection");
+            ImGui::Spacing();
+            inputMs("Connection timeout", "##d timeout", &m_working.dde.connectionTimeoutMs);
+            inputInt("Max retry count", "##d retry", &m_working.dde.maxRetryCount);
+            inputInt("Max concurrent connections", "##d conns", &m_working.dde.maxConnections);
         }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip("Upper bound on parallel DDE clients kept open by the manager.");
-        }
+        ImGui::EndChild();
+
+        applyWorkingDDE();
     }
 
     void PreferencesDialog::renderSectionDDEPerformance() {
@@ -158,8 +164,8 @@ namespace gui {
 
         auto inputMs = [](const char* label, const char* id, int* value) {
             ImGui::TextUnformatted(label);
-            ImGui::SameLine(200);
-            ImGui::SetNextItemWidth(120);
+            ImGui::SameLine(ImGuiUtils::DpiScale(200.0f));
+            ImGui::SetNextItemWidth(ImGuiUtils::DpiScale(120.0f));
             ImGui::InputInt(id, value, 0, 0);
             ImGui::SameLine();
             ImGui::TextUnformatted("ms");

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -131,55 +131,59 @@ namespace gui {
     void PreferencesDialog::renderSectionDDE() {
         ImGuiUtils::SectionHeader("DDE Connection", "New values apply to subsequent requests only.");
 
-        auto inputMs = [](const char* label, const char* id, int* value) {
+        auto inputMs = [](const char* label, const char* id, int* value) -> bool {
             ImGui::TextUnformatted(label);
             ImGui::SameLine(ImGuiUtils::DpiScale(250.0f));
             ImGui::SetNextItemWidth(ImGuiUtils::DpiScale(120.0f));
-            ImGui::InputInt(id, value, 0, 0);
+            bool changed = ImGui::InputInt(id, value, 0, 0);
             ImGui::SameLine();
             ImGui::TextUnformatted("ms");
+            return changed;
         };
 
-        auto inputInt = [](const char* label, const char* id, int* value) {
+        auto inputInt = [](const char* label, const char* id, int* value) -> bool {
             ImGui::TextUnformatted(label);
             ImGui::SameLine(ImGuiUtils::DpiScale(250.0f));
             ImGui::SetNextItemWidth(ImGuiUtils::DpiScale(120.0f));
-            ImGui::InputInt(id, value, 0, 0);
+            return ImGui::InputInt(id, value, 0, 0);
         };
 
         if (ImGui::BeginChild("##dde_conn", ImVec2(0, 0), ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY)) {
             ImGui::TextUnformatted("Connection");
             ImGui::Spacing();
-            inputMs("Connection timeout", "##d timeout", &m_working.dde.connectionTimeoutMs);
-            inputInt("Max retry count", "##d retry", &m_working.dde.maxRetryCount);
-            inputInt("Max concurrent connections", "##d conns", &m_working.dde.maxConnections);
+            bool changed = false;
+            changed |= inputMs("Connection timeout", "##d timeout", &m_working.dde.connectionTimeoutMs);
+            changed |= inputInt("Max retry count", "##d retry", &m_working.dde.maxRetryCount);
+            changed |= inputInt("Max concurrent connections", "##d conns", &m_working.dde.maxConnections);
+            if (changed) applyWorkingDDE();
         }
         ImGui::EndChild();
-
-        applyWorkingDDE();
     }
 
     void PreferencesDialog::renderSectionDDEPerformance() {
         ImGuiUtils::SectionHeader("DDE Performance", "Per-request timeout overrides (ms).");
 
-        auto inputMs = [](const char* label, const char* id, int* value) {
+        auto inputMs = [](const char* label, const char* id, int* value) -> bool {
             ImGui::TextUnformatted(label);
             ImGui::SameLine(ImGuiUtils::DpiScale(200.0f));
             ImGui::SetNextItemWidth(ImGuiUtils::DpiScale(120.0f));
-            ImGui::InputInt(id, value, 0, 0);
+            bool changed = ImGui::InputInt(id, value, 0, 0);
             ImGui::SameLine();
             ImGui::TextUnformatted("ms");
+            return changed;
         };
+
+        bool changed = false;
 
         // --- Optical System Info ---
         if (ImGui::BeginChild("##perf_initdata", ImVec2(0, ImGui::GetFrameHeightWithSpacing() * 7), ImGuiChildFlags_Borders)) {
             ImGui::TextUnformatted("Optical System Info");
             ImGui::Spacing();
-            inputMs("GetName",        "##t GetName",        &m_working.dde.getNameTimeoutMs);
-            inputMs("GetFile",        "##t GetFile",        &m_working.dde.getFileTimeoutMs);
-            inputMs("GetSystem",      "##t GetSystem",      &m_working.dde.getSystemTimeoutMs);
-            inputMs("GetField",       "##t GetField",       &m_working.dde.getFieldTimeoutMs);
-            inputMs("GetWave",        "##t GetWave",        &m_working.dde.getWaveTimeoutMs);
+            changed |= inputMs("GetName",        "##t GetName",        &m_working.dde.getNameTimeoutMs);
+            changed |= inputMs("GetFile",        "##t GetFile",        &m_working.dde.getFileTimeoutMs);
+            changed |= inputMs("GetSystem",      "##t GetSystem",      &m_working.dde.getSystemTimeoutMs);
+            changed |= inputMs("GetField",       "##t GetField",       &m_working.dde.getFieldTimeoutMs);
+            changed |= inputMs("GetWave",        "##t GetWave",        &m_working.dde.getWaveTimeoutMs);
         }
         ImGui::EndChild();
 
@@ -189,8 +193,8 @@ namespace gui {
         if (ImGui::BeginChild("##perf_profile", ImVec2(0, ImGui::GetFrameHeightWithSpacing() * 4), ImGuiChildFlags_Borders)) {
             ImGui::TextUnformatted("Surface Profile Inspector");
             ImGui::Spacing();
-            inputMs("GetSurfaceData", "##t P GetSurf", &m_working.dde.getSurfaceDataProfileTimeoutMs);
-            inputMs("GetSag",         "##t P GetSag",  &m_working.dde.getSagProfileTimeoutMs);
+            changed |= inputMs("GetSurfaceData", "##t P GetSurf", &m_working.dde.getSurfaceDataProfileTimeoutMs);
+            changed |= inputMs("GetSag",         "##t P GetSag",  &m_working.dde.getSagProfileTimeoutMs);
         }
         ImGui::EndChild();
 
@@ -200,12 +204,12 @@ namespace gui {
         if (ImGui::BeginChild("##perf_map", ImVec2(0, ImGui::GetFrameHeightWithSpacing() * 4), ImGuiChildFlags_Borders)) {
             ImGui::TextUnformatted("Surface Irregularity Map");
             ImGui::Spacing();
-            inputMs("GetSurfaceData", "##t M GetSurf", &m_working.dde.getSurfaceDataMapTimeoutMs);
-            inputMs("GetSag",         "##t M GetSag",  &m_working.dde.getSagMapTimeoutMs);
+            changed |= inputMs("GetSurfaceData", "##t M GetSurf", &m_working.dde.getSurfaceDataMapTimeoutMs);
+            changed |= inputMs("GetSag",         "##t M GetSag",  &m_working.dde.getSagMapTimeoutMs);
         }
         ImGui::EndChild();
 
-        applyWorkingDDE();
+        if (changed) applyWorkingDDE();
     }
 
     void PreferencesDialog::renderSectionPlot() {

--- a/src/gui/popups/preferences_dialog.h
+++ b/src/gui/popups/preferences_dialog.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <memory>
+
 #include "app/settings.h"
+#include "gui/popups/reset_confirm_dialog.h"
 
 namespace gui {
 
@@ -36,7 +39,6 @@ namespace gui {
             void renderSidebar();
             void renderContent();
             void renderFooter();
-            void renderResetConfirm();
 
             void renderSectionGeneral();
             void renderSectionAppearance();
@@ -55,12 +57,12 @@ namespace gui {
             void onReset();
 
             SettingsManager& m_settings;
+            std::unique_ptr<ResetConfirmDialog> m_resetConfirmDialog;
             app::AppSettings m_working;
             app::AppSettings m_loaded;
             Section m_section = Section::General;
             float m_sidebarWidth = 0.0f;
             bool m_open = false;
-            bool m_confirmReset = false;
     };
 
 } // namespace gui

--- a/src/gui/popups/reset_confirm_dialog.cpp
+++ b/src/gui/popups/reset_confirm_dialog.cpp
@@ -1,0 +1,58 @@
+#include "gui/popups/reset_confirm_dialog.h"
+
+#include "gui/constants.h"
+#include "gui/imgui_utils.h"
+#include "lib/imgui/imgui.h"
+
+namespace gui {
+
+    void ResetConfirmDialog::open() noexcept {
+        m_confirmReset = true;
+        m_open = true;
+    }
+
+    void ResetConfirmDialog::close() noexcept {
+        m_confirmReset = false;
+        m_open = false;
+    }
+
+    void ResetConfirmDialog::render() {
+        if (!m_confirmReset) return;
+
+        if (m_open && !ImGui::IsPopupOpen(RESET_CONFIRM_POPUP_NAME)) {
+            ImGui::OpenPopup(RESET_CONFIRM_POPUP_NAME);
+        }
+
+        ImGuiUtils::CenterNextWindow();
+        ImGuiUtils::SetDpiScaledWindowConstraints(RESET_CONFIRM_MIN_SIZE.x, RESET_CONFIRM_MIN_SIZE.y);
+        ImGuiUtils::SetDpiScaledWindowSize(RESET_CONFIRM_DEFAULT_SIZE);
+
+        if (!ImGui::BeginPopupModal(RESET_CONFIRM_POPUP_NAME, &m_confirmReset,
+                                    ImGuiWindowFlags_NoCollapse)) {
+            return;
+        }
+
+        ImGui::BeginChild("##reset_confirm_body",
+                          ImVec2(0, -ImGui::GetFrameHeightWithSpacing()),
+                          ImGuiChildFlags_Borders);
+        ImGui::TextUnformatted("This will reset all preferences to their factory defaults.");
+        ImGui::TextUnformatted("Unsaved changes will be lost.");
+        ImGui::EndChild();
+
+        float cancelBtnW = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
+        float resetBtnW  = ImGuiUtils::DpiScale(BASE_POPUP_BUTTON_WIDTH);
+        const float totalW = cancelBtnW + resetBtnW + ImGui::GetStyle().ItemSpacing.x;
+        ImGui::SetCursorPosX((ImGui::GetContentRegionAvail().x - totalW) * 0.5f);
+        if (ImGui::Button("Cancel", ImVec2(cancelBtnW, 0))) {
+            close();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Reset", ImVec2(resetBtnW, 0))) {
+            if (m_onReset) m_onReset();
+            close();
+        }
+
+        ImGui::EndPopup();
+    }
+
+} // namespace gui

--- a/src/gui/popups/reset_confirm_dialog.h
+++ b/src/gui/popups/reset_confirm_dialog.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <functional>
+
+namespace gui {
+
+    /// Modal confirmation dialog for resetting all preferences to factory defaults.
+    /// Owned by PreferencesDialog; triggers a callback when the user confirms.
+    class ResetConfirmDialog {
+        public:
+            using ResetCallback = std::function<void()>;
+
+            void open() noexcept;
+            void close() noexcept;
+            [[nodiscard]] bool isOpen() const noexcept { return m_open; }
+
+            /// Called every frame by the owning PreferencesDialog.
+            void render();
+
+            void setOnReset(ResetCallback cb) { m_onReset = std::move(cb); }
+
+        private:
+            bool m_open = false;
+            bool m_confirmReset = false;
+            ResetCallback m_onReset;
+    };
+
+} // namespace gui


### PR DESCRIPTION
## Changes

### DDE Connection UI
- Replace SliderInt controls with InputInt fields (matching DDE Performance style)
- Group fields in bordered child section with AutoResizeY
- Apply ImGuiUtils::DpiScale to all layout offsets (SameLine, SetNextItemWidth)

### DDE Connection validation ranges
- kMinRetries: 1 → 0 (allow zero retries)
- kMaxConnections: 4 → 16 (allow more concurrent connections)

### Fix log spam
- Add change guards to all 12 DDEConnectionManager setters (skip if value unchanged)
- Add missing m_defaultTimeoutMs/m_defaultRetries member fields
- Make inputMs/inputInt lambdas return bool for change detection
- Only call pplyWorkingDDE() when a value actually changes

### Reset Preferences popup
- Extract into standalone ResetConfirmDialog class (following existing popup pattern)
- Fix broken body text: remove AlwaysAutoResize (incompatible with BeginChild negative height)
- Use NoCollapse + CenterNextWindow + SetDpiScaledWindowConstraints (matching other popups)
- Add RESET_CONFIRM_POPUP_NAME and size constants