### PR TITLE
test: GoogleTest infrastructure + CI unit tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,6 +10,7 @@ on:
       - 'fix/**'
     paths:
       - 'src/**'
+      - 'tests/**'
       - 'CMakeLists.txt'
       - 'build.sh'
       - '.github/workflows/build-test.yml'
@@ -18,6 +19,7 @@ on:
       - main
     paths:
       - 'src/**'
+      - 'tests/**'
       - 'CMakeLists.txt'
       - 'build.sh'
       - '.github/workflows/build-test.yml'
@@ -83,6 +85,20 @@ jobs:
         run: |
           mkdir -p artifacts
           cp build/bin/*.exe artifacts/${{ env.PROJECT_NAME }}-dev-debug.exe
+        shell: msys2 {0}
+
+      - name: Build Tests
+        run: |
+          cmake -B build -DBUILD_TESTING=ON -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            --fresh
+          cmake --build build --target tests
+        shell: msys2 {0}
+
+      - name: Run Tests
+        run: |
+          cd build && ctest --output-on-failure
         shell: msys2 {0}
 
       - name: Upload dev build artifact

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,13 +63,13 @@ jobs:
         run: git update-index --chmod=+x build.sh
         shell: msys2 {0}
 
-      - name: Build Test
+      - name: Build Release
         run: |
           export MSYS_NO_PATHCONV=1
           BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }} ./build.sh
         shell: msys2 {0}
 
-      - name: Save test binary
+      - name: Save release binary
         run: |
           mkdir -p artifacts
           cp build/bin/*.exe artifacts/${{ env.PROJECT_NAME }}-dev.exe
@@ -87,7 +87,7 @@ jobs:
           cp build/bin/*.exe artifacts/${{ env.PROJECT_NAME }}-dev-debug.exe
         shell: msys2 {0}
 
-      - name: Build Tests
+      - name: Build Unit Tests
         run: |
           cmake -B build -DBUILD_TESTING=ON -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
@@ -96,7 +96,7 @@ jobs:
           cmake --build build --target tests
         shell: msys2 {0}
 
-      - name: Run Tests
+      - name: Run Unit Tests
         run: |
           cd build && ctest --output-on-failure
         shell: msys2 {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,3 +247,10 @@ endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES
     OUTPUT_NAME "${PROJECT_NAME}_${APP_VERSION_STRING}_${APP_BUILD_NUMBER}"
 )
+
+# Tests (opt-in)
+option(BUILD_TESTING "Build unit tests (GoogleTest)" OFF)
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,37 @@
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+include(GoogleTest)
+
+set(TEST_SOURCES
+    test_settings.cpp
+    test_operation_monitor.cpp
+)
+
+set(TEST_LIB_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/app/settings.cpp
+    ${CMAKE_SOURCE_DIR}/src/dde/operation_monitor.cpp
+)
+
+add_executable(tests ${TEST_SOURCES} ${TEST_LIB_SOURCES})
+
+target_include_directories(tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/app
+    ${CMAKE_SOURCE_DIR}/src/gui
+    ${CMAKE_SOURCE_DIR}/src/lib/json/single_include
+)
+
+target_link_libraries(tests PRIVATE GTest::gtest_main)
+
+target_compile_options(tests PRIVATE
+    -Wall -Wextra
+    -DUNICODE -D_UNICODE
+)
+
+gtest_discover_tests(tests)

--- a/tests/test_operation_monitor.cpp
+++ b/tests/test_operation_monitor.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include "dde/operation_monitor.h"
+
+namespace ZemaxDDE {
+namespace {
+
+TEST(OperationMonitor, RegisterReturnsIncrementingId) {
+    OperationMonitor mon;
+    uint64_t id1 = mon.registerOperation("svc1", 5);
+    uint64_t id2 = mon.registerOperation("svc2", 3);
+    uint64_t id3 = mon.registerOperation("svc3", 1);
+
+    EXPECT_EQ(id1, 1);
+    EXPECT_EQ(id2, 2);
+    EXPECT_EQ(id3, 3);
+}
+
+TEST(OperationMonitor, TransitionPendingToInFlightToCompleted) {
+    OperationMonitor mon;
+    uint64_t id = mon.registerOperation("svc", 3);
+
+    EXPECT_EQ(mon.getOperations().size(), 1u);
+    EXPECT_EQ(mon.getOperations()[0].status, OperationStatus::Pending);
+
+    mon.onRequestQueued(id, "GetName");
+    EXPECT_EQ(mon.getOperations()[0].status, OperationStatus::InFlight);
+    EXPECT_EQ(mon.getOperations()[0].command, "GetName");
+
+    mon.reportProgress(id, 1, "step 1");
+    EXPECT_EQ(mon.getOperations()[0].currentStep, 1);
+
+    mon.onCompleted(id);
+    EXPECT_EQ(mon.getOperations()[0].status, OperationStatus::Completed);
+    EXPECT_EQ(mon.getOperations()[0].message, "Completed");
+}
+
+TEST(OperationMonitor, TransitionToFailed) {
+    OperationMonitor mon;
+    uint64_t id = mon.registerOperation("svc", 1);
+    mon.onRequestQueued(id, "GetFile");
+    mon.onError(id, "timeout");
+
+    EXPECT_EQ(mon.getOperations()[0].status, OperationStatus::Failed);
+    EXPECT_EQ(mon.getOperations()[0].error, "timeout");
+}
+
+TEST(OperationMonitor, ClearCompletedRemovesDone) {
+    OperationMonitor mon;
+    uint64_t id1 = mon.registerOperation("svc", 1);
+    uint64_t id2 = mon.registerOperation("svc", 1);
+    uint64_t id3 = mon.registerOperation("svc", 1);
+
+    mon.onCompleted(id1);
+    mon.onError(id2, "err");
+    mon.onRequestQueued(id3, "cmd");
+
+    mon.clearCompleted();
+
+    EXPECT_EQ(mon.getOperations().size(), 1u);
+    EXPECT_EQ(mon.getOperations()[0].id, id3);
+    EXPECT_EQ(mon.getOperations()[0].status, OperationStatus::InFlight);
+}
+
+TEST(OperationMonitor, IsCancelledFalseByDefault) {
+    OperationMonitor mon;
+    uint64_t id = mon.registerOperation("svc", 1);
+
+    EXPECT_FALSE(mon.isCancelled(id));
+
+    mon.requestCancel(id);
+    EXPECT_TRUE(mon.isCancelled(id));
+    EXPECT_EQ(mon.getOperations()[0].message, "Cancelling...");
+}
+
+} // namespace
+} // namespace ZemaxDDE

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -1,0 +1,228 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <cstdio>
+#include <string>
+
+#include "app/settings.h"
+
+namespace app {
+namespace {
+
+// ============================================================
+//  Helpers
+// ============================================================
+
+static std::string tmpPath(const char* name) {
+    return std::string(std::tmpnam(nullptr)) + name;
+}
+
+static void writeFile(const std::string& path, const std::string& content) {
+    std::ofstream out(path, std::ios::trunc);
+    out << content;
+}
+
+// ============================================================
+//  AppSettings::defaults() / reset()
+// ============================================================
+
+TEST(SettingsDefaults, AllFieldsMatchExpected) {
+    auto s = AppSettings::defaults();
+
+    EXPECT_EQ(s.version, AppSettings::kCurrentVersion);
+    EXPECT_TRUE(s.general.showDebugLogOnStartup);
+    EXPECT_TRUE(s.general.restoreWindowLayout);
+    EXPECT_EQ(s.appearance.themeMode, ThemeMode::System);
+    EXPECT_EQ(s.dde.connectionTimeoutMs, 5000);
+    EXPECT_EQ(s.dde.maxRetryCount, 3);
+    EXPECT_EQ(s.dde.maxConnections, 4);
+    EXPECT_EQ(s.dde.getNameTimeoutMs, 2000);
+    EXPECT_EQ(s.dde.getFileTimeoutMs, 2000);
+    EXPECT_EQ(s.dde.getSystemTimeoutMs, 2000);
+    EXPECT_EQ(s.dde.getFieldTimeoutMs, 2000);
+    EXPECT_EQ(s.dde.getWaveTimeoutMs, 2000);
+    EXPECT_EQ(s.dde.getSurfaceDataProfileTimeoutMs, 2000);
+    EXPECT_EQ(s.dde.getSagProfileTimeoutMs, 1000);
+    EXPECT_EQ(s.dde.getSurfaceDataMapTimeoutMs, 2000);
+    EXPECT_EQ(s.dde.getSagMapTimeoutMs, 1000);
+    EXPECT_TRUE(s.plot.showGridByDefault);
+    EXPECT_FLOAT_EQ(s.plot.lineWeight, 1.0f);
+    EXPECT_FLOAT_EQ(s.plot.markerSize, 5.0f);
+    EXPECT_FALSE(s.updates.autoCheckOnStartup);
+    EXPECT_EQ(s.updates.channel, UpdateChannel::Stable);
+}
+
+TEST(SettingsReset, RestoresDefaults) {
+    AppSettings s;
+    s.dde.connectionTimeoutMs = 9999;
+    s.appearance.themeMode = ThemeMode::Light;
+    s.plot.lineWeight = 2.5f;
+
+    s.reset();
+
+    EXPECT_EQ(s.dde.connectionTimeoutMs, 5000);
+    EXPECT_EQ(s.appearance.themeMode, ThemeMode::System);
+    EXPECT_FLOAT_EQ(s.plot.lineWeight, 1.0f);
+}
+
+// ============================================================
+//  Enum roundtrip
+// ============================================================
+
+TEST(ThemeModeRoundtrip, LightDarkSystem) {
+    EXPECT_EQ(themeModeFromString(themeModeToString(ThemeMode::Light)),  ThemeMode::Light);
+    EXPECT_EQ(themeModeFromString(themeModeToString(ThemeMode::Dark)),   ThemeMode::Dark);
+    EXPECT_EQ(themeModeFromString(themeModeToString(ThemeMode::System)), ThemeMode::System);
+}
+
+TEST(ThemeModeFromString, InvalidReturnsSystem) {
+    EXPECT_EQ(themeModeFromString("invalid"), ThemeMode::System);
+    EXPECT_EQ(themeModeFromString(""), ThemeMode::System);
+}
+
+TEST(UpdateChannelRoundtrip, StableBeta) {
+    EXPECT_EQ(updateChannelFromString(updateChannelToString(UpdateChannel::Stable)), UpdateChannel::Stable);
+    EXPECT_EQ(updateChannelFromString(updateChannelToString(UpdateChannel::Beta)),   UpdateChannel::Beta);
+}
+
+TEST(UpdateChannelFromString, InvalidReturnsStable) {
+    EXPECT_EQ(updateChannelFromString("invalid"), UpdateChannel::Stable);
+    EXPECT_EQ(updateChannelFromString(""), UpdateChannel::Stable);
+}
+
+// ============================================================
+//  Load / save roundtrip
+// ============================================================
+
+TEST(SettingsLoadSave, RoundtripPreservesValues) {
+    std::string path = tmpPath("_settings_roundtrip.json");
+
+    AppSettings s;
+    s.dde.connectionTimeoutMs = 7777;
+    s.appearance.themeMode = ThemeMode::Dark;
+    s.plot.lineWeight = 2.0f;
+    s.updates.channel = UpdateChannel::Beta;
+    ASSERT_TRUE(s.saveToFile(path));
+
+    AppSettings loaded;
+    std::string err;
+    EXPECT_EQ(loaded.loadFromFileWithReason(path, err), AppSettings::LoadResult::Success);
+    EXPECT_EQ(loaded.dde.connectionTimeoutMs, 7777);
+    EXPECT_EQ(loaded.appearance.themeMode, ThemeMode::Dark);
+    EXPECT_FLOAT_EQ(loaded.plot.lineWeight, 2.0f);
+    EXPECT_EQ(loaded.updates.channel, UpdateChannel::Beta);
+
+    std::remove(path.c_str());
+}
+
+// ============================================================
+//  Load error cases
+// ============================================================
+
+TEST(SettingsLoad, FileMissingReturnsFileMissing) {
+    AppSettings s;
+    std::string err;
+    EXPECT_EQ(s.loadFromFileWithReason("nonexistent_file_abc123.json", err), AppSettings::LoadResult::FileMissing);
+}
+
+TEST(SettingsLoad, ParseErrorReturnsParseError) {
+    std::string path = tmpPath("_settings_parse_err.json");
+    writeFile(path, "{invalid json!!!}");
+
+    AppSettings s;
+    std::string err;
+    EXPECT_EQ(s.loadFromFileWithReason(path, err), AppSettings::LoadResult::ParseError);
+    EXPECT_FALSE(err.empty());
+
+    std::remove(path.c_str());
+}
+
+TEST(SettingsLoad, NotAnObjectReturnsNotAnObject) {
+    std::string path = tmpPath("_settings_notobj.json");
+    writeFile(path, "[1, 2, 3]");
+
+    AppSettings s;
+    std::string err;
+    EXPECT_EQ(s.loadFromFileWithReason(path, err), AppSettings::LoadResult::NotAnObject);
+
+    std::remove(path.c_str());
+}
+
+TEST(SettingsLoad, UnknownVersionResetsAndReturns) {
+    std::string path = tmpPath("_settings_ver.json");
+    writeFile(path, R"({"version": 999})");
+
+    AppSettings s;
+    s.dde.connectionTimeoutMs = 7777;
+    std::string err;
+    EXPECT_EQ(s.loadFromFileWithReason(path, err), AppSettings::LoadResult::UnknownVersion);
+    EXPECT_FALSE(err.empty());
+
+    std::remove(path.c_str());
+}
+
+// ============================================================
+//  DDE clamp
+// ============================================================
+
+TEST(SettingsClamp, ConnectionTimeoutBelowMin) {
+    std::string path = tmpPath("_settings_clamp_min.json");
+    writeFile(path, R"({"version": 1, "dde": {"connectionTimeoutMs": 100}})");
+
+    AppSettings s;
+    std::string err;
+    ASSERT_EQ(s.loadFromFileWithReason(path, err), AppSettings::LoadResult::Success);
+    EXPECT_EQ(s.dde.connectionTimeoutMs, 5000);
+
+    std::remove(path.c_str());
+}
+
+TEST(SettingsClamp, ConnectionTimeoutAboveMax) {
+    std::string path = tmpPath("_settings_clamp_max.json");
+    writeFile(path, R"({"version": 1, "dde": {"connectionTimeoutMs": 99999}})");
+
+    AppSettings s;
+    std::string err;
+    ASSERT_EQ(s.loadFromFileWithReason(path, err), AppSettings::LoadResult::Success);
+    EXPECT_EQ(s.dde.connectionTimeoutMs, 5000);
+
+    std::remove(path.c_str());
+}
+
+TEST(SettingsClamp, ConnectionTimeoutValid) {
+    std::string path = tmpPath("_settings_clamp_valid.json");
+    writeFile(path, R"({"version": 1, "dde": {"connectionTimeoutMs": 3000}})");
+
+    AppSettings s;
+    std::string err;
+    ASSERT_EQ(s.loadFromFileWithReason(path, err), AppSettings::LoadResult::Success);
+    EXPECT_EQ(s.dde.connectionTimeoutMs, 3000);
+
+    std::remove(path.c_str());
+}
+
+TEST(SettingsClamp, LineWeightBelowMin) {
+    std::string path = tmpPath("_settings_lw.json");
+    writeFile(path, R"({"version": 1, "plot": {"lineWeight": 0.1}})");
+
+    AppSettings s;
+    std::string err;
+    ASSERT_EQ(s.loadFromFileWithReason(path, err), AppSettings::LoadResult::Success);
+    EXPECT_FLOAT_EQ(s.plot.lineWeight, 1.0f);
+
+    std::remove(path.c_str());
+}
+
+TEST(SettingsClamp, MarkerSizeAboveMax) {
+    std::string path = tmpPath("_settings_ms.json");
+    writeFile(path, R"({"version": 1, "plot": {"markerSize": 50.0}})");
+
+    AppSettings s;
+    std::string err;
+    ASSERT_EQ(s.loadFromFileWithReason(path, err), AppSettings::LoadResult::Success);
+    EXPECT_FLOAT_EQ(s.plot.markerSize, 5.0f);
+
+    std::remove(path.c_str());
+}
+
+} // namespace
+} // namespace app


### PR DESCRIPTION
## Changes

- **tests/CMakeLists.txt**: FetchContent GoogleTest v1.15.2, BUILD_TESTING option
- **tests/test_settings.cpp**: 16 tests (defaults, reset, JSON roundtrip, parse errors, clamp)
- **tests/test_operation_monitor.cpp**: 5 tests (register, transitions, clear, cancel)
- **.github/workflows/build-test.yml**: +Build Unit Tests, +Run Unit Tests steps, +tests/** paths

## Summary

Added GoogleTest unit testing infrastructure with 21 tests covering Settings (JSON load/save, clamp logic, enum roundtrip) and OperationMonitor (state machine, lifecycle). CI workflow now builds and runs unit tests on every push/PR.