### PR TITLE
fix: code currency audit

### DIFF
--- a/src/dde/client_connection.cpp
+++ b/src/dde/client_connection.cpp
@@ -1,6 +1,5 @@
 #include <algorithm>
 #include <stdexcept>
-#include <fstream>
 #include <vector>
 
 #include "client.h"

--- a/src/dde/constants.h
+++ b/src/dde/constants.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <numbers>
+
 namespace ZemaxDDE {
+    inline constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
     inline constexpr const wchar_t* DDE_APP_NAME    = L"ZEMAX";     // Appname DDE
     inline constexpr const wchar_t* DDE_TOPIC       = L"RayData";   // Topic DDE
     static constexpr int DDE_TIMEOUT_MS             = 300;          // Timeout in ms (300 ms)

--- a/src/dde/utils.cpp
+++ b/src/dde/utils.cpp
@@ -31,12 +31,12 @@ namespace ZemaxDDE {
     // Convert CP1251 (Windows-1251) encoded data to UTF‑8
     std::string cp1251_to_utf8(const char* data, size_t len) {
         if (!data || len == 0) return {};
-        int wlen = MultiByteToWideChar(1251, 0, data, (int)len, nullptr, 0);
+        int wlen = MultiByteToWideChar(1251, 0, data, static_cast<int>(len), nullptr, 0);
         
         if (wlen <= 0) return {};
 
         std::wstring wstr(wlen, L'\0');
-        MultiByteToWideChar(1251, 0, data, (int)len, &wstr[0], wlen);
+        MultiByteToWideChar(1251, 0, data, static_cast<int>(len), &wstr[0], wlen);
 
         int u8len = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), wlen, nullptr, 0, nullptr, nullptr);
         if (u8len <= 0) return {};

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <filesystem>
 #include <memory>
-#include <optional>
-#include <utility>
-#include <vector>
 
 #include <windows.h>
 #include <GLFW/glfw3.h>

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -82,7 +82,8 @@ void GuiManager::render() {
     }
 
     // Check system theme change every 60 frames (once per second at 60 FPS)
-    if (++m_frameCount % 60 == 0) {
+    constexpr unsigned int kThemeCheckInterval = 60;
+    if (++m_frameCount % kThemeCheckInterval == 0) {
         m_settingsManager->checkAndApplySystemTheme();
     }
 
@@ -92,7 +93,8 @@ void GuiManager::render() {
     }
 
     float navbarHeight = ImGui::GetFrameHeight();
-    float statusBarHeight = m_uiOpMonitor.hasActiveTasks() ? ImGui::GetFrameHeight() * 1.5f : 0.0f;
+    constexpr float kStatusBarHeightMultiplier = 1.5f;
+    float statusBarHeight = m_uiOpMonitor.hasActiveTasks() ? ImGui::GetFrameHeight() * kStatusBarHeightMultiplier : 0.0f;
     ImGui::SetNextWindowPos(ImVec2(0.0f, navbarHeight));
     ImGui::SetNextWindowSize(ImVec2(
         ImGui::GetIO().DisplaySize.x,
@@ -114,8 +116,9 @@ void GuiManager::render() {
         m_pWndMgr->RenderAll();
     }
 
+    constexpr ImVec2 kDetachedWindowSize(600, 400);
+    constexpr float kComboWidthMultiplier = 10.0f;
     {
-        constexpr ImVec2 kDetachedWindowSize(600, 400);
         auto& tolSurface = m_profileService->m_tolerancedSurfaceData;
         auto& nomSurface = m_profileService->m_nominalSurfaceData;
 
@@ -165,12 +168,12 @@ void GuiManager::render() {
     {
         if (m_irregularityMapService->m_showTolerancedSurfaceMap) {
             if (m_irregularityMapService->hasData()) {
-                ImGui::SetNextWindowSize(ImVec2(600, 400), ImGuiCond_Once);
+                ImGui::SetNextWindowSize(kDetachedWindowSize, ImGuiCond_Once);
                 if (ImGui::Begin("Surface Irregularity Map 3D", &m_irregularityMapService->m_showTolerancedSurfaceMap)) {
                     {
                         const char* cmapNames[] = { "Cool", "Aqua-Purple", "Ocean", "Aurora" };
                         int cmap = m_irregularityMapService->m_windowState.selectedColormapSurface;
-                        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 10.0f);
+                        ImGui::SetNextItemWidth(ImGui::GetFontSize() * kComboWidthMultiplier);
                         if (ImGui::Combo("Colormap", &cmap, cmapNames, IM_ARRAYSIZE(cmapNames)))
                             m_irregularityMapService->m_windowState.selectedColormapSurface = cmap;
                         ImGui::SameLine();
@@ -189,12 +192,12 @@ void GuiManager::render() {
 
         if (m_irregularityMapService->m_showDeviationSurfaceMap) {
             if (m_irregularityMapService->hasData() && m_irregularityMapService->m_nominalSurfaceData.isValid()) {
-                ImGui::SetNextWindowSize(ImVec2(600, 400), ImGuiCond_Once);
+                ImGui::SetNextWindowSize(kDetachedWindowSize, ImGuiCond_Once);
                 if (ImGui::Begin("Surface Irregularity Map 3D Deviation", &m_irregularityMapService->m_showDeviationSurfaceMap)) {
                     {
                         const char* cmapNames[] = { "Cool", "Aqua-Purple", "Ocean", "Aurora" };
                         int cmap = m_irregularityMapService->m_windowState.selectedColormapDeviation;
-                        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 10.0f);
+                        ImGui::SetNextItemWidth(ImGui::GetFontSize() * kComboWidthMultiplier);
                         if (ImGui::Combo("Colormap", &cmap, cmapNames, IM_ARRAYSIZE(cmapNames)))
                             m_irregularityMapService->m_windowState.selectedColormapDeviation = cmap;
                         ImGui::SameLine();
@@ -213,8 +216,7 @@ void GuiManager::render() {
 
         if (m_irregularityMapService->m_showWorstSectionProfile) {
             if (m_irregularityMapService->m_worstProfileData.isValid()) {
-                constexpr ImVec2 kDetachedWndSize(600, 400);
-                ImGui::SetNextWindowSize(kDetachedWndSize, ImGuiCond_Once);
+                ImGui::SetNextWindowSize(kDetachedWindowSize, ImGuiCond_Once);
                 if (ImGui::Begin("Worst Section Profile", &m_irregularityMapService->m_showWorstSectionProfile)) {
                     auto& wp = m_irregularityMapService->m_worstProfileData;
                     std::string title = std::format("Worst Section ({}°, {} pts)", wp.angle, wp.sampling);
@@ -229,8 +231,7 @@ void GuiManager::render() {
         if (m_irregularityMapService->m_showWorstSectionDeviation) {
             if (m_irregularityMapService->m_worstProfileData.isValid()
                 && m_irregularityMapService->m_nominalSurfaceData.isValid()) {
-                constexpr ImVec2 kDetachedWndSize(600, 400);
-                ImGui::SetNextWindowSize(kDetachedWndSize, ImGuiCond_Once);
+                ImGui::SetNextWindowSize(kDetachedWindowSize, ImGuiCond_Once);
                 if (ImGui::Begin("Worst Section Deviation", &m_irregularityMapService->m_showWorstSectionDeviation)) {
                     m_profileService->renderProfileDeviationPlot("##WorstDeviation",
                         m_irregularityMapService->m_nominalSurfaceData,

--- a/src/gui/popups/update_checker.cpp
+++ b/src/gui/popups/update_checker.cpp
@@ -13,6 +13,12 @@
 #include <cstdio>
 
 namespace gui {
+    namespace {
+        constexpr const wchar_t* kGitHubRepoPath = L"d3m37r4/ZemaxDDEClient";
+        constexpr DWORD kHttpTimeoutMs = 10000;
+        constexpr size_t kReadBufferSize = 4096;
+    }
+
     UpdateChecker::UpdateChecker() = default;
 
     UpdateChecker::~UpdateChecker() {
@@ -61,7 +67,7 @@ namespace gui {
         HINTERNET hSession = WinHttpOpen(L"ZemaxDDEClient/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
         if (!hSession) return false;
 
-        DWORD timeout = 10000;
+        DWORD timeout = kHttpTimeoutMs;
         WinHttpSetOption(hSession, WINHTTP_OPTION_RECEIVE_TIMEOUT, &timeout, sizeof(timeout));
         WinHttpSetOption(hSession, WINHTTP_OPTION_SEND_TIMEOUT, &timeout, sizeof(timeout));
         WinHttpSetOption(hSession, WINHTTP_OPTION_CONNECT_TIMEOUT, &timeout, sizeof(timeout));
@@ -88,7 +94,7 @@ namespace gui {
 
         std::string response;
         if (success) {
-            char buffer[4096];
+            char buffer[kReadBufferSize];
             DWORD dwSize = sizeof(buffer);
             while (WinHttpReadData(hRequest, buffer, sizeof(buffer) - 1, &dwSize) && dwSize > 0) {
                 buffer[dwSize] = '\0';

--- a/src/gui/surface_irregularity_map_service.cpp
+++ b/src/gui/surface_irregularity_map_service.cpp
@@ -13,8 +13,6 @@
 #include "lib/implot3d/implot3d.h"
 
 namespace {
-    constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
-
     ImVec4 imcol(int r, int g, int b) {
         return ImVec4(r / 255.0f, g / 255.0f, b / 255.0f, 1.0f);
     }

--- a/src/gui/surface_profile_calculator.cpp
+++ b/src/gui/surface_profile_calculator.cpp
@@ -1,6 +1,5 @@
 #include <format>
 #include <cmath>
-#include <numbers>
 
 #include "surface_profile_calculator.h"
 #include "dde/constants.h"
@@ -157,8 +156,7 @@ namespace gui {
                 std::format("Point {}/{}", m_sagPointIndex, m_targetSampling));
         }
 
-        constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
-        const double rad = m_targetAngle * DEG_TO_RAD;
+        const double rad = m_targetAngle * ZemaxDDE::DEG_TO_RAD;
         double semiDiameter = m_result.semiDiameter;
         double step = 2.0 * semiDiameter / (m_targetSampling - 1);
         double r = -semiDiameter + m_sagPointIndex * step;
@@ -196,8 +194,7 @@ namespace gui {
             return;
         }
 
-        constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
-        const double rad = m_targetAngle * DEG_TO_RAD;
+        const double rad = m_targetAngle * ZemaxDDE::DEG_TO_RAD;
         double semiDiameter = m_result.semiDiameter;
         double step = 2.0 * semiDiameter / (m_targetSampling - 1);
         double r = -semiDiameter + m_sagPointIndex * step;

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -35,7 +35,7 @@ namespace gui {
             const auto& sem = m_themeManager->semantic();
             if (connectionLost) {
                 value = "Connection Lost";
-                valueColor = ImVec4(1.0f, 0.6f, 0.0f, 1.0f); // warning/orange
+                valueColor = sem.warning;
             } else if (connected) {
                 value = "Connected";
                 valueColor = sem.success;

--- a/src/gui/windows_dockable/surface_irregularity_map.cpp
+++ b/src/gui/windows_dockable/surface_irregularity_map.cpp
@@ -2,10 +2,10 @@
 #include <cmath>
 #include <format>
 #include <vector>
-#include <numbers>
 
 #include "gui/gui.h"
 #include "gui/constants.h"
+#include "dde/constants.h"
 #include "gui/imgui_utils.h"
 #include "logger/logger.h"
 #include "lib/imgui/imgui.h"
@@ -13,8 +13,6 @@
 #include "lib/implot3d/implot3d.h"
 
 namespace {
-    constexpr double DEG_TO_RAD = std::numbers::pi / 180.0;
-
     std::string getSamplingTooltip() {
         return std::format(
             "Total number of sample points across the full surface diameter (min={}, max={}).\n"


### PR DESCRIPTION
## Changes

- Remove unused `#include` directives in `gui.h`, `client_connection.cpp`
- Replace hardcoded `ImVec2(600,400)` with named `kDetachedWindowSize` constant
- Extract magic numbers to named constants (`kThemeCheckInterval`, `kStatusBarHeightMultiplier`, `kComboWidthMultiplier`)
- Replace hardcoded orange color in `dde_status.cpp` with `sem.warning` semantic token
- Replace C-style casts with `static_cast` in `dde/utils.cpp`
- Consolidate `DEG_TO_RAD` into `dde/constants.h` (was duplicated in 3 files)
- Extract HTTP constants in `update_checker.cpp` (`kHttpTimeoutMs`, `kReadBufferSize`)

### Notes
- `#include <imgui_internal.h>` retained — required for `ImGuiDockNodeFlags_NoCloseButton`
- Both Release and Debug builds verified