### PR TITLE
fix: design system compliance

### DIFF
--- a/src/gui/constants.h
+++ b/src/gui/constants.h
@@ -62,4 +62,17 @@ namespace gui {
     // Preferences popup
     inline constexpr ImVec2 PREFERENCES_POPUP_DEFAULT_SIZE = ImVec2(660.0f, 280.0f);
     inline constexpr ImVec2 PREFERENCES_POPUP_MIN_SIZE     = ImVec2(660.0f, 280.0f);
+
+    // Preferences dialog layout
+    inline constexpr float PREFS_SPLITTER_WIDTH     = 4.0f;
+    inline constexpr float PREFS_SIDEBAR_MIN_WIDTH  = 60.0f;
+    inline constexpr float PREFS_SIDEBAR_EXTRA_PAD  = 20.0f;
+    inline constexpr float PREFS_RIGHT_MARGIN       = 100.0f;
+
+    // DDE status panel
+    inline constexpr float DDE_STATUS_ELEMENT_GAP   = 4.0f;
+    inline constexpr float DDE_STATUS_BTN_VPAD      = 4.0f;
+
+    // Default highlight color for worst-section markers
+    inline constexpr ImVec4 DEFAULT_WORST_HIGHLIGHT_COLOR{1.0f, 0.0f, 0.0f, 1.0f};
 }

--- a/src/gui/imgui_utils.h
+++ b/src/gui/imgui_utils.h
@@ -166,11 +166,9 @@ namespace ImGuiUtils {
 
         return changed;
     }
-    /// Renders a section header with title, separator, and optional description.
+    /// Renders a section header with bold title + separator line, optional description.
     inline void SectionHeader(const char* title, const char* description = nullptr) {
-        ImGui::TextUnformatted(title);
-        ImGui::Separator();
-        ImGui::Spacing();
+        ImGui::SeparatorText(title);
         if (description) {
             ImGui::TextDisabled(description);
             ImGui::Spacing();

--- a/src/gui/imgui_utils.h
+++ b/src/gui/imgui_utils.h
@@ -121,7 +121,7 @@ namespace ImGuiUtils {
                              pos.y + btnSize.y * 0.5f);
         dl->PathArcTo(spinnerCenter, spinnerRadius, angle,
                       angle + static_cast<float>(std::numbers::pi) * 1.5f, 32);
-        dl->PathStroke(ImGui::GetColorU32(ImGuiCol_Text, disabledAlpha), 0, 2.0f);
+        dl->PathStroke(ImGui::GetColorU32(ImGuiCol_Text, disabledAlpha), 0, DpiScale(2.0f));
 
         ImVec2 textPos(pos.x + style.FramePadding.x + spinnerDiameter + spacing,
                        pos.y + (btnSize.y - textSize.y) * 0.5f);

--- a/src/gui/popups/preferences_dialog.cpp
+++ b/src/gui/popups/preferences_dialog.cpp
@@ -51,13 +51,13 @@ namespace gui {
             float maxW = 0.0f;
             for (auto* l : sidebarLabels)
                 maxW = std::max(maxW, ImGui::CalcTextSize(l).x);
-            m_sidebarWidth = maxW + ImGui::GetStyle().FramePadding.x * 2.0f + 20.0f;
+            m_sidebarWidth = maxW + ImGui::GetStyle().FramePadding.x * 2.0f + ImGuiUtils::DpiScale(PREFS_SIDEBAR_EXTRA_PAD);
         }
 
         const float footerH    = ImGui::GetFrameHeightWithSpacing();
         const float availH     = ImGui::GetContentRegionAvail().y - footerH;
         const float availW     = ImGui::GetContentRegionAvail().x;
-        const float splitterW  = 4.0f;
+        const float splitterW  = ImGuiUtils::DpiScale(PREFS_SPLITTER_WIDTH);
 
         ImGui::BeginChild("##prefs_sidebar",
                           ImVec2(m_sidebarWidth, availH),
@@ -68,7 +68,7 @@ namespace gui {
         ImGui::SameLine();
 
         ImGuiUtils::SplitterH("##prefs_splitter", m_sidebarWidth, availH,
-                               splitterW, 60.0f, availW - 100.0f - splitterW);
+                               splitterW, ImGuiUtils::DpiScale(PREFS_SIDEBAR_MIN_WIDTH), availW - ImGuiUtils::DpiScale(PREFS_RIGHT_MARGIN) - splitterW);
 
         ImGui::SameLine();
 

--- a/src/gui/surface_irregularity_map_service.h
+++ b/src/gui/surface_irregularity_map_service.h
@@ -9,6 +9,7 @@
 #include "dde/client.h"
 #include "gui/ui_operation_monitor.h"
 #include "gui/surface_profile_calculator.h"
+#include "gui/constants.h"
 #include "lib/imgui/imgui.h"
 
 class Logger;
@@ -34,8 +35,8 @@ namespace gui {
 
         bool highlightWorstSurface = true;
         bool highlightWorstDeviation = true;
-        ImVec4 worstColorSurface{1.0f, 0.0f, 0.0f, 1.0f};
-        ImVec4 worstColorDeviation{1.0f, 0.0f, 0.0f, 1.0f};
+        ImVec4 worstColorSurface = DEFAULT_WORST_HIGHLIGHT_COLOR;
+        ImVec4 worstColorDeviation = DEFAULT_WORST_HIGHLIGHT_COLOR;
     };
 
     struct MaxPVResult {

--- a/src/gui/windows_dockable/dde_status.cpp
+++ b/src/gui/windows_dockable/dde_status.cpp
@@ -2,6 +2,7 @@
 
 #include "windows_dockable/dde_status.h"
 #include "gui/constants.h"
+#include "gui/imgui_utils.h"
 #include "gui/theme_manager.h"
 #include "dde/utils.h"
 #include "lib/imgui/imgui.h"
@@ -47,12 +48,12 @@ namespace gui {
             float availableWidth = ImGui::GetContentRegionAvail().x;
             float labelWidth = ImGui::CalcTextSize(label).x;
             float valueWidth = ImGui::CalcTextSize(value).x;
-            float totalWidth = labelWidth + valueWidth + 4.0f;
+            float totalWidth = labelWidth + valueWidth + ImGuiUtils::DpiScale(DDE_STATUS_ELEMENT_GAP);
             float offsetX = (availableWidth - totalWidth) * 0.5f;
             if (offsetX > 0.0f) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + offsetX);
 
             ImGui::TextUnformatted(label);
-            ImGui::SameLine(0.0f, 4.0f);
+            ImGui::SameLine(0.0f, ImGuiUtils::DpiScale(DDE_STATUS_ELEMENT_GAP));
 
             ImGui::PushStyleColor(ImGuiCol_Text, valueColor);
             ImGui::TextUnformatted(value);
@@ -109,7 +110,7 @@ namespace gui {
         // Connect/disconnect button uses semantic danger/success tokens (not ImGuiCol_Button*)
         // so the action remains visually unambiguous regardless of the active theme.
         const auto& sem = m_themeManager->semantic();
-        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(-1.0f, 4.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(-1.0f, ImGuiUtils::DpiScale(DDE_STATUS_BTN_VPAD)));
         ImGui::PushStyleColor(ImGuiCol_Button,        connected ? sem.dangerButton        : sem.successButton);
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, connected ? sem.dangerButtonHover   : sem.successButtonHover);
         ImGui::PushStyleColor(ImGuiCol_ButtonActive,  connected ? sem.dangerButtonActive  : sem.successButtonActive);

--- a/src/gui/windows_dockable/optical_system_info.cpp
+++ b/src/gui/windows_dockable/optical_system_info.cpp
@@ -74,14 +74,14 @@ namespace gui {
             maxLabelWidth = std::max(maxLabelWidth, ImGui::CalcTextSize(l).x);
         maxLabelWidth += 8.0f;
 
-        ImGui::SeparatorText("File");
+        ImGuiUtils::SectionHeader("File");
         ImGuiUtils::BeginPropertyGrid("##File", maxLabelWidth);
         ImGuiUtils::PropertyGridRow("Lens Name", s.lensName.c_str());
         ImGuiUtils::PropertyGridRow("File Name", s.fileName.c_str());
         ImGuiUtils::EndPropertyGrid();
         ImGuiUtils::SpacingY(0.25f);
 
-        ImGui::SeparatorText("System");
+        ImGuiUtils::SectionHeader("System");
         ImGuiUtils::BeginPropertyGrid("##System", maxLabelWidth);
         ImGuiUtils::PropertyGridRow("Surfaces", std::to_string(s.numSurfs).c_str());
         ImGuiUtils::PropertyGridRow("Units", getUnitString(s.units));
@@ -90,7 +90,7 @@ namespace gui {
         ImGuiUtils::EndPropertyGrid();
         ImGuiUtils::SpacingY(0.25f);
 
-        ImGui::SeparatorText("Fields & Waves");
+        ImGuiUtils::SectionHeader("Fields & Waves");
         ImGuiUtils::BeginPropertyGrid("##Fields", maxLabelWidth);
         ImGuiUtils::PropertyGridRow("Fields", std::format("{} (Type {})", s.numFields, s.fieldType).c_str());
         ImGuiUtils::PropertyGridRow("Wavelengths", std::to_string(s.numWaves).c_str());
@@ -103,7 +103,7 @@ namespace gui {
         ImGui::EndChild();
         ImGuiUtils::SpacingY(0.25f);
 
-        ImGui::SeparatorText("Settings");
+        ImGuiUtils::SectionHeader("Settings");
         ImGuiUtils::BeginPropertyGrid("##Settings", maxLabelWidth);
         ImGuiUtils::PropertyGridRow("Non-Axial", s.nonAxialFlag ? "Non-Axial" : "Axial");
         ImGuiUtils::PropertyGridRow("Ray Aiming", getRayAimingTypeString(s.rayAimingType));
@@ -111,7 +111,7 @@ namespace gui {
         ImGuiUtils::EndPropertyGrid();
         ImGuiUtils::SpacingY(0.25f);
 
-        ImGui::SeparatorText("Environment");
+        ImGuiUtils::SectionHeader("Environment");
         ImGuiUtils::BeginPropertyGrid("##Env", maxLabelWidth);
         ImGuiUtils::PropertyGridRow("Temperature", std::format("{:.4f} °C", s.temp).c_str());
         ImGuiUtils::PropertyGridRow("Pressure", std::format("{:.4f} atm", s.pressure).c_str());

--- a/src/gui/windows_dockable/surface_irregularity_map.cpp
+++ b/src/gui/windows_dockable/surface_irregularity_map.cpp
@@ -53,7 +53,7 @@ namespace gui {
             maxLabelWidth = std::max(maxLabelWidth, ImGui::CalcTextSize(l).x);
         maxLabelWidth += cp * 2.0f;
 
-        ImGui::SeparatorText("Nominal surface parameters");
+        ImGuiUtils::SectionHeader("Nominal surface parameters");
 
         ImGui::BeginChild(
             "NominalSurfaceContent",
@@ -164,7 +164,7 @@ namespace gui {
 
         ImGui::EndChild();
 
-        ImGui::SeparatorText("Toleranced surface parameters");
+        ImGuiUtils::SectionHeader("Toleranced surface parameters");
 
         ImGui::BeginChild(
             "TolerancedSurfaceContent",
@@ -219,7 +219,7 @@ namespace gui {
 
         ImGui::EndChild();
 
-        ImGui::SeparatorText("Analysis");
+        ImGuiUtils::SectionHeader("Analysis");
 
         if (m_uiOpMonitor.isActive(TaskSource::SurfaceIrregularityMap)) {
             ImGuiUtils::SpinnerButton("Processing...", true);
@@ -246,7 +246,7 @@ namespace gui {
         if (m_irregularityMapService->hasData()) {
             bool calculating = m_uiOpMonitor.isActive(TaskSource::SurfaceIrregularityMap);
 
-            ImGui::SeparatorText("Results");
+            ImGuiUtils::SectionHeader("Results");
 
             ImGui::BeginDisabled(calculating);
 

--- a/src/gui/windows_dockable/surface_profile_inspector.cpp
+++ b/src/gui/windows_dockable/surface_profile_inspector.cpp
@@ -46,7 +46,7 @@ namespace gui {
             maxLabelWidth = std::max(maxLabelWidth, ImGui::CalcTextSize(l).x);
         maxLabelWidth += cp * 2.0f;
 
-        ImGui::SeparatorText("Nominal surface parameters");
+        ImGuiUtils::SectionHeader("Nominal surface parameters");
         ImGui::BeginChild(
             "NominalSurfaceContent",
             ImVec2(0.0f, 0.0f),
@@ -168,7 +168,7 @@ namespace gui {
         }
         ImGui::EndChild();
 
-        ImGui::SeparatorText("Toleranced surface parameters");
+        ImGuiUtils::SectionHeader("Toleranced surface parameters");
         ImGui::BeginChild(
             "TolerancedSurfaceContent",
             ImVec2(0.0f, 0.0f),
@@ -292,7 +292,7 @@ namespace gui {
         ImGui::EndChild();
 
         if (nominal.isValid() && toleranced.isValid()) {
-            ImGui::SeparatorText("Surface profile analysis results");
+            ImGuiUtils::SectionHeader("Surface profile analysis results");
 
             if (ImGui::Button("Show comparison graphic")) {
                 m_profileService->m_showComparisonProfileWindow = true;


### PR DESCRIPTION
## Changes

### Commit 1: Extract hardcoded pixel values to constants, add DpiScale()
- Add `PREFS_SPLITTER_WIDTH`, `PREFS_SIDEBAR_MIN_WIDTH`, `PREFS_SIDEBAR_EXTRA_PAD`, `PREFS_RIGHT_MARGIN` to `constants.h`
- Add `DDE_STATUS_ELEMENT_GAP`, `DDE_STATUS_BTN_VPAD` to `constants.h`
- Add `DEFAULT_WORST_HIGHLIGHT_COLOR` to `constants.h`
- Replace hardcoded pixel values in `preferences_dialog.cpp` and `dde_status.cpp` with `DpiScale(constants)`
- Replace hardcoded `2.0f` spinner line thickness in `imgui_utils.h` with `DpiScale()`
- Replace hardcoded red `ImVec4` default in `surface_irregularity_map_service.h` with named constant

### Commit 2: Unify section headers via SectionHeader component
- Rewrite `SectionHeader` to use `SeparatorText` for bold + line visual
- Replace 12 `SeparatorText` calls with `SectionHeader` across 3 dockable panels
- All section dividers now use a single consistent component

### Verification
- Release and Debug builds pass
- `SectionHeader` in dockable panels: bold + line (same as before)
- `SectionHeader` in Preferences: bold + line + optional description subtitle